### PR TITLE
Fixed small Python3 issue 

### DIFF
--- a/mhctools/cleanup_context.py
+++ b/mhctools/cleanup_context.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function, division, absolute_import
 import logging
 import os
-
 import shutil
 
 class CleanupFiles(object):

--- a/mhctools/epitope_collection.py
+++ b/mhctools/epitope_collection.py
@@ -28,7 +28,7 @@ class EpitopeCollection(Collection):
             binding_predictions,
             path=None,
             distinct=True,
-            sort_key=lambda x: x.percentile_rank):
+            sort_key=lambda x: x.value):
         Collection.__init__(
             self,
             elements=binding_predictions,

--- a/mhctools/epitope_collection.py
+++ b/mhctools/epitope_collection.py
@@ -17,6 +17,7 @@ from collections import defaultdict
 
 import pandas as pd
 from varcode import Collection
+
 from .binding_prediction import BindingPrediction
 
 class EpitopeCollection(Collection):

--- a/mhctools/iedb.py
+++ b/mhctools/iedb.py
@@ -13,18 +13,11 @@
 # limitations under the License.
 
 from __future__ import print_function, division, absolute_import
-
-import io
-try:
-    # For Python 3.0 and later
-    from urllib.request import urlopen, Request
-    from urllib.parse import urlencode
-except ImportError:
-    # Fall back to Python 2's urllib2
-    from urllib2 import urlopen, Request
-    from urllib import urlencode
 import logging
+import io
 
+from six.moves.urllib.request import urlopen, Request
+from six.moves.urllib.parse import urlencode
 import pandas as pd
 
 from .base_predictor import BasePredictor

--- a/mhctools/process_helpers.py
+++ b/mhctools/process_helpers.py
@@ -17,7 +17,8 @@ import logging
 import os
 from subprocess import Popen, CalledProcessError
 import time
-from Queue import Queue
+
+from six.moves import queue
 
 class AsyncProcess(object):
     """
@@ -102,7 +103,7 @@ def run_multiple_commands_redirect_stdout(
     assert all(len(args) > 0 for args in multiple_args_dict.values())
     assert all(hasattr(f, 'name') for f in multiple_args_dict.keys())
     start_time = time.time()
-    processes = Queue(maxsize=process_limit)
+    processes = queue(maxsize=process_limit)
 
     def add_to_queue(process):
         if print_commands:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy==1.7
 pandas==0.13.1
-varcode >=0.3.1, <0.4.0
+varcode >=0.3.1, <0.8.0
+six >= 1.9.0

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ except:
 if __name__ == '__main__':
     setup(
         name='mhctools',
-        version="0.0.8",
+        version="0.0.9",
         description="Python interface to running command-line and web-based MHC binding predictors",
         author="Alex Rubinsteyn",
         author_email="alex {dot} rubinsteyn {at} mssm {dot} edu",
@@ -55,7 +55,8 @@ if __name__ == '__main__':
         install_requires=[
             'numpy>=1.7',
             'pandas>=0.13.1',
-            'varcode >=0.3.1, <0.4.0'
+            'varcode >=0.3.1, <0.8.0',
+            'six >=1.9.0'
         ],
         long_description=readme,
         packages=['mhctools'],


### PR DESCRIPTION
- using `six` to import version agnostic Python packages

Fixes https://github.com/hammerlab/mhctools/issues/18

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/mhctools/19)

<!-- Reviewable:end -->
