### PR TITLE
Adding ability to run mhctools CLI with netMHCpan 4.0.

### DIFF
--- a/mhctools/cli/args.py
+++ b/mhctools/cli/args.py
@@ -43,6 +43,12 @@ from .. import (
     MHCflurry,
 )
 
+# Defining FileNotFoundError for Python 2.x
+try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = IOError
+
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Also: adding support for easily running with multiple versions of the same netMHC tool (same original binary name, optionally different versioned binary names made by the user) installed on one machine.

This lets us do things like:
```
mhctools --sequence SIINFEKL SIINFEKLQ --mhc-predictor netmhcpan3 --mhc-alleles A0201
```
vs
```
mhctools --sequence SIINFEKL SIINFEKLQ --mhc-predictor netmhcpan4 --mhc-alleles A0201
```
as well as the unversioned
```
mhctools --sequence SIINFEKL SIINFEKLQ --mhc-predictor netmhcpan --mhc-alleles A0201
```
