### PR TITLE
update MHCflurry to take predictor instead of models_dir

### DIFF
--- a/mhctools/mhcflurry.py
+++ b/mhctools/mhcflurry.py
@@ -37,20 +37,21 @@ class MHCflurry(BasePredictor):
             self,
             alleles,
             default_peptide_lengths=[9],
-            models_dir=None):
+            predictor=None):
         """
         Parameters
         -----------
-        models_dir : string
-            MHCflurry models to load
+        predictor : mhcflurry.Class1AffinityPredictor (optional)
+            MHCflurry predictor to use
 
         """
         BasePredictor.__init__(
             self,
             alleles=alleles,
             default_peptide_lengths=default_peptide_lengths)
-        self.predictor = Class1AffinityPredictor.load(
-            models_dir=models_dir)
+        if predictor is None:
+            predictor = Class1AffinityPredictor()
+        self.predictor = predictor
 
     def predict_peptides(self, peptides):
         binding_predictions = []

--- a/mhctools/mhcflurry.py
+++ b/mhctools/mhcflurry.py
@@ -50,7 +50,7 @@ class MHCflurry(BasePredictor):
             alleles=alleles,
             default_peptide_lengths=default_peptide_lengths)
         if predictor is None:
-            predictor = Class1AffinityPredictor()
+            predictor = Class1AffinityPredictor.load()
         self.predictor = predictor
 
     def predict_peptides(self, peptides):


### PR DESCRIPTION
Enables user to reuse one MHCflurry predictor for queries across different alleles, an important speed optimization