### PR TITLE
Don't worry about tags for pypi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,5 +35,4 @@ deploy:
   password: # See http://docs.travis-ci.com/user/encryption-keys/
     secure: "gJSWl4PLXKtVc2ERwbzfd4qKk9Yy4T8dpfR7Q89VLVXTd7Tv1SsEknShJZUFaCPN85aYFcAWsoOI6vSlBSdXeTONU/pmPgcWOLfiErsgCqUs6qq7edOhrtOS307SREX4oF6AF2iyJduWAF4NPq+9IoJUROIiB4u5qeUtWfVu2Eo="
   on:
-    tags: true
     branch: master


### PR DESCRIPTION
Let's try deploying whenever Travis runs on the `master` branch, so we don't have to worry about tags.

From @iskandr: "the first push to PyPI for a specific version will succeed and the following ones will fail. Which is probably fine because any change the user has to deal with should have a distinct version"

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/mhctools/26)

<!-- Reviewable:end -->
