### PR TITLE
Fixing mhcnames version to 0.1.0 temporarily

### DIFF
--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -19,7 +19,7 @@ from .netmhc_pan3 import NetMHCpan3
 from .netmhcii_pan import NetMHCIIpan
 from .random_predictor import RandomBindingPredictor
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"
 
 __all__ = [
     "BindingPrediction",

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ pylint>=1.4.4
 nose>=1.3.6
 sercol>=0.0.2
 mhcflurry
-mhcnames
+mhcnames==0.1.0

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ if __name__ == '__main__':
             'six>=1.9.0',
             'sercol>=0.0.2',
             'mhcflurry',
-            'mhcnames',
+            'mhcnames==0.1.0',
         ],
         long_description=readme,
         packages=['mhctools', 'mhctools.cli'],


### PR DESCRIPTION
since the latest (0.2.1) breaks mhctools.