### PR TITLE
Add NetMHC 4.0 to mhctools

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ strongest_predicted_binder = epitope_collection[0]
 ## API
 
 The following models are available in `mhctools`:
-* `NetMHC3`: requires locally installed version of [NetMHC 3.x](http://www.cbs.dtu.dk/services/NetMHC/)
+* `NetMHC3`: requires locally installed version of [NetMHC 3.x](http://www.cbs.dtu.dk/services/NetMHC-3.4/)
 * `NetMHC4`: requires locally installed version of [NetMHC 4.x](http://www.cbs.dtu.dk/services/NetMHC/)
 * `NetMHCpan`: requires locally installed version of [NetMHCpan](http://www.cbs.dtu.dk/services/NetMHCpan/)
 * `NetMHCIIpan`: requires locally installed version of [NetMHCIIpan](http://www.cbs.dtu.dk/services/NetMHCIIpan/)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ strongest_predicted_binder = epitope_collection[0]
 ## API
 
 The following models are available in `mhctools`:
-* `NetMHC`: requires locally installed version of [NetMHC](http://www.cbs.dtu.dk/services/NetMHC/)
+* `NetMHC3`: requires locally installed version of [NetMHC 3.x](http://www.cbs.dtu.dk/services/NetMHC/)
+* `NetMHC4`: requires locally installed version of [NetMHC 4.x](http://www.cbs.dtu.dk/services/NetMHC/)
 * `NetMHCpan`: requires locally installed version of [NetMHCpan](http://www.cbs.dtu.dk/services/NetMHCpan/)
 * `NetMHCIIpan`: requires locally installed version of [NetMHCIIpan](http://www.cbs.dtu.dk/services/NetMHCIIpan/)
 * `NetMHCcons`: requires locally installed version of [NetMHCcons](http://www.cbs.dtu.dk/services/NetMHCcons/)

--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -8,7 +8,8 @@ from .iedb import (
     IedbSMM_PMBEC,
     IedbNetMHCIIpan,
 )
-from .netmhc import NetMHC
+from .netmhc3 import NetMHC3
+from .netmhc4 import NetMHC4
 from .netmhc_cons import NetMHCcons
 from .netmhc_pan import NetMHCpan
 from .netmhcii_pan import NetMHCIIpan
@@ -23,7 +24,8 @@ __all__ = [
     "IedbSMM",
     "IedbSMM_PMBEC",
     "IedbNetMHCIIpan",
-    "NetMHC",
+    "NetMHC3",
+    "NetMHC4",
     "NetMHCcons",
     "NetMHCpan",
     "NetMHCIIpan",

--- a/mhctools/base_commandline_predictor.py
+++ b/mhctools/base_commandline_predictor.py
@@ -180,11 +180,9 @@ class BaseCommandlinePredictor(BasePredictor):
                         continue
             return supported_alleles
         except:
-            logging.warning(
-                "Failed to run %s %s",
+            raise SystemError("Failed to run %s %s. Possibly an incorrect executable version?" % (
                 command,
-                supported_allele_flag)
-            raise
+                supported_allele_flag))
 
     def prepare_allele_name(self, allele_name):
         """

--- a/mhctools/file_formats.py
+++ b/mhctools/file_formats.py
@@ -91,13 +91,13 @@ def split_stdout_lines(stdout):
         if len(l) > 0 and not l.startswith("#"):
             yield l.split()
 
-def parse_netmhc_stdout(
+def parse_netmhc3_stdout(
         stdout,
         fasta_dictionary,
         prediction_method_name="netmhc",
         sequence_key_mapping=None):
     """
-    Parse the output format for NetMHC, which looks like:
+    Parse the output format for NetMHC 3.x, which looks like:
 
     ----------------------------------------------------------------------------------------------------
     pos    peptide      logscore affinity(nM) Bind Level    Protein Name     Allele
@@ -109,9 +109,6 @@ def parse_netmhc_stdout(
     2  INKFFFQQQ         0.046        30406                         A2 HLA-A02:01
     3  NKFFFQQQQ         0.050        29197                         A2 HLA-A02:01
     --------------------------------------------------------------------------------------------------
-
-    ...this is similar to the NetMHCpan output, but the columns are in a
-    different order and the percentile rank column is missing.
     """
 
     builder = EpitopeCollectionBuilder(
@@ -161,6 +158,67 @@ def parse_netmhc_stdout(
                 ic50=ic50,
                 log_ic50=log_affinity,
                 rank=0.0)
+    return builder.get_collection()
+
+def parse_netmhc4_stdout(
+        stdout,
+        fasta_dictionary,
+        prediction_method_name="netmhc",
+        sequence_key_mapping=None):
+    """
+    # Peptide length 9
+    # Rank Threshold for Strong binding peptides   0.500
+    # Rank Threshold for Weak binding peptides   2.000
+    -----------------------------------------------------------------------------------
+      pos          HLA      peptide         Core Offset  I_pos  I_len  D_pos  D_len        iCore        Identity 1-log50k(aff) Affinity(nM)    %Rank  BindLevel
+    -----------------------------------------------------------------------------------
+        0    HLA-A0201    TMDKSELVQ    TMDKSELVQ      0      0      0      0      0    TMDKSELVQ 143B_BOVIN_P293         0.051     28676.59    43.00
+        1    HLA-A0201    MDKSELVQK    MDKSELVQK      0      0      0      0      0    MDKSELVQK 143B_BOVIN_P293         0.030     36155.15    70.00
+        2    HLA-A0201    DKSELVQKA    DKSELVQKA      0      0      0      0      0    DKSELVQKA 143B_BOVIN_P293         0.030     36188.42    70.00
+        3    HLA-A0201    KSELVQKAK    KSELVQKAK      0      0      0      0      0    KSELVQKAK 143B_BOVIN_P293         0.032     35203.22    65.00
+        4    HLA-A0201    SELVQKAKL    SELVQKAKL      0      0      0      0      0    SELVQKAKL 143B_BOVIN_P293         0.031     35670.99    65.00
+        5    HLA-A0201    ELVQKAKLA    ELVQKAKLA      0      0      0      0      0    ELVQKAKLA 143B_BOVIN_P293         0.080     21113.07    29.00
+        6    HLA-A0201    LVQKAKLAE    LVQKAKLAE      0      0      0      0      0    LVQKAKLAE 143B_BOVIN_P293         0.027     37257.56    75.00
+        7    HLA-A0201    VQKAKLAEQ    VQKAKLAEQ      0      0      0      0      0    VQKAKLAEQ 143B_BOVIN_P293         0.040     32404.62    55.00
+      219    HLA-A0201    QLLRDNLTL    QLLRDNLTL      0      0      0      0      0    QLLRDNLTL 143B_BOVIN_P293         0.527       167.10     1.50 <= WB
+    -----------------------------------------------------------------------------------
+    """
+    builder = EpitopeCollectionBuilder(
+        fasta_dictionary=fasta_dictionary,
+        prediction_method_name=prediction_method_name)
+
+    n_fields = 14
+    for fields in split_stdout_lines(stdout):
+        if len(fields) < n_fields:
+            continue
+
+        pos, allele, peptide, core, offset, i_pos, i_len, d_pos, d_len, i_core, key, log_affinity, ic50, rank = fields[:n_fields]
+        try:
+            pos = int(pos)
+            allele = str(allele)
+            peptide = str(peptide)
+            key = str(key)
+            log_affinity = float(log_affinity)
+            ic50 = float(ic50)
+            rank = float(rank)
+        except:
+            # if position or affinity values can't be parsed,
+            # then skip this line
+            continue
+        if sequence_key_mapping:
+            original_key = sequence_key_mapping[key]
+        else:
+            # if sequence_key_mapping isn't provided then let's assume it's the
+            # identity function
+            original_key = key
+        builder.add_binding_prediction(
+            source_sequence_key=original_key,
+            offset=pos,
+            peptide=peptide,
+            allele=allele,
+            ic50=ic50,
+            rank=rank,
+            log_ic50=log_affinity)
     return builder.get_collection()
 
 def parse_netmhcpan_stdout(

--- a/mhctools/file_formats.py
+++ b/mhctools/file_formats.py
@@ -94,7 +94,7 @@ def split_stdout_lines(stdout):
 def parse_netmhc3_stdout(
         stdout,
         fasta_dictionary,
-        prediction_method_name="netmhc",
+        prediction_method_name="netmhc3",
         sequence_key_mapping=None):
     """
     Parse the output format for NetMHC 3.x, which looks like:
@@ -163,7 +163,7 @@ def parse_netmhc3_stdout(
 def parse_netmhc4_stdout(
         stdout,
         fasta_dictionary,
-        prediction_method_name="netmhc",
+        prediction_method_name="netmhc4",
         sequence_key_mapping=None):
     """
     # Peptide length 9

--- a/mhctools/netmhc3.py
+++ b/mhctools/netmhc3.py
@@ -15,15 +15,9 @@
 from __future__ import print_function, division, absolute_import
 
 from .base_commandline_predictor import BaseCommandlinePredictor
-<<<<<<< Updated upstream:mhctools/netmhc.py
-from .file_formats import parse_netmhc_stdout
-
-class NetMHC(BaseCommandlinePredictor):
-=======
 from .file_formats import parse_netmhc3_stdout
 
 class NetMHC3(BaseCommandlinePredictor):
->>>>>>> Stashed changes:mhctools/netmhc3.py
     def __init__(
             self,
             alleles,

--- a/mhctools/netmhc3.py
+++ b/mhctools/netmhc3.py
@@ -15,9 +15,15 @@
 from __future__ import print_function, division, absolute_import
 
 from .base_commandline_predictor import BaseCommandlinePredictor
+<<<<<<< Updated upstream:mhctools/netmhc.py
 from .file_formats import parse_netmhc_stdout
 
 class NetMHC(BaseCommandlinePredictor):
+=======
+from .file_formats import parse_netmhc3_stdout
+
+class NetMHC3(BaseCommandlinePredictor):
+>>>>>>> Stashed changes:mhctools/netmhc3.py
     def __init__(
             self,
             alleles,
@@ -29,7 +35,7 @@ class NetMHC(BaseCommandlinePredictor):
             program_name=program_name,
             alleles=alleles,
             epitope_lengths=epitope_lengths,
-            parse_output_fn=parse_netmhc_stdout,
+            parse_output_fn=parse_netmhc3_stdout,
             # NetMHC just expects the first arg to be an input FASTA
             input_fasta_flag="",
             # NetMHC doesn't have the ability to use a custom

--- a/mhctools/netmhc4.py
+++ b/mhctools/netmhc4.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2015. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function, division, absolute_import
+
+from .base_commandline_predictor import BaseCommandlinePredictor
+from .file_formats import parse_netmhc4_stdout
+
+class NetMHC4(BaseCommandlinePredictor):
+    def __init__(
+            self,
+            alleles,
+            epitope_lengths=[9],
+            program_name="netMHC",
+            max_file_records=None,
+            process_limit=0):
+        BaseCommandlinePredictor.__init__(
+            self,
+            program_name=program_name,
+            alleles=alleles,
+            epitope_lengths=epitope_lengths,
+            parse_output_fn=parse_netmhc4_stdout,
+            input_fasta_flag="-f",
+            tempdir_flag="-tdir",
+            length_flag="-l",
+            allele_flag="-a",
+            supported_alleles_flag="-listMHC",
+            max_file_records=max_file_records,
+            process_limit=process_limit)
+
+    def prepare_allele_name(self, allele_name):
+        allele_name = super(NetMHC4, self).prepare_allele_name(allele_name)
+        return allele_name.replace(":", "")

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ except:
 if __name__ == '__main__':
     setup(
         name='mhctools',
-        version="0.1.8",
+        version="0.2.0",
         description="Python interface to running command-line and web-based MHC binding predictors",
         author="Alex Rubinsteyn",
         author_email="alex {dot} rubinsteyn {at} mssm {dot} edu",

--- a/test/test_known_class1_epitopes.py
+++ b/test/test_known_class1_epitopes.py
@@ -21,17 +21,28 @@ mhc_classes = [
     mhctools.NetMHCcons,
     mhctools.NetMHCpan,
     mhctools.NetMHCcons,
-    mhctools.NetMHC,
+    mhctools.NetMHC3,
+    mhctools.NetMHC4,
     mhctools.IedbNetMHCcons,
     mhctools.IedbNetMHCpan,
     mhctools.IedbSMM,
     mhctools.IedbSMM_PMBEC,
 ]
 
+# Tests assume that a netMHC-3.4 binary exists, and that netMHC is 4.0.
+program_name_overrides = {mhctools.NetMHC3: "netMHC-3.4"}
+
 def expect_binder(mhc_model, peptide):
     prediction = mhc_model.predict(peptide)[0]
     assert prediction.value < 500, "Expected %s to have IC50 < 500nM, got %s" % (
         peptide, prediction)
+
+def make_mhc_model(mhc_class, alleles, epitope_lengths):
+    kwargs = {"alleles": alleles,
+              "epitope_lengths": epitope_lengths}
+    if mhc_class in program_name_overrides:
+        kwargs.update({"program_name": program_name_overrides[mhc_class]})
+    return mhc_class(**kwargs)
 
 def test_MAGE_epitope():
     # Test the A1 MAGE epitope ESDPIVAQY from
@@ -39,12 +50,12 @@ def test_MAGE_epitope():
     #   as a Cross-Reactive Target for Engineered MAGE A3-Directed
     #   T Cells
     for mhc_class in mhc_classes:
-        mhc_model = mhc_class("HLA-A*01:01", epitope_lengths=9)
+        mhc_model = make_mhc_model(mhc_class, "HLA-A*01:01", 9)
         yield (expect_binder, mhc_model, "ESDPIVAQY")
 
 def test_HIV_epitope():
     # Test the A2 HIV epitope SLYNTVATL from
     #    The HIV-1 HLA-A2-SLYNTVATL Is a Help-Independent CTL Epitope
     for mhc_class in mhc_classes:
-        mhc_model = mhc_class("HLA-A*02:01", epitope_lengths=9)
+        mhc_model = make_mhc_model(mhc_class, "HLA-A*02:01", 9)
         yield (expect_binder, mhc_model, "SLYNTVATL")

--- a/test/test_netmhc_version.py
+++ b/test/test_netmhc_version.py
@@ -1,0 +1,26 @@
+from nose.tools import raises
+
+from mhctools import NetMHC3, NetMHC4
+from mhctools.alleles import normalize_allele_name
+
+
+def run_class_with_executable(mhc_class, mhc_executable):
+    alleles = [normalize_allele_name("HLA-A*02:01")]
+    predictor = mhc_class(
+        alleles=alleles,
+        epitope_lengths=[9],
+        program_name=mhc_executable)
+    fasta_dictionary = {
+        "SMAD4-001": "ASIINFKELA",
+        "TP53-001": "ASILLLVFYW"
+    }
+    epitope_collection = predictor.predict(
+        fasta_dictionary=fasta_dictionary)
+
+@raises(SystemError)
+def test_executable_mismatch_3_4():
+    run_class_with_executable(NetMHC3, "netMHC")
+
+@raises(SystemError)
+def test_executable_mismatch_4_3():
+    run_class_with_executable(NetMHC4, "netMHC-3.4")


### PR DESCRIPTION
No more `NetMHC` class.

Confusingly, test code relies on `netMHC` = 4.0 and `netMHC-3.4` = 3.4. Happy to consider less confusing alternatives.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/mhctools/48)

<!-- Reviewable:end -->
