### PR TITLE
Add Travis to mhctools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
 addons:
   apt:
     packages:
+      # Needed for NetMHC
       tcsh
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,13 @@ language: python
 python:
 - "2.7"
 - "3.4"
+addons:
+  apt:
+    packages:
+    - python-scipy
+    - python3-scipy
+virtualenv: # Needed in conjunction with apt-get'ing scipy
+  system_site_packages: true
 install:
 - pip install -r requirements.txt
 - python install .  

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+sudo: false  # Use container-based infrastructure
+language: python
+python:
+- "2.7"
+- "3.4"
+install:
+- pip install -r requirements.txt
+- python install .  
+script: nosetests test && ./lint.sh
+deploy:
+  provider: pypi
+  user: hammerlab
+  password: # See http://docs.travis-ci.com/user/encryption-keys/
+    secure: gJSWl4PLXKtVc2ERwbzfd4qKk9Yy4T8dpfR7Q89VLVXTd7Tv1SsEknShJZUFaCPN85aYFcAWsoOI6vSlBSdXeTONU/pmPgcWOLfiErsgCqUs6qq7edOhrtOS307SREX4oF6AF2iyJduWAF4NPq+9IoJUROIiB4u5qeUtWfVu2Eo=
+  on:
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,19 @@
 sudo: false  # Use container-based infrastructure
 language: python
 python:
-- "2.7"
-- "3.4"
-addons:
-  apt:
-    packages:
-    - python-scipy
-    - python3-scipy
-virtualenv: # Needed in conjunction with apt-get'ing scipy
-  system_site_packages: true
+  - "2.7"
+  - "3.4"
+# Setup anaconda; see https://gist.github.com/dan-blanchard/7045057
+before_install:
+  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - chmod +x miniconda.sh
+  - ./miniconda.sh -b
+  - export PATH=/home/travis/miniconda/bin:$PATH
+  - conda update --yes conda
 install:
-- pip install -r requirements.txt
-- python install .  
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy nose pandas
+  - pip install -r requirements.txt
+  - python install .
 script: nosetests test && ./lint.sh
 deploy:
   provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,28 @@ language: python
 python:
   - "2.7"
   - "3.4"
-# Setup anaconda; see https://gist.github.com/dan-blanchard/7045057
+addons:
+  apt:
+    packages:
+      tcsh
+env:
+  global:
+    # MHC_BUNDLE_PASS
+    - secure: "TIminZrp9m1kMXhemqz8Zx4BjojIoEYZJnNrDrL6T/pKMpP5FQ6sprj8meGfNse4ApRIPmp5lhqxbPOe7Cg7ooetIcORekjRueHwRkYXqgMbgffgZYuEJTAGLKFsBDEXFD1kWT7igmvXFsP1T0bb1TxRPK93Q5G+e1dEAm6Iqwo="
+# Setup anaconda for easily running scipy on Travis; see https://gist.github.com/dan-blanchard/7045057
 before_install:
   - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
   - ./miniconda.sh -b
   - export PATH=/home/travis/miniconda/bin:$PATH
   - conda update --yes conda
+  - git clone https://mhcbundle:$MHC_BUNDLE_PASS@github.com/hammerlab/netmhc-bundle.git
+  - export NETMHC_BUNDLE_HOME=$PWD/netmhc-bundle
+  - mkdir tmp
+  - export NETMHC_BUNDLE_TMPDIR=$PWD/tmp
+  - export PATH=$PATH:$NETMHC_BUNDLE_HOME/bin
 install:
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy nose
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy nose pandas
   - pip install -r requirements.txt
   - pip install .
 script: nosetests test && ./lint.sh
@@ -19,6 +32,6 @@ deploy:
   provider: pypi
   user: hammerlab
   password: # See http://docs.travis-ci.com/user/encryption-keys/
-    secure: gJSWl4PLXKtVc2ERwbzfd4qKk9Yy4T8dpfR7Q89VLVXTd7Tv1SsEknShJZUFaCPN85aYFcAWsoOI6vSlBSdXeTONU/pmPgcWOLfiErsgCqUs6qq7edOhrtOS307SREX4oF6AF2iyJduWAF4NPq+9IoJUROIiB4u5qeUtWfVu2Eo=
+    secure: "gJSWl4PLXKtVc2ERwbzfd4qKk9Yy4T8dpfR7Q89VLVXTd7Tv1SsEknShJZUFaCPN85aYFcAWsoOI6vSlBSdXeTONU/pmPgcWOLfiErsgCqUs6qq7edOhrtOS307SREX4oF6AF2iyJduWAF4NPq+9IoJUROIiB4u5qeUtWfVu2Eo="
   on:
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ before_install:
   - export PATH=/home/travis/miniconda/bin:$PATH
   - conda update --yes conda
 install:
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy nose pandas
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION numpy scipy nose
   - pip install -r requirements.txt
-  - python install .
+  - pip install .
 script: nosetests test && ./lint.sh
 deploy:
   provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,3 +36,4 @@ deploy:
     secure: "gJSWl4PLXKtVc2ERwbzfd4qKk9Yy4T8dpfR7Q89VLVXTd7Tv1SsEknShJZUFaCPN85aYFcAWsoOI6vSlBSdXeTONU/pmPgcWOLfiErsgCqUs6qq7edOhrtOS307SREX4oF6AF2iyJduWAF4NPq+9IoJUROIiB4u5qeUtWfVu2Eo="
   on:
     tags: true
+    branch: master

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/hammerlab/mhctools.svg?branch=master)](https://travis-ci.org/hammerlab/mhctools)
+
 # mhctools
 Python interface to running command-line and web-based MHC binding predictors. 
 

--- a/lint.sh
+++ b/lint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -o errexit
+
+find . -name '*.py' \
+  | xargs pylint \
+  --errors-only \
+  --disable=print-statement
+
+echo 'Passes pylint check'

--- a/lint.sh
+++ b/lint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -o errexit
 
-find . -name '*.py' \
+find mhctools test -name '*.py' \
   | xargs pylint \
   --errors-only \
   --disable=print-statement

--- a/mhctools/base_commandline_predictor.py
+++ b/mhctools/base_commandline_predictor.py
@@ -86,6 +86,7 @@ class BaseCommandlinePredictor(BasePredictor):
                         logging.info("Skipping allele %s: %s" % (
                             line, error))
                         continue
+            return valid_alleles
         except:
             logging.warning(
                 "Failed to run %s %s",

--- a/mhctools/common.py
+++ b/mhctools/common.py
@@ -16,6 +16,7 @@ from __future__ import print_function, division, absolute_import
 
 # Python3 doesn't have a unicode classes
 try:
+    # pylint: disable=undefined-variable
     string_classes = (unicode, str)
 except NameError:
     string_classes = (str,)

--- a/mhctools/epitope_collection.py
+++ b/mhctools/epitope_collection.py
@@ -58,7 +58,7 @@ class EpitopeCollection(Collection):
 
     def groupby(self, key_fn):
         groups = defaultdict(list)
-        for binding_prediction in self.binding_predictions:
+        for binding_prediction in self.elements:
             key = key_fn(binding_prediction)
             groups[key].append(binding_prediction)
         # want to create an EpitopeCollection for each group

--- a/mhctools/iedb.py
+++ b/mhctools/iedb.py
@@ -75,6 +75,11 @@ def _parse_iedb_response(response):
     if len(response) == 0:
         raise ValueError("Empty response from IEDB!")
     df = pd.read_csv(io.BytesIO(response), delim_whitespace=True, header=0)
+
+    # pylint doesn't realize that df is a DataFrame, so tell is
+    assert type(df) == pd.DataFrame
+    df = pd.DataFrame(df)
+
     if len(df) == 0:
         raise ValueError(
             "No binding predictions in response from IEDB: %s" % (response,))

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,4 @@
+[TYPECHECK]
+# Without ignoring this, we get errors like:
+# E:249,20: Module 'numpy' has no 'nan' member (no-member)
+ignored-modules = numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-numpy==1.7
-pandas==0.13.1
-varcode >=0.3.17
-six >= 1.9.0
-pylint >= 1.4.4
-nose >= 1.3.6
+numpy>=1.7
+pandas>=0.13.1
+varcode>=0.3.17
+six>=1.9.0
+pylint>=1.4.4
+nose>=1.3.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ numpy==1.7
 pandas==0.13.1
 varcode >=0.3.17
 six >= 1.9.0
+pylint >= 1.4.4
+nose >= 1.3.6

--- a/setup.py
+++ b/setup.py
@@ -55,8 +55,8 @@ if __name__ == '__main__':
         install_requires=[
             'numpy>=1.7',
             'pandas>=0.13.1',
-            'varcode >=0.3.17',
-            'six >=1.9.0'
+            'varcode>=0.3.17',
+            'six>=1.9.0'
         ],
         long_description=readme,
         packages=['mhctools'],

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ except:
 if __name__ == '__main__':
     setup(
         name='mhctools',
-        version="0.1.3",
+        version="0.1.4",
         description="Python interface to running command-line and web-based MHC binding predictors",
         author="Alex Rubinsteyn",
         author_email="alex {dot} rubinsteyn {at} mssm {dot} edu",

--- a/test/test_known_epitopes.py
+++ b/test/test_known_epitopes.py
@@ -44,5 +44,5 @@ def test_HIV_epitope():
     for mhc_class in mhc_classes:
         mhc_model = mhc_class("HLA-A*02:01", epitope_lengths=9)
         epitope = mhc_model.predict("SLYNTVATL")[0]
-        assert epitope.percentile_rank < 1.0, \
-            "Expected %s to have percentile rank <= 1.0" % epitope
+        assert epitope.percentile_rank <= 4.0, \
+            "Expected %s to have percentile rank <= 3.0" % str(epitope)

--- a/test/test_known_epitopes.py
+++ b/test/test_known_epitopes.py
@@ -18,6 +18,7 @@ Make sure all binding predictors give a high IC50 and percentile rank.
 import mhctools
 
 mhc_classes = [
+    mhctools.NetMHCcons,
     mhctools.NetMHCpan,
     mhctools.NetMHCcons,
     mhctools.NetMHC,
@@ -43,5 +44,5 @@ def test_HIV_epitope():
     for mhc_class in mhc_classes:
         mhc_model = mhc_class("HLA-A*02:01", epitope_lengths=9)
         epitope = mhc_model.predict("SLYNTVATL")[0]
-        assert epitope.value < 500, \
-            "Expected %s to have IC50 < 500nM" % (epitope,)
+        assert epitope.percentile_rank < 1.0, \
+            "Expected %s to have percentile rank <= 1.0" % epitope

--- a/test/test_known_epitopes.py
+++ b/test/test_known_epitopes.py
@@ -44,5 +44,5 @@ def test_HIV_epitope():
     for mhc_class in mhc_classes:
         mhc_model = mhc_class("HLA-A*02:01", epitope_lengths=9)
         epitope = mhc_model.predict("SLYNTVATL")[0]
-        assert epitope.percentile_rank <= 4.0, \
-            "Expected %s to have percentile rank <= 3.0" % str(epitope)
+        assert epitope.value < 500, \
+            "Expected %s to have IC50 < 500nM" % (epitope,)


### PR DESCRIPTION
In this PR:
- Runs on Python 2 and 3.
- Deploys to PyPi when tagged on `master`.
- It wasn't straighforward to set up `NetMHC` on Travis. In order to use `netmhc-bundle`, which is a private repo: I created a GitHub username just for that, encrypted the password with `travis encrypt`, and used that encrypted password as an environment variable in `git clone`ing the repo. I hope we can come up with a better way via SSH keys, though I had less luck with that, and think this'll do for now. (There's a lot that we can't do without Travis Pro, but this current scenario does not seem like a good reason to pay for Travis Pro.)
- I had to do some fiddling to get `NetMHC` to actually run; namely, `apt get`ing `tcsh`.
- Adds a linter, and addresses some issues caught by the linter.
- Uses anaconda to get `scipy` installed on Travis, and changes `numpy==` to `numpy>=` for compatibility with that.
- Fix a unit test re `percentile_rank` (@iskander, I don't know what you intended with this test, but it didn't work as written)
- Add a return statement to `_determine_valid_alleles` (see #24)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/mhctools/25)

<!-- Reviewable:end -->
