### PR TITLE
Break up NetMHCcons runs into multiple processes

### DIFF
--- a/mhctools/file_formats.py
+++ b/mhctools/file_formats.py
@@ -14,24 +14,35 @@
 
 from __future__ import print_function, division, absolute_import
 import tempfile
+from math import ceil
 
 from varcode import Variant, MutationEffect
 
 from .epitope_collection_builder import EpitopeCollectionBuilder
 
-def create_input_fasta_file(fasta_dictionary):
+def create_input_fasta_files(fasta_dictionary, max_file_records=None):
     """
-    Turn peptide entries from a dataframe into a FASTA file.
+    Turn peptide entries from a dataframe into one or more FASTA files.
     If mutation_window_size is an integer >0 then only use subsequence
     around mutated residues.
 
-    Return the name of closed file which has to be manually deleted,
+    Return the name of closed files which have to be manually deleted,
     and a dictionary from FASTA IDs to peptide records.
+
+    If max_file_records is not provided, one file is created.
+    If max_file_records is provided, each file will only hold (at most)
+    max_file_records records.
     """
-    input_file = tempfile.NamedTemporaryFile(
-        "w", prefix="peptide", delete=False)
     n_fasta_records = len(fasta_dictionary)
+    input_files = []
+    # A file for every max_file_records records
+    i_range = [0] if not max_file_records else range(
+        int(ceil(n_fasta_records / max_file_records)))
+    input_files = [tempfile.NamedTemporaryFile(
+        "w_%s" % i, prefix="peptide", delete=False) for i in i_range]
+
     sequence_key_mapping = {}
+    file_counter = 0
     for i, (original_key, seq) in enumerate(fasta_dictionary.items()):
         unique_id = str(i)
         # make a nicer string representation for Variants and Effects
@@ -50,12 +61,23 @@ def create_input_fasta_file(fasta_dictionary):
         # original key with a unique indentifier
         key = sanitized[: 14 - len(unique_id)] + "_" + unique_id
         sequence_key_mapping[key] = original_key
-        input_file.write(">%s\n%s" % (key, seq))
-        # newline unless at end of file
+        input_files[file_counter].write(">%s\n%s" % (key, seq))
+        # Don't add a newline after the last record
         if i + 1 < n_fasta_records:
-            input_file.write("\n")
-    input_file.close()
-    return input_file.name, sequence_key_mapping
+            # If we are splitting files, don't add a newline as the
+            # last line
+            if max_file_records:
+                if (i + 1) % max_file_records != 0:
+                    input_files[file_counter].write("\n")
+                else:
+                    file_counter += 1
+            else:
+                input_files[file_counter].write("\n")
+    input_file_names = []
+    for input_file in input_files:
+        input_file_names.append(input_file.name)
+        input_file.close()
+    return input_file_names, sequence_key_mapping
 
 def parse_netmhc_stdout(
         netmhc_output,

--- a/mhctools/netmhc_cons.py
+++ b/mhctools/netmhc_cons.py
@@ -20,7 +20,7 @@ from .base_commandline_predictor import BaseCommandlinePredictor
 from .cleanup_context import CleanupFiles
 from .common import check_sequence_dictionary
 from .epitope_collection import EpitopeCollection
-from .file_formats import create_input_fasta_file, parse_netmhc_stdout
+from .file_formats import create_input_fasta_files, parse_netmhc_stdout
 from .process_helpers import run_multiple_commands_redirect_stdout
 
 class NetMHCcons(BaseCommandlinePredictor):
@@ -28,7 +28,11 @@ class NetMHCcons(BaseCommandlinePredictor):
             self,
             alleles,
             netmhc_command="netMHCcons",
-            epitope_lengths=[9]):
+            epitope_lengths=[9],
+            max_file_records=None,
+            process_limit=0):
+        self.max_file_records = max_file_records
+        self.process_limit = process_limit
         BaseCommandlinePredictor.__init__(
             self,
             name="NetMHCcons",
@@ -44,40 +48,41 @@ class NetMHCcons(BaseCommandlinePredictor):
         return an EpitopeCollection of binding predictions.
         """
         fasta_dictionary = check_sequence_dictionary(fasta_dictionary)
-        input_filename, sequence_key_mapping = create_input_fasta_file(
-            fasta_dictionary)
+        input_filenames, sequence_key_mapping = create_input_fasta_files(
+            fasta_dictionary, max_file_records=self.max_file_records)
         output_files = {}
         commands = {}
         dirs = []
         alleles = [allele.replace("*", "") for allele in self.alleles]
-        for i, allele in enumerate(alleles):
-            for length in self.epitope_lengths:
-                temp_dirname = tempfile.mkdtemp(
-                    prefix="tmp_netmhccons_length_%d" % length)
-                logging.info(
-                    "Created temporary directory %s for allele %s, length %d",
-                    temp_dirname,
-                    allele,
-                    length)
-                dirs.append(temp_dirname)
-                output_file = tempfile.NamedTemporaryFile(
+        for i, input_filename in enumerate(input_filenames):
+            for j, allele in enumerate(alleles):
+                for length in self.epitope_lengths:
+                    temp_dirname = tempfile.mkdtemp(
+                        prefix="tmp_netmhccons_length_%d" % length)
+                    logging.info(
+                        "Created temporary directory %s for allele %s, length %d",
+                        temp_dirname,
+                        allele,
+                        length)
+                    dirs.append(temp_dirname)
+                    output_file = tempfile.NamedTemporaryFile(
                         "w",
-                        prefix="netMHCcons_output_%d" % i,
+                        prefix="netMHCcons_output_%d_%d" % (i, j),
                         delete=False)
-                command = [
-                    self.command,
-                    "-length", str(length),
-                    "-f", input_filename,
-                    "-a", allele,
-                    "-tdir", temp_dirname
-                ]
-                commands[output_file] = command
+                    command = [
+                        self.command,
+                        "-length", str(length),
+                        "-f", input_filename,
+                        "-a", allele,
+                        "-tdir", temp_dirname
+                    ]
+                    commands[output_file] = command
 
         epitope_collections = []
 
         # Cleanup either when finished or if an exception gets raised by
         # deleting the input and output files
-        filenames_to_delete = [input_filename]
+        filenames_to_delete = input_filenames
         for f in output_files.keys():
             filenames_to_delete.append(f.name)
 
@@ -85,7 +90,8 @@ class NetMHCcons(BaseCommandlinePredictor):
                 filenames=filenames_to_delete,
                 directories=dirs):
             run_multiple_commands_redirect_stdout(
-                commands, print_commands=True)
+                commands, print_commands=True,
+                process_limit=self.process_limit)
             for output_file, command in commands.iteritems():
                 # closing/opening looks insane
                 # but I was getting empty files otherwise
@@ -97,6 +103,11 @@ class NetMHCcons(BaseCommandlinePredictor):
                         sequence_key_mapping=sequence_key_mapping,
                         prediction_method_name="netmhccons")
                     epitope_collections.append(epitope_collection)
+
+        if len(epitope_collections) != len(commands):
+            raise ValueError("Expected an epitope collection for each "
+                             "command (%d), but instead there are %d" %
+                             (len(commands), len(epitope_collections)))
 
         if len(epitope_collections) == 0:
             raise ValueError("No epitopes from netMHCcons")

--- a/mhctools/netmhc_pan.py
+++ b/mhctools/netmhc_pan.py
@@ -19,7 +19,7 @@ import logging
 from .base_commandline_predictor import BaseCommandlinePredictor
 from .cleanup_context import CleanupFiles
 from .common import check_sequence_dictionary, seq_to_str
-from .file_formats import create_input_fasta_file, parse_netmhc_stdout
+from .file_formats import create_input_fasta_files, parse_netmhc_stdout
 from .process_helpers import AsyncProcess
 
 class NetMHCpan(BaseCommandlinePredictor):
@@ -38,8 +38,11 @@ class NetMHCpan(BaseCommandlinePredictor):
 
     def predict(self, fasta_dictionary):
         fasta_dictionary = check_sequence_dictionary(fasta_dictionary)
-        input_filename, sequence_key_mapping = create_input_fasta_file(
+        input_filenames, sequence_key_mapping = create_input_fasta_files(
             fasta_dictionary)
+        # TODO: We are not currently using the file chunking
+        # functionality here. See NetMHCcons.
+        input_filename = input_filenames[0]
 
         alleles_str = \
             ",".join(allele.replace("*", "") for allele in self.alleles)

--- a/mhctools/process_helpers.py
+++ b/mhctools/process_helpers.py
@@ -17,6 +17,7 @@ import logging
 import os
 from subprocess import Popen, CalledProcessError
 import time
+from Queue import Queue
 
 class AsyncProcess(object):
     """
@@ -24,7 +25,6 @@ class AsyncProcess(object):
     suppresses stdout printing, and raises an exception if the return code
     of wait() isn't 0
     """
-
     def __init__(
             self,
             args,
@@ -32,11 +32,20 @@ class AsyncProcess(object):
             redirect_stdout_file=None):
         assert len(args) > 0
         self.cmd = args[0]
+        self.args = args
+        self.redirect_stdout_file = redirect_stdout_file
 
         with open(os.devnull, 'w') as devnull:
             stdout = redirect_stdout_file if redirect_stdout_file else devnull
             stderr = devnull if suppress_stderr else None
             self.process = Popen(args, stdout=stdout, stderr=stderr)
+
+    def poll(self):
+        """
+        Peeks at whether the process is done or not, without
+        waiting for it. Leaves exception handling and such to wait().
+        """
+        return self.process.poll()
 
     def wait(self):
         ret_code = self.process.wait()
@@ -61,45 +70,11 @@ def run_command(args, **kwargs):
     elapsed_time = time.time() - start_time
     logging.info("%s took %0.4f seconds", cmd, elapsed_time)
 
-def run_multiple_commands(multiple_args_lists, print_commands=True, **kwargs):
-    """
-    Run multiple shell commands in parallel.
-
-    Parameters
-    ----------
-
-    multiple_args_lists : list of lists
-        A collection of args lists to run on the shell.
-        For example:
-            [["ls", "-als"], ["rm", "-rf", "/dev"]]
-
-    print_commands : bool
-        Print shell commands before running them
-    """
-    assert len(multiple_args_lists) > 0
-    assert all(len(args) > 0 for args in multiple_args_lists)
-    start_time = time.time()
-    command_names = [args[0] for args in multiple_args_lists]
-    processes = []
-    for args in multiple_args_lists:
-        if print_commands:
-            print(" ".join(args))
-        p = AsyncProcess(args, **kwargs)
-        processes.append(p)
-
-    for p in processes:
-        p.wait()
-
-    elapsed_time = time.time() - start_time
-    logging.info("Ran %d commands (%s) in %0.4f seconds",
-        len(multiple_args_lists),
-        ",".join(command_names),
-        elapsed_time
-    )
-
 def run_multiple_commands_redirect_stdout(
         multiple_args_dict,
         print_commands=True,
+        process_limit=0,
+        polling_freq=1,
         **kwargs):
     """
     Run multiple shell commands in parallel, write each of their
@@ -114,23 +89,54 @@ def run_multiple_commands_redirect_stdout(
 
     print_commands : bool
         Print shell commands before running them.
+
+    process_limit : int
+        Limit the number of concurrent processes to this number. 0
+        if there is no limit
+
+    polling_freq : int
+        Number of seconds between checking for done processes, if
+        we have a process limit
     """
     assert len(multiple_args_dict) > 0
     assert all(len(args) > 0 for args in multiple_args_dict.values())
     assert all(hasattr(f, 'name') for f in multiple_args_dict.keys())
     start_time = time.time()
-    processes = []
-    for f, args in multiple_args_dict.iteritems():
+    processes = Queue(maxsize=process_limit)
+
+    def add_to_queue(process):
         if print_commands:
-            print(" ".join(args), ">", f.name)
+            print(" ".join(process.args), ">",
+                  process.redirect_stdout_file.name)
+        processes.put(process)
+
+    for f, args in multiple_args_dict.iteritems():
         p = AsyncProcess(
             args,
             redirect_stdout_file=f,
             **kwargs)
-        processes.append(p)
+        if not processes.full():
+            add_to_queue(p)
+        else:
+            while processes.full():
+                # Are there any done processes?
+                to_remove = []
+                for possibly_done in processes.queue:
+                    if possibly_done.poll() != None:
+                        possibly_done.wait()
+                        to_remove.append(possibly_done)
+                # Remove them from the queue and stop checking
+                if to_remove:
+                    for process_to_remove in to_remove:
+                        processes.queue.remove(process_to_remove)
+                    break
+                # Check again in a second if there weren't
+                time.sleep(polling_freq)
+            add_to_queue(p)
 
-    for p in processes:
-        p.wait()
+    # Wait for all the rest of the processes
+    while not processes.empty():
+        processes.get().wait()
 
     elapsed_time = time.time() - start_time
     logging.info("Ran %d commands in %0.4f seconds",

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ except:
 if __name__ == '__main__':
     setup(
         name='mhctools',
-        version="0.0.7",
+        version="0.0.8",
         description="Python interface to running command-line and web-based MHC binding predictors",
         author="Alex Rubinsteyn",
         author_email="alex {dot} rubinsteyn {at} mssm {dot} edu",

--- a/test/test_netmhc_cons.py
+++ b/test/test_netmhc_cons.py
@@ -18,3 +18,36 @@ def test_netmhc_cons():
 
     assert len(epitope_collection) == 4, \
         "Expected 4 epitopes from %s" % (epitope_collection,)
+
+def test_netmhc_cons_chunking():
+    alleles = [normalize_allele_name(DEFAULT_ALLELE)]
+    fasta_dictionary = {
+        "SMAD4-001": "ASIINFKELA",
+        "TP53-001": "ASILLLVFYW",
+        "SMAD4-002": "ASIINFKELS",
+        "TP53-002": "ASILLLVFYS",
+        "TP53-003": "ASILLLVFYT",
+        "TP53-004": "ASILLLVFYG",
+        "TP53-005": "ASILLLVFYG"
+    }
+    for max_file_records in [1, 3, 5, 14, 20]:
+        for process_limit in [1, 2, 10]:
+            cons_predictor = NetMHCcons(
+                alleles=alleles,
+                epitope_lengths=[9],
+                max_file_records=max_file_records,
+                process_limit=process_limit
+            )
+            epitope_collection = cons_predictor.predict(
+                fasta_dictionary=fasta_dictionary)
+            assert len(epitope_collection) == 14, \
+                "Expected 14 epitopes from %s" % (epitope_collection,)
+            source_keys = []
+            for epitope in epitope_collection:
+                source_keys.append(epitope.source_sequence_key)
+            for fasta_key in fasta_dictionary.keys():
+                fasta_count = source_keys.count(fasta_key)
+                assert fasta_count == 2, \
+                    ("Expected each fasta key to appear twice, once for "
+                     "each length, but saw %s %d time(s)" % (
+                         fasta_key, fasta_count))


### PR DESCRIPTION
Before: a single input file and process per allele/length.

Now: arbitrary division of input file into multiple files and arbitrary number of processes; processes are de-queue'd and thrown at the input files.

Currently only used in `NetMHCcons`.

Also:
- Got run of apparently unused `run_multiple_commands`

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/mhctools/12)

<!-- Reviewable:end -->
