### PR TITLE
Add support for mhcflurry percentile ranks and custom MHCflurry models dir

### DIFF
--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -18,6 +18,7 @@ from .netmhc_pan28 import NetMHCpan28
 from .netmhc_pan3 import NetMHCpan3
 from .netmhcii_pan import NetMHCIIpan
 from .random_predictor import RandomBindingPredictor
+from .unsupported_allele import UnsupportedAllele
 
 __version__ = "1.6.7"
 
@@ -40,4 +41,5 @@ __all__ = [
     "NetMHCpan3",
     "NetMHCIIpan",
     "RandomBindingPredictor",
+    "UnsupportedAllele",
 ]

--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -20,7 +20,7 @@ from .netmhcii_pan import NetMHCIIpan
 from .random_predictor import RandomBindingPredictor
 from .unsupported_allele import UnsupportedAllele
 
-__version__ = "1.6.7"
+__version__ = "1.6.8"
 
 __all__ = [
     "BindingPrediction",

--- a/mhctools/cli/args.py
+++ b/mhctools/cli/args.py
@@ -83,6 +83,11 @@ def add_mhc_args(arg_parser):
         required=True)
 
     mhc_options_arg_group.add_argument(
+        "--mhc-predictor-models-path",
+        help="Path to models to use with predictor. Currently supported only "
+        "by mhcflurry predictor.")
+
+    mhc_options_arg_group.add_argument(
         "--mhc-peptide-lengths",
         type=parse_int_list,
         help="Lengths of epitopes to consider for MHC binding prediction")
@@ -146,5 +151,6 @@ def mhc_binding_predictor_from_args(args):
     kwargs = dict(alleles=alleles)
     if peptide_lengths is not None:
         kwargs["default_peptide_lengths"] = peptide_lengths
-
+    if args.mhc_predictor_models_path:
+        kwargs["models_path"] = args.mhc_predictor_models_path
     return mhc_class(**kwargs)

--- a/mhctools/cli/script.py
+++ b/mhctools/cli/script.py
@@ -109,4 +109,5 @@ def main(args_list=None):
     df = binding_predictions.to_dataframe()
     logger.info('\n%s', df)
     if args.output_csv:
-        df.to_csv(args.output_csv)
+        df.to_csv(args.output_csv, index=False)
+        print("Wrote: %s" % args.output_csv)

--- a/mhctools/cli/script.py
+++ b/mhctools/cli/script.py
@@ -71,6 +71,10 @@ def run_predictor(args):
 
     if args.input_fasta_file:
         input_dictionary = parse_fasta_dictionary(args.input_fasta_file)
+        if not input_dictionary:
+            raise ValueError(
+                "No sequences could be parsed from fasta file: %s" % (
+                    args.input_fasta_file))
         binding_predictions = predictor.predict_subsequences(input_dictionary)
     elif args.sequence:
         if args.extract_subsequences:

--- a/mhctools/mhcflurry.py
+++ b/mhctools/mhcflurry.py
@@ -15,6 +15,8 @@
 from __future__ import print_function, division, absolute_import
 import logging
 
+from numpy import nan
+
 from .base_predictor import BasePredictor
 from .binding_prediction import BindingPrediction
 from .binding_prediction_collection import BindingPredictionCollection
@@ -89,3 +91,4 @@ class MHCflurry(BasePredictor):
                 )
                 binding_predictions.append(binding_prediction)
         return BindingPredictionCollection(binding_predictions)
+

--- a/mhctools/mhcflurry.py
+++ b/mhctools/mhcflurry.py
@@ -33,12 +33,16 @@ class MHCflurry(BasePredictor):
             self,
             alleles,
             default_peptide_lengths=[9],
-            predictor=None):
+            predictor=None,
+            models_path=None):
         """
         Parameters
         -----------
         predictor : mhcflurry.Class1AffinityPredictor (optional)
             MHCflurry predictor to use
+
+        models_path : string
+            Models dir to use if predictor argument is None
 
         """
         # moving import here since the mhcflurry package imports
@@ -51,9 +55,13 @@ class MHCflurry(BasePredictor):
             default_peptide_lengths=default_peptide_lengths,
             min_peptide_length=8,
             max_peptide_length=15)
-        if predictor is None:
-            predictor = Class1AffinityPredictor.load()
-        self.predictor = predictor
+        if predictor:
+            self.predictor = predictor
+        elif models_path:
+            logging.info("Loading MHCflurry models from %s" % models_path)
+            self.predictor = Class1AffinityPredictor.load(models_path)
+        else:
+            self.predictor = Class1AffinityPredictor.load()
 
     def predict_peptides(self, peptides):
         """
@@ -67,18 +75,17 @@ class MHCflurry(BasePredictor):
         binding_predictions = []
         encodable_sequences = EncodableSequences.create(peptides)
         for allele in self.alleles:
-            predictions = self.predictor.predict(
+            predictions_df = self.predictor.predict_to_dataframe(
                 encodable_sequences, allele=allele)
-            for (i, peptide) in enumerate(peptides):
+            for (_, row) in predictions_df.iterrows():
                 binding_prediction = BindingPrediction(
                     allele=allele,
-                    peptide=peptide,
-                    affinity=predictions[i],
-
-                    # TODO: include percentile rank when MHCflurry supports it
-                    percentile_rank=None,
+                    peptide=row.peptide,
+                    affinity=row.prediction,
+                    percentile_rank=(
+                        row.prediction_percentile
+                        if 'prediction_percentile' in row else nan),
                     prediction_method_name="mhcflurry"
                 )
-                logger.info(binding_prediction)
                 binding_predictions.append(binding_prediction)
         return BindingPredictionCollection(binding_predictions)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -58,3 +58,4 @@ def test_peptides_file_with_subsequences():
     eq_(binding_predictions[0].peptide, peptide[:9])
     eq_(binding_predictions[1].peptide, peptide[1:10])
     remove(f.name)
+


### PR DESCRIPTION
If the user is using MHCflurry models that support percentile ranks, they will be included in mhctools output. Otherwise, the results stay the same as they currently are (NaNs for percentile ranks).

Also add --mhc-predictor-models-path argument for specifying MHCflurry models directory.