### PR TITLE
NetMHCpan-4.1 support

### DIFF
--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -17,7 +17,7 @@ from .netmhc_cons import NetMHCcons
 from .netmhc_pan import NetMHCpan
 from .netmhc_pan28 import NetMHCpan28
 from .netmhc_pan3 import NetMHCpan3
-from .netmhc_pan4 import NetMHCpan4, NetMHCpan4_BA, NetMHCpan4_EL
+from .netmhc_pan4 import NetMHCpan4, NetMHCpan41, NetMHCpan4_BA, NetMHCpan4_EL
 from .netmhcii_pan import NetMHCIIpan, NetMHCIIpan3, NetMHCIIpan4, NetMHCIIpan4_BA, NetMHCIIpan4_EL
 from .random_predictor import RandomBindingPredictor
 from .unsupported_allele import UnsupportedAllele
@@ -43,6 +43,7 @@ __all__ = [
     "NetMHCpan28",
     "NetMHCpan3",
     "NetMHCpan4",
+    "NetMHCpan41",
     "NetMHCpan4_BA",
     "NetMHCpan4_EL",
     "NetMHCIIpan",

--- a/mhctools/netmhc_pan4.py
+++ b/mhctools/netmhc_pan4.py
@@ -15,7 +15,7 @@
 from __future__ import print_function, division, absolute_import
 
 from .base_commandline_predictor import BaseCommandlinePredictor
-from .parsing import parse_netmhcpan4_stdout
+from .parsing import parse_netmhcpan4_stdout, parse_netmhcpan41_stdout
 from functools import partial
 
 class NetMHCpan4(BaseCommandlinePredictor):
@@ -48,6 +48,43 @@ class NetMHCpan4(BaseCommandlinePredictor):
             alleles=alleles,
             default_peptide_lengths=default_peptide_lengths,
             parse_output_fn=partial(parse_netmhcpan4_stdout, mode=mode),
+            supported_alleles_flag="-listMHC",
+            input_file_flag="-f",
+            length_flag="-l",
+            allele_flag="-a",
+            extra_flags=flags + extra_flags,
+            process_limit=process_limit)
+
+class NetMHCpan41(BaseCommandlinePredictor):
+    def __init__(
+            self,
+            alleles,
+            default_peptide_lengths=[9],
+            program_name="netMHCpan",
+            process_limit=-1,
+            mode="binding_affinity",
+            extra_flags=[]):
+        """
+        Wrapper for NetMHCpan4.1.
+
+        The mode argument should be one of "binding_affinity" (default) or
+        "elution_score".
+        """
+
+        # The -BA flag is required to predict binding affinity
+        if mode == "binding_affinity":
+            flags = ["-BA"]
+        elif mode == "elution_score":
+            flags = []
+        else:
+            raise ValueError("Unsupported mode", mode)
+
+        BaseCommandlinePredictor.__init__(
+            self,
+            program_name=program_name,
+            alleles=alleles,
+            default_peptide_lengths=default_peptide_lengths,
+            parse_output_fn=partial(parse_netmhcpan41_stdout, mode=mode),
             supported_alleles_flag="-listMHC",
             input_file_flag="-f",
             length_flag="-l",

--- a/mhctools/parsing.py
+++ b/mhctools/parsing.py
@@ -400,6 +400,44 @@ def parse_netmhcpan4_stdout(
         rank_index=12 if mode == "elution_score" else 13,
         transforms=transforms)
 
+def parse_netmhcpan41_stdout(
+        stdout,
+        prediction_method_name="netmhcpan",
+        sequence_key_mapping=None,
+        mode="binding_affinity"):
+    """
+	NetMHCpan version 4.1b
+	# Rank Threshold for Strong binding peptides   0.500
+	# Rank Threshold for Weak binding peptides   2.000
+	---------------------------------------------------------------------------------------------------------------------------
+	 Pos         MHC        Peptide      Core Of Gp Gl Ip Il        Icore        Identity  Score_EL %Rank_EL Score_BA %Rank_BA  Aff(nM) BindLevel
+	---------------------------------------------------------------------------------------------------------------------------
+	   1 HLA-A*03:01    GKSGGGRCGGG GKSGGGRGG  0  7  2  0  0  GKSGGGRCGGG            seq1 0.0000000  100.000 0.009240   95.346 45243.03
+	---------------------------------------------------------------------------------------------------------------------------
+
+	Protein seq1. Allele HLA-A*03:01. Number of high binders 0. Number of weak binders 0. Number of peptides 1
+
+	-----------------------------------------------------------------------------------
+    """
+
+    # the offset specified in "pos" (at index 0) is 1-based instead of 0-based. we adjust it to be
+    # 0-based, as in all the other netmhc predictors supported by this library.
+    transforms = {
+        0: lambda x: int(x) - 1,
+    }
+    return parse_stdout(
+        stdout=stdout,
+        prediction_method_name=prediction_method_name,
+        sequence_key_mapping=sequence_key_mapping,
+        key_index=10,
+        offset_index=0,
+        peptide_index=2,
+        allele_index=1,
+        score_index=11 if mode == "elution_score" else 13,
+        ic50_index=None if mode == "elution_score" else 15,
+        rank_index=12 if mode == "elution_score" else 14,
+        transforms=transforms)
+
 
 def parse_netmhccons_stdout(
         stdout,


### PR DESCRIPTION
According to issue #152  parser does not support NetMHCpan-4.1
Here are the changes needed for NetMHCpan-4.1 support.
NetMHCpan-4.0 and NetMHCpan-4.1 have different column numbers in the std output. 
So I made these changes based on NetMHCpan4 class.