### PR TITLE
Fixing netmhciipan

### DIFF
--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -19,7 +19,7 @@ from .netmhc_pan3 import NetMHCpan3
 from .netmhcii_pan import NetMHCIIpan
 from .random_predictor import RandomBindingPredictor
 
-__version__ = "1.5.0"
+__version__ = "1.6.0"
 
 __all__ = [
     "BindingPrediction",

--- a/mhctools/base_commandline_predictor.py
+++ b/mhctools/base_commandline_predictor.py
@@ -21,7 +21,7 @@ import tempfile
 from six import string_types
 from typechecks import require_string, require_integer, require_iterable_of
 from mhcnames import normalize_allele_name
-from mhcnames.parsing_helpers import AlleleParseError
+from mhcnames import AlleleParseError
 
 
 from .base_predictor import BasePredictor
@@ -215,7 +215,8 @@ class BaseCommandlinePredictor(BasePredictor):
                         logger.info("Skipping allele %s: %s", line, error)
                         continue
             return supported_alleles
-        except:
+        except Exception as e:
+            logging.exception(e)
             raise SystemError("Failed to run %s %s. Possibly an incorrect executable version?" % (
                 command,
                 supported_allele_flag))

--- a/mhctools/base_commandline_predictor.py
+++ b/mhctools/base_commandline_predictor.py
@@ -214,6 +214,8 @@ class BaseCommandlinePredictor(BasePredictor):
                     except AlleleParseError as error:
                         logger.info("Skipping allele %s: %s", line, error)
                         continue
+            if len(supported_alleles) == 0:
+                raise ValueError("Unable to determine supported alleles")
             return supported_alleles
         except Exception as e:
             logging.exception(e)

--- a/mhctools/base_commandline_predictor.py
+++ b/mhctools/base_commandline_predictor.py
@@ -20,9 +20,7 @@ import tempfile
 
 from six import string_types
 from typechecks import require_string, require_integer, require_iterable_of
-from mhcnames import normalize_allele_name
-from mhcnames import AlleleParseError
-
+from mhcnames import normalize_allele_name, AlleleParseError
 
 from .base_predictor import BasePredictor
 from .unsupported_allele import UnsupportedAllele
@@ -33,7 +31,6 @@ from .process_helpers import run_multiple_commands_redirect_stdout
 from .binding_prediction_collection import BindingPredictionCollection
 
 logger = logging.getLogger(__name__)
-
 
 class BaseCommandlinePredictor(BasePredictor):
     """
@@ -218,7 +215,7 @@ class BaseCommandlinePredictor(BasePredictor):
                 raise ValueError("Unable to determine supported alleles")
             return supported_alleles
         except Exception as e:
-            logging.exception(e)
+            logger.exception(e)
             raise SystemError("Failed to run %s %s. Possibly an incorrect executable version?" % (
                 command,
                 supported_allele_flag))

--- a/mhctools/netmhcii_pan.py
+++ b/mhctools/netmhcii_pan.py
@@ -45,6 +45,19 @@ class NetMHCIIpan(BaseCommandlinePredictor):
             process_limit=process_limit,
             min_peptide_length=9)
 
+    def _prepare_drb_allele_name(self, parsed_beta_allele):
+        """
+        Assume that we're dealing with a human DRB allele
+        which NetMHCIIpan treats differently because there is
+        little population diversity in the DR-alpha gene
+        """
+        if "DRB" not in parsed_beta_allele.gene:
+            raise ValueError("Unexpected allele %s" % parsed_beta_allele)
+        return "%s_%s%s" % (
+            parsed_beta_allele.gene,
+            parsed_beta_allele.allele_family,
+            parsed_beta_allele.allele_code)
+
     def prepare_allele_name(self, allele_name):
         """
         netMHCIIpan has some unique requirements for allele formats,
@@ -65,16 +78,12 @@ class NetMHCIIpan(BaseCommandlinePredictor):
                     allele.species,
                     allele.gene,
                     allele.allele_code)
-            else:
-                # assume that we're dealing with a human DRB allele
-                # which NetMHCIIpan treats differently because there is
-                # supposedly no population diversity in the DR-alpha gene
-                return "%s_%s%s" % (
-                    allele.gene,
-                    allele.allele_family,
-                    allele.allele_code)
+            return self._prepare_drb_allele_name(allele)
+
         else:
             alpha, beta = parsed_alleles
+            if "DRA" in alpha:
+                return self._prepare_drb_allele_name(beta)
             return "HLA-%s%s%s-%s%s%s" % (
                 alpha.gene,
                 alpha.allele_family,

--- a/mhctools/netmhcii_pan.py
+++ b/mhctools/netmhcii_pan.py
@@ -82,7 +82,7 @@ class NetMHCIIpan(BaseCommandlinePredictor):
 
         else:
             alpha, beta = parsed_alleles
-            if "DRA" in alpha:
+            if "DRA" in alpha.gene:
                 return self._prepare_drb_allele_name(beta)
             return "HLA-%s%s%s-%s%s%s" % (
                 alpha.gene,

--- a/mhctools/parsing.py
+++ b/mhctools/parsing.py
@@ -343,6 +343,13 @@ def parse_netmhciipan_stdout(
          9         DRB1_0301       PKYVKQNTLKLAT    Sequence    2    YVKQNTLKL 0.575         0.442        418.70   6.00   9.999   <=WB
         10         DRB1_0301     ENPVVHFFKNIVTPR    Sequence    6    FFKNIVTPR 0.425         0.357       1049.04  32.00   9.999
     """
+    if "ERROR" in stdout:
+        # if NetMHCIIpan failed with an error then let's pull out the error
+        # message line and raise an exception with it
+        error_index = stdout.index("ERROR")
+        stdout_after_error = stdout[error_index:]
+        error_line = stdout_after_error.split("\n")[0]
+        raise ValueError("NetMHCIIpan failed - %s" % error_line)
     return parse_stdout(
         stdout=stdout,
         prediction_method_name=prediction_method_name,
@@ -351,6 +358,6 @@ def parse_netmhciipan_stdout(
         offset_index=0,
         peptide_index=2,
         allele_index=1,
-        ic50_index=7,
-        rank_index=8,
-        log_ic50_index=6)
+        ic50_index=8,
+        rank_index=9,
+        log_ic50_index=7)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ pylint>=1.4.4
 nose>=1.3.6
 sercol>=0.0.2
 mhcflurry
-mhcnames
+mhcnames>=0.2.0

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ if __name__ == '__main__':
             'six>=1.9.0',
             'sercol>=0.0.2',
             'mhcflurry',
-            'mhcnames',
+            'mhcnames>=0.2.0',
         ],
         long_description=readme,
         packages=['mhctools', 'mhctools.cli'],

--- a/test/test_netmhc_version.py
+++ b/test/test_netmhc_version.py
@@ -8,7 +8,7 @@ def run_class_with_executable(mhc_class, mhc_executable):
     alleles = [normalize_allele_name("HLA-A*02:01")]
     predictor = mhc_class(
         alleles=alleles,
-        program_name=mhc_executable)    
+        program_name=mhc_executable)
     sequence_dict = {
         "SMAD4-001": "ASIINFKELA",
         "TP53-001": "ASILLLVFYW"


### PR DESCRIPTION
Change field indices for parsing output of NetMHCIIpan to work for NetMHCIIpan 3.1 instead of 3.0

Also includes some fixes to NetMHCIIpan allele formatting and raises an exception if NetMHCIIpan output contains "ERROR".

(previously attempted in https://github.com/hammerlab/mhctools/pull/61)