### PR TITLE
Add a function to wrap NetMHC 3 vs 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ strongest_predicted_binder = epitope_collection[0]
 The following models are available in `mhctools`:
 * `NetMHC3`: requires locally installed version of [NetMHC 3.x](http://www.cbs.dtu.dk/services/NetMHC-3.4/)
 * `NetMHC4`: requires locally installed version of [NetMHC 4.x](http://www.cbs.dtu.dk/services/NetMHC/)
+* `NetMHC`: a wrapper function to automatically use `NetMHC3` or `NetMHC4` depending on what's installed.
 * `NetMHCpan`: requires locally installed version of [NetMHCpan](http://www.cbs.dtu.dk/services/NetMHCpan/)
 * `NetMHCIIpan`: requires locally installed version of [NetMHCIIpan](http://www.cbs.dtu.dk/services/NetMHCIIpan/)
 * `NetMHCcons`: requires locally installed version of [NetMHCcons](http://www.cbs.dtu.dk/services/NetMHCcons/)

--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -8,6 +8,7 @@ from .iedb import (
     IedbSMM_PMBEC,
     IedbNetMHCIIpan,
 )
+from .netmhc import NetMHC
 from .netmhc3 import NetMHC3
 from .netmhc4 import NetMHC4
 from .netmhc_cons import NetMHCcons
@@ -24,6 +25,7 @@ __all__ = [
     "IedbSMM",
     "IedbSMM_PMBEC",
     "IedbNetMHCIIpan",
+    "NetMHC",
     "NetMHC3",
     "NetMHC4",
     "NetMHCcons",

--- a/mhctools/netmhc.py
+++ b/mhctools/netmhc.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2015. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function, division, absolute_import
+from .netmhc3 import NetMHC3
+from .netmhc4 import NetMHC4
+
+def NetMHC(alleles,
+           epitope_lengths=[9],
+           program_name="netMHC",
+           max_file_records=None):
+    """
+    This function wraps NetMHC3 and NetMHC4 to automatically detect which class
+    to use. This is currently based on the results of supported_alleles_flag,
+    and assumes that the flag for 3.x causes an error in 4.x and vice versa.
+
+    TODO: Make this more robust.
+    """
+    netmhc_classes = [NetMHC3, NetMHC4]
+    successes = []
+    for netmhc_class in netmhc_classes:
+        try:
+            successes.append(netmhc_class(
+                alleles=alleles,
+                epitope_lengths=epitope_lengths,
+                program_name=program_name,
+                max_file_records=max_file_records))
+        except SystemError:
+            pass
+
+    if len(successes) > 1:
+        raise SystemError("Command %s is valid for multiple NetMHC versions. "
+                          "This is likely an mhctools bug." % program_name)
+    if len(successes) == 0:
+        raise SystemError("Command %s is not a valid way of calling any NetMHC software."
+                          % program_name)
+
+    return successes[0]

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ except:
 if __name__ == '__main__':
     setup(
         name='mhctools',
-        version="0.2.0",
+        version="0.2.1",
         description="Python interface to running command-line and web-based MHC binding predictors",
         author="Alex Rubinsteyn",
         author_email="alex {dot} rubinsteyn {at} mssm {dot} edu",

--- a/test/test_known_class1_epitopes.py
+++ b/test/test_known_class1_epitopes.py
@@ -21,6 +21,7 @@ mhc_classes = [
     mhctools.NetMHCcons,
     mhctools.NetMHCpan,
     mhctools.NetMHCcons,
+    mhctools.NetMHC,
     mhctools.NetMHC3,
     mhctools.NetMHC4,
     mhctools.IedbNetMHCcons,

--- a/test/test_netmhc_version.py
+++ b/test/test_netmhc_version.py
@@ -1,6 +1,6 @@
-from nose.tools import raises
+from nose.tools import raises, eq_
 
-from mhctools import NetMHC3, NetMHC4
+from mhctools import NetMHC, NetMHC3, NetMHC4
 from mhctools.alleles import normalize_allele_name
 
 
@@ -24,3 +24,21 @@ def test_executable_mismatch_3_4():
 @raises(SystemError)
 def test_executable_mismatch_4_3():
     run_class_with_executable(NetMHC4, "netMHC-3.4")
+
+def test_wrapper_function():
+    alleles = [normalize_allele_name("HLA-A*02:01")]
+    wrapped_4 = NetMHC(alleles=alleles,
+                     epitope_lengths=[9],
+                     program_name="netMHC")
+    eq_(type(wrapped_4), NetMHC4)
+    wrapped_3 = NetMHC(alleles=alleles,
+                     epitope_lengths=[9],
+                     program_name="netMHC-3.4")
+    eq_(type(wrapped_3), NetMHC3)
+
+@raises(SystemError)
+def test_wrapper_failure():
+    alleles = [normalize_allele_name("HLA-A*02:01")]
+    NetMHC(alleles=alleles,
+           epitope_lengths=[9],
+           program_name="netMHC-none")


### PR DESCRIPTION
Currently uses the supported allele flag to distinguish the two.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/mhctools/49)

<!-- Reviewable:end -->
