### PR TITLE
Check peptide inputs always

### DIFF
--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -19,7 +19,7 @@ from .netmhc_pan3 import NetMHCpan3
 from .netmhcii_pan import NetMHCIIpan
 from .random_predictor import RandomBindingPredictor
 
-__version__ = "1.6.2"
+__version__ = "1.6.3"
 
 __all__ = [
     "BindingPrediction",

--- a/mhctools/base_commandline_predictor.py
+++ b/mhctools/base_commandline_predictor.py
@@ -287,6 +287,8 @@ class BaseCommandlinePredictor(BasePredictor):
 
     def predict_peptides(self, peptides):
         require_iterable_of(peptides, string_types)
+        self._check_peptide_inputs(peptides)
+
         input_filenames = create_input_peptides_files(
             peptides,
             max_peptides_per_file=self.max_peptides_per_file,

--- a/mhctools/base_predictor.py
+++ b/mhctools/base_predictor.py
@@ -204,8 +204,6 @@ class BasePredictor(object):
                     peptide_to_name_offset_pairs[peptide].append((name, i))
         peptide_list = sorted(peptide_set)
 
-        self._check_peptide_inputs(peptide_list)
-
         binding_predictions = self.predict_peptides(peptide_list)
 
         # create BindingPrediction objects with sequence name and offset


### PR DESCRIPTION
Right now the check is only happening in `predict_subsequences`, which calls `predict_peptides` on the subsequences it computes. But if you call `predict_peptides` directly, you miss out on the validity check.