### PR TITLE
added -extract-subsequences flag

### DIFF
--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -18,7 +18,7 @@ from .netmhc_pan3 import NetMHCpan3
 from .netmhcii_pan import NetMHCIIpan
 from .random_predictor import RandomBindingPredictor
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"
 
 __all__ = [
     "BindingPrediction",

--- a/mhctools/base_predictor.py
+++ b/mhctools/base_predictor.py
@@ -185,6 +185,8 @@ class BasePredictor(object):
         """
         if isinstance(sequence_dict, string_types):
             sequence_dict = {"seq": sequence_dict}
+        elif isinstance(sequence_dict, (list, tuple)):
+            sequence_dict = {seq: seq for seq in sequence_dict}
 
         peptide_lengths = self._check_peptide_lengths(peptide_lengths)
 

--- a/mhctools/cli/script.py
+++ b/mhctools/cli/script.py
@@ -43,7 +43,7 @@ def add_input_args(arg_parser):
         action="store_true",
         help=(
             "Extract subsequences from peptides supplied by --sequence or "
-            "--input-peptides-files, lengths specified by "
+            "--input-peptides-file, lengths specified by "
             "--mhc-peptide-lengths argument."))
     input_group.add_argument(
         "--input-peptides-file",

--- a/mhctools/cli/script.py
+++ b/mhctools/cli/script.py
@@ -42,8 +42,9 @@ def add_input_args(arg_parser):
         default=False,
         action="store_true",
         help=(
-            "Extract subsequences from --sequence arguments, "
-            "lengths specified by --mhc-peptide-lengths argument."))
+            "Extract subsequences from peptides supplied by --sequence or "
+            "--input-peptides-files, lengths specified by "
+            "--mhc-peptide-lengths argument."))
     input_group.add_argument(
         "--input-peptides-file",
         help="Path to file with one peptide per line")
@@ -89,8 +90,11 @@ def main(args_list=None):
             binding_predictions = predictor.predict_peptides(args.sequence)
     elif args.input_peptides_file:
         with open(args.input_peptides_file) as f:
-            peptides = [line.strip() for line in f]
+            peptides = [line.strip() for line in f if line]
+        if args.extract_subsequences:
             binding_predictions = predictor.predict_peptides(peptides)
+        else:
+            binding_predictions = predictor.predict_subsequences(peptides)
     else:
         raise ValueError(
             ("No input sequences provided, "

--- a/mhctools/cli/script.py
+++ b/mhctools/cli/script.py
@@ -36,7 +36,14 @@ def add_input_args(arg_parser):
         "--sequence",
         nargs="*",
         help=(
-            "Peptide sequences (MHC binding predictor will not extract sub-sequences)"))
+            "Peptide sequences"))
+    input_group.add_argument(
+        "--extract-subsequences",
+        default=False,
+        action="store_true",
+        help=(
+            "Extract subsequences from --sequence arguments, "
+            "lengths specified by --mhc-peptide-lengths argument."))
     input_group.add_argument(
         "--input-peptides-file",
         help="Path to file with one peptide per line")
@@ -61,8 +68,10 @@ def main(args_list=None):
         mhctools
             --sequence SFFPIQQQQQAAALLLI \
             --sequence SILQQQAQAQQAQAASSSC \
+            --extract-subsequences \
             --mhc-predictor netmhc \
             --mhc-alleles HLA-A0201 H2-Db \
+            --mhc-predictor netmhc \
             --output-csv epitope.csv
     """
     if args_list is None:
@@ -74,7 +83,10 @@ def main(args_list=None):
         input_dictionary = parse_fasta_dictionary(args.input_fasta_file)
         binding_predictions = predictor.predict_subsequences(input_dictionary)
     elif args.sequence:
-        binding_predictions = predictor.predict_peptides(args.sequence)
+        if args.extract_subsequences:
+            binding_predictions = predictor.predict_subsequences(args.sequence)
+        else:
+            binding_predictions = predictor.predict_peptides(args.sequence)
     elif args.input_peptides_file:
         with open(args.input_peptides_file) as f:
             peptides = [line.strip() for line in f]

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -27,7 +27,7 @@ def test_peptides_with_subsequences():
     eq_(binding_predictions[0].peptide, peptide[:9])
     eq_(binding_predictions[1].peptide, peptide[1:10])
 
-def test_peptidess_file_without_subsequences():
+def test_peptides_file_without_subsequences():
     peptide = "SIINFEKLQY"
     with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
         f.write("%s\n" % peptide)
@@ -42,7 +42,7 @@ def test_peptidess_file_without_subsequences():
     eq_(binding_predictions[0].peptide, peptide)
     remove(f.name)
 
-def test_peptidess_file_with_subsequences():
+def test_peptides_file_with_subsequences():
     peptide = "SIINFEKLQY"
     with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
         f.write("%s\n" % peptide)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,0 +1,60 @@
+from mhctools.cli.script import parse_args, run_predictor
+from nose.tools import eq_
+import tempfile
+from os import remove
+
+def test_peptides_without_subsequences():
+    peptide = "SIINFEKLQY"
+    args = parse_args([
+        "--mhc-predictor", "netmhc",
+        "--mhc-peptide-lengths", "9",
+        "--sequence", peptide,
+        "--mhc-alleles", "H-2-Kb"])
+    binding_predictions = run_predictor(args)
+    eq_(len(binding_predictions), 1, binding_predictions)
+    eq_(binding_predictions[0].peptide, peptide)
+
+def test_peptides_with_subsequences():
+    peptide = "SIINFEKLQY"
+    args = parse_args([
+        "--mhc-predictor", "netmhc",
+        "--mhc-peptide-lengths", "9",
+        "--sequence", peptide,
+        "--extract-subsequences",
+        "--mhc-alleles", "H-2-Kb"])
+    binding_predictions = sorted(run_predictor(args), key=lambda bp: bp.offset)
+    eq_(len(binding_predictions), 2, binding_predictions)
+    eq_(binding_predictions[0].peptide, peptide[:9])
+    eq_(binding_predictions[1].peptide, peptide[1:10])
+
+def test_peptidess_file_without_subsequences():
+    peptide = "SIINFEKLQY"
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+        f.write("%s\n" % peptide)
+
+    args = parse_args([
+        "--mhc-predictor", "netmhc",
+        "--mhc-peptide-lengths", "9",
+        "--input-peptides-file", f.name,
+        "--mhc-alleles", "H-2-Kb"])
+    binding_predictions = run_predictor(args)
+    eq_(len(binding_predictions), 1, binding_predictions)
+    eq_(binding_predictions[0].peptide, peptide)
+    remove(f.name)
+
+def test_peptidess_file_with_subsequences():
+    peptide = "SIINFEKLQY"
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+        f.write("%s\n" % peptide)
+
+    args = parse_args([
+        "--mhc-predictor", "netmhc",
+        "--mhc-peptide-lengths", "9",
+        "--input-peptides-file", f.name,
+        "--extract-subsequences",
+        "--mhc-alleles", "H-2-Kb"])
+    binding_predictions = sorted(run_predictor(args), key=lambda bp: bp.offset)
+    eq_(len(binding_predictions), 2, binding_predictions)
+    eq_(binding_predictions[0].peptide, peptide[:9])
+    eq_(binding_predictions[1].peptide, peptide[1:10])
+    remove(f.name)


### PR DESCRIPTION
Currently `--sequence` only allows you to specify short peptides for prediction, `--extract-subsequences` extends this to also allow predictions of subsequences (with lengths specified by `--mhc-peptide-lengths`). 