### PR TITLE
sniff for multiple dashes in NetMHC4 output file

### DIFF
--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -19,7 +19,7 @@ from .netmhc_pan3 import NetMHCpan3
 from .netmhcii_pan import NetMHCIIpan
 from .random_predictor import RandomBindingPredictor
 
-__version__ = "1.6.0"
+__version__ = "1.6.1"
 
 __all__ = [
     "BindingPrediction",

--- a/mhctools/base_commandline_predictor.py
+++ b/mhctools/base_commandline_predictor.py
@@ -262,7 +262,6 @@ class BaseCommandlinePredictor(BasePredictor):
         # deleting the input and output files
         filenames_to_delete = list(input_filenames) + [
             f.name for f in commands.keys()]
-
         with CleanupFiles(
                 filenames=filenames_to_delete,
                 directories=temp_dir_list):
@@ -275,9 +274,10 @@ class BaseCommandlinePredictor(BasePredictor):
                 # but I was getting empty files otherwise
                 output_file.close()
                 with open(output_file.name, 'r') as f:
+                    file_contents = f.read()
                     binding_predictions.extend(
                         self.parse_output_fn(
-                            stdout=f.read(),
+                            stdout=file_contents,
                             sequence_key_mapping=sequence_key_mapping,
                             prediction_method_name=self.program_name))
 
@@ -286,7 +286,7 @@ class BaseCommandlinePredictor(BasePredictor):
         return BindingPredictionCollection(binding_predictions)
 
     def predict_peptides(self, peptides):
-        require_iterable_of(peptides, string_types)
+        self._check_peptide_inputs(peptides)
         input_filenames = create_input_peptides_files(
             peptides,
             max_peptides_per_file=self.max_peptides_per_file,

--- a/mhctools/base_predictor.py
+++ b/mhctools/base_predictor.py
@@ -152,6 +152,7 @@ class BasePredictor(object):
         """
         Check peptide sequences to make sure they are valid for this predictor.
         """
+        require_iterable_of(peptides, string_types)
         check_X = not self.allow_X_in_peptides
         check_lower = not self.allow_lowercase_in_peptides
         check_min_length = self.min_peptide_length is not None

--- a/mhctools/parsing.py
+++ b/mhctools/parsing.py
@@ -41,7 +41,9 @@ def split_stdout_lines(stdout):
     for l in stdout.split("\n"):
         l = l.strip()
         # wait for a line like '----------' before trying to parse entries
-        if l.startswith("-"):
+        # have to include multiple dashes here since NetMHC 4.0 sometimes
+        # gives negative positions in its "peptide" input mode
+        if l.startswith("---"):
             seen_dash = True
             continue
         if not seen_dash:


### PR DESCRIPTION
NetMHC4 seems to have a delightful behavior where the position of sequences derived from its "peptide" input mode (`-p`) may have negative values. This confuses the ad-hoc parser of NetMHC's output format, which looks for a line that starts with "-". 