### PR TITLE
Set correct min/max peptide lengths for predictors

### DIFF
--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -19,7 +19,7 @@ from .netmhc_pan3 import NetMHCpan3
 from .netmhcii_pan import NetMHCIIpan
 from .random_predictor import RandomBindingPredictor
 
-__version__ = "1.4.0"
+__version__ = "1.5.0"
 
 __all__ = [
     "BindingPrediction",

--- a/mhctools/base_commandline_predictor.py
+++ b/mhctools/base_commandline_predictor.py
@@ -55,7 +55,9 @@ class BaseCommandlinePredictor(BasePredictor):
             max_peptides_per_file=10 ** 4,
             process_limit=-1,
             default_peptide_lengths=[9],
-            group_peptides_by_length=False):
+            group_peptides_by_length=False,
+            min_peptide_length=8,
+            max_peptide_length=None,):
         """
         Parameters
         ----------
@@ -106,6 +108,12 @@ class BaseCommandlinePredictor(BasePredictor):
 
         group_peptides_by_length : bool
             Run commandline predictor on groups of peptides of equal length
+
+        min_peptide_length : int
+            Shortest peptide this predictor can handle
+
+        max_peptide_length : int
+            Longest peptide this predictor can handle
         """
         require_string(program_name, "Predictor program name")
         self.program_name = program_name
@@ -167,7 +175,9 @@ class BaseCommandlinePredictor(BasePredictor):
                 self,
                 alleles=alleles,
                 valid_alleles=valid_alleles,
-                default_peptide_lengths=default_peptide_lengths)
+                default_peptide_lengths=default_peptide_lengths,
+                min_peptide_length=min_peptide_length,
+                max_peptide_length=max_peptide_length)
         except UnsupportedAllele as e:
             if self.supported_alleles_flag:
                 additional_message = (

--- a/mhctools/base_predictor.py
+++ b/mhctools/base_predictor.py
@@ -34,7 +34,7 @@ class BasePredictor(object):
             alleles,
             valid_alleles=None,
             default_peptide_lengths=None,
-            min_peptide_length=1,
+            min_peptide_length=8,
             max_peptide_length=None,
             allow_X_in_peptides=False,
             allow_lowercase_in_peptides=False):
@@ -203,6 +203,7 @@ class BasePredictor(object):
                     peptide_set.add(peptide)
                     peptide_to_name_offset_pairs[peptide].append((name, i))
         peptide_list = sorted(peptide_set)
+
         self._check_peptide_inputs(peptide_list)
 
         binding_predictions = self.predict_peptides(peptide_list)

--- a/mhctools/iedb.py
+++ b/mhctools/iedb.py
@@ -136,11 +136,13 @@ class IedbBasePredictor(BasePredictor):
             alleles,
             default_peptide_lengths,
             prediction_method,
-            url):
+            url,
+            min_peptide_length=8):
         BasePredictor.__init__(
             self,
             alleles=alleles,
-            default_peptide_lengths=default_peptide_lengths)
+            default_peptide_lengths=default_peptide_lengths,
+            min_peptide_length=min_peptide_length)
         self.prediction_method = prediction_method
 
         if not isinstance(url, string_types):
@@ -291,4 +293,5 @@ class IedbNetMHCIIpan(IedbBasePredictor):
             # only epitope lengths of 15 currently supported by IEDB's web API
             default_peptide_lengths=default_peptide_lengths,
             prediction_method="NetMHCIIpan",
-            url=IEDB_MHC_CLASS_II_URL)
+            url=IEDB_MHC_CLASS_II_URL,
+            min_peptide_length=9)

--- a/mhctools/mhcflurry.py
+++ b/mhctools/mhcflurry.py
@@ -48,7 +48,9 @@ class MHCflurry(BasePredictor):
         BasePredictor.__init__(
             self,
             alleles=alleles,
-            default_peptide_lengths=default_peptide_lengths)
+            default_peptide_lengths=default_peptide_lengths,
+            min_peptide_length=7,
+            max_peptide_length=15)
         if predictor is None:
             predictor = Class1AffinityPredictor.load()
         self.predictor = predictor
@@ -64,7 +66,7 @@ class MHCflurry(BasePredictor):
                     allele=allele,
                     peptide=peptide,
                     affinity=predictions[i],
-                    
+
                     # TODO: include percentile rank when MHCflurry supports it
                     percentile_rank=None,
                     prediction_method_name="mhcflurry"

--- a/mhctools/mhcflurry.py
+++ b/mhctools/mhcflurry.py
@@ -49,7 +49,7 @@ class MHCflurry(BasePredictor):
             self,
             alleles=alleles,
             default_peptide_lengths=default_peptide_lengths,
-            min_peptide_length=7,
+            min_peptide_length=8,
             max_peptide_length=15)
         if predictor is None:
             predictor = Class1AffinityPredictor.load()

--- a/mhctools/netmhcii_pan.py
+++ b/mhctools/netmhcii_pan.py
@@ -42,7 +42,8 @@ class NetMHCIIpan(BaseCommandlinePredictor):
             peptide_mode_flags=["-inptype", "1"],
             length_flag="-length",
             tempdir_flag="-tdir",
-            process_limit=process_limit)
+            process_limit=process_limit,
+            min_peptide_length=9)
 
     def prepare_allele_name(self, allele_name):
         """

--- a/test/test_peptide_lengths.py
+++ b/test/test_peptide_lengths.py
@@ -1,0 +1,30 @@
+
+"""
+Class I predictors typically allow 8mer or longer peptides, whereas
+NetMHCIIpan allows 9mer or longer. So far only MHCflurry has a max
+length (of 15mer).
+"""
+
+from mhctools import NetMHCIIpan, NetMHC
+from nose.tools import eq_, assert_raises
+
+
+def test_class2_9mer_success():
+    ii_pan_predictor = NetMHCIIpan(alleles=["HLA-DRB1*01:01"])
+    predictions = ii_pan_predictor.predict_peptides(["A" * 9])
+    eq_(len(predictions), 1)
+
+def test_class2_8mer_fails():
+    ii_pan_predictor = NetMHCIIpan(alleles=["HLA-DRB1*01:01"])
+    with assert_raises(ValueError):
+        ii_pan_predictor.predict_peptides(["A" * 8])
+
+def test_class1_8mer_success():
+    netmhc = NetMHC(alleles=["HLA-A0201"])
+    predictions = netmhc.predict_peptides(["A" * 8])
+    eq_(len(predictions), 1)
+
+def test_class1_7mer_failure():
+    netmhc = NetMHC(alleles=["HLA-A0201"])
+    with assert_raises(ValueError):
+        netmhc.predict_peptides(["A" * 7])


### PR DESCRIPTION
Fixes https://github.com/hammerlab/mhctools/issues/106

Min for NetMHC family Class I predictors is 8mer
Min for NetMHCIIpan is 9mer
MHCflurry allows 8mer-15mer