### PR TITLE
Fix when multiple alleles are passed as a string

### DIFF
--- a/mhctools/base_predictor.py
+++ b/mhctools/base_predictor.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from __future__ import print_function, division, absolute_import
-import logging
 
 from typechecks import require_iterable_of
 
@@ -52,7 +51,7 @@ class BasePredictor(object):
         # I find myself often constructing a predictor with just one allele
         # so as a convenience, allow user to not wrap that allele as a list
         if isinstance(alleles, str):
-            alleles = [alleles]
+            alleles = alleles.split(',')
         self.alleles = self._check_hla_alleles(alleles, valid_alleles)
 
         if isinstance(epitope_lengths, int):

--- a/test/test_netmhc_cons.py
+++ b/test/test_netmhc_cons.py
@@ -19,6 +19,20 @@ def test_netmhc_cons():
     assert len(epitope_collection) == 4, \
         "Expected 4 epitopes from %s" % (epitope_collection,)
 
+def test_netmhc_cons_multiple_alleles():
+    alleles = 'A*02:01,B*35:02'
+    cons_predictor = NetMHCcons(
+        alleles=alleles,
+        epitope_lengths=[9])
+    fasta_dictionary = {
+        "SMAD4-001": "ASIINFKELA",
+        "TP53-001": "ASILLLVFYW"
+    }
+    epitope_collection = cons_predictor.predict(
+        fasta_dictionary=fasta_dictionary)
+    assert len(epitope_collection) == 8, \
+        "Expected 4 epitopes from %s" % (epitope_collection,)
+
 def test_netmhc_cons_chunking():
     alleles = [normalize_allele_name(DEFAULT_ALLELE)]
     fasta_dictionary = {


### PR DESCRIPTION
When alleles are passed as a string they are coerced into a list. When this happens, if multiple comma-separated alleles were passed, everything works! Except only the first allele is processed. Weird case, but just changing making a one element list to `split` works, 

Take a look at the added test case for an example.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/mhctools/46)

<!-- Reviewable:end -->
