### PR TITLE
WIP: Support for mhcflurry - Take #2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ addons:
       # from markdown to RST
       - pandoc
 before_install:
+<<<<<<< HEAD
   # Commands below copied from: http://conda.pydata.org/docs/travis.html
   # We do this conditionally because it saves us some downloading if the
   # version is the same.

--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -14,6 +14,7 @@ from .netmhc4 import NetMHC4
 from .netmhc_cons import NetMHCcons
 from .netmhc_pan import NetMHCpan
 from .netmhcii_pan import NetMHCIIpan
+from .mhcflurry import MHCFlurry
 from .random_predictor import RandomBindingPredictor
 
 __version__ = "0.3.0"
@@ -33,5 +34,6 @@ __all__ = [
     "NetMHCcons",
     "NetMHCpan",
     "NetMHCIIpan",
+    "MHCFlurry",
     "RandomBindingPredictor",
 ]

--- a/mhctools/epitope_collection.py
+++ b/mhctools/epitope_collection.py
@@ -82,4 +82,6 @@ class EpitopeCollection(Collection):
     def dataframe(self):
         return pd.DataFrame(
             self.elements,
-            columns=BindingPrediction._fields)
+            columns=(
+                self.elements[0]._fields if self.elements
+                else BindingPrediction._fields))

--- a/mhctools/mhcflurry.py
+++ b/mhctools/mhcflurry.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2014. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function, division, absolute_import
+
+import collections
+
+from mhcflurry import Mhc1BindingPredictor
+
+from .epitope_collection_builder import EpitopeCollectionBuilder
+from .common import check_sequence_dictionary
+from .binding_measure import ic50_nM
+from .base_predictor import BasePredictor
+
+class MHCFlurry(BasePredictor):
+    def __init__(self, alleles, epitope_lengths=[9], valid_alleles=None):
+        BasePredictor.__init__(self, alleles, epitope_lengths, valid_alleles)
+        self._predictors = dict(
+            (allele, Mhc1BindingPredictor(allele)) for allele in self.alleles)
+
+    def predict(self, fasta_dictionary):
+        fasta_dictionary = check_sequence_dictionary(fasta_dictionary)
+        
+        # dict of peptide sequence -> list of (fasta key, offset into sequence)
+        # where the peptide came from.
+        peptides = collections.defaultdict(list)  
+        for (key, sequence) in fasta_dictionary.items():
+            for epitope_length in self.epitope_lengths:
+                for i in range(len(sequence) - epitope_length + 1):
+                    peptide = sequence[i:i + epitope_length]
+                    peptides[peptide].append((key, i))
+        peptides_list = list(peptides)
+
+        builder = EpitopeCollectionBuilder(
+            fasta_dictionary=fasta_dictionary,
+            prediction_method_name="mhcflurry",
+            binding_measure=ic50_nM)
+
+        for (allele, predictor) in self._predictors.items():
+            predictions_df = predictor.predict_peptides(peptides_list)
+            for (i, record) in predictions_df.iterrows():
+                for (key, offset) in peptides[record.Peptide]:
+                    # TODO: determine percentile rank somehow.
+                    # Currently we just set it to 50.
+                    builder.add_binding_prediction(
+                            source_sequence_key=key,
+                            offset=offset,
+                            allele=allele,
+                            peptide=record.Peptide,
+                            ic50=record.Prediction,
+                            rank=50)
+
+        return builder.get_collection()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pylint>=1.4.4
 nose>=1.3.6
 sercol
 mhcnames
+git+https://github.com/hammerlab/mhcflurry.git

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ if __name__ == '__main__':
             'Topic :: Scientific/Engineering :: Bio-Informatics',
         ],
         install_requires=[
+            'mhcflurry',
             'numpy>=1.7',
             'pandas>=0.13.1',
             'varcode>=0.3.17',

--- a/test/test_known_class1_epitopes.py
+++ b/test/test_known_class1_epitopes.py
@@ -28,6 +28,7 @@ mhc_classes = [
     mhctools.IedbNetMHCpan,
     mhctools.IedbSMM,
     mhctools.IedbSMM_PMBEC,
+    mhctools.MHCFlurry,
 ]
 
 # Tests assume that a netMHC-3.4 binary exists, and that netMHC is 4.0.


### PR DESCRIPTION
Re-based @timodonnell's #45 onto the latest code to revive the integration possibility. 

TODO:
- [ ] cut a mhcflurry release to be distributed on PyPI (so that we can rely on some stable CLI/APIs)
- [ ] add mhcflurry training procedure to the Travis job (otherwise tests fail)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/mhctools/58)

<!-- Reviewable:end -->
