### PR TITLE
Attempt to fix failing travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ before_script:
   - mhcflurry-downloads fetch
 script:
   - ./lint.sh
-  - nosetests test --with-coverage --cover-package=mhctools
+  - nosetests -sv test --with-coverage --cover-package=mhctools
 after_success:
   coveralls
 deploy:


### PR DESCRIPTION
Run tests with `-sv` flag to generate output as tests are running to help travis not die due to no output in 10 mins (still weird the tests are taking that long though).