### PR TITLE
Update CI: pin netmhc-bundle to v1.0.0, add conditional token check, standardize checkout@v4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,8 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      HAS_NETMHC_TOKEN: ${{ secrets.NETMHC_BUNDLE_ACCESS_TOKEN != '' }}
     strategy:
       fail-fast: true
       matrix:
@@ -22,13 +24,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
 
       - name: Checkout private netmhc-bundle repo
-        if: ${{ secrets.NETMHC_BUNDLE_ACCESS_TOKEN != '' }}
+        if: env.HAS_NETMHC_TOKEN == 'true'
         uses: actions/checkout@v4
         with:
           repository: openvax/netmhc-bundle
@@ -37,7 +39,7 @@ jobs:
           path: netmhc-bundle
 
       - name: Install netmhc-bundle dependencies
-        if: ${{ secrets.NETMHC_BUNDLE_ACCESS_TOKEN != '' }}
+        if: env.HAS_NETMHC_TOKEN == 'true'
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: tcsh gawk python2-minimal
@@ -57,7 +59,7 @@ jobs:
         run: |
           mhcflurry-downloads fetch
       - name: Set up netmhc-bundle environment
-        if: ${{ secrets.NETMHC_BUNDLE_ACCESS_TOKEN != '' }}
+        if: env.HAS_NETMHC_TOKEN == 'true'
         run: |
           # configure netmhc-bundle paths
           export NETMHC_BUNDLE_HOME=$PWD/netmhc-bundle

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       HAS_NETMHC_TOKEN: ${{ secrets.NETMHC_BUNDLE_ACCESS_TOKEN != '' }}
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v3
@@ -28,13 +28,16 @@ jobs:
           cache: "pip"
 
       - name: Checkout private netmhc-bundle repo
+        if: ${{ secrets.NETMHC_BUNDLE_ACCESS_TOKEN != '' }}
         uses: actions/checkout@v4
         with:
           repository: openvax/netmhc-bundle
+          ref: v1.0.0
           token: ${{ secrets.NETMHC_BUNDLE_ACCESS_TOKEN }}
           path: netmhc-bundle
 
       - name: Install netmhc-bundle dependencies
+        if: ${{ secrets.NETMHC_BUNDLE_ACCESS_TOKEN != '' }}
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: tcsh gawk python2-minimal
@@ -53,7 +56,8 @@ jobs:
       - name: Install MHCflurry data
         run: |
           mhcflurry-downloads fetch
-      - name: Run unit tests
+      - name: Set up netmhc-bundle environment
+        if: ${{ secrets.NETMHC_BUNDLE_ACCESS_TOKEN != '' }}
         run: |
           # configure netmhc-bundle paths
           export NETMHC_BUNDLE_HOME=$PWD/netmhc-bundle
@@ -68,6 +72,14 @@ jobs:
           echo `which netMHCcons` && netMHCcons -h
           echo `which netMHCstab` && netMHCstab -h
           echo `which netMHCstabpan` && netMHCstabpan -h
+      - name: Run unit tests
+        run: |
+          if [ -d "$PWD/netmhc-bundle" ]; then
+            export NETMHC_BUNDLE_HOME=$PWD/netmhc-bundle
+            mkdir -p $PWD/netmhc-bundle-tmp
+            export NETMHC_BUNDLE_TMPDIR=$PWD/netmhc-bundle-tmp
+            export PATH=$PATH:$NETMHC_BUNDLE_HOME/bin
+          fi
 
           ./test.sh
       - name: Publish coverage to Coveralls


### PR DESCRIPTION
## Summary
- Standardize main repository checkout from `actions/checkout@v3` to `actions/checkout@v4`
- Pin the netmhc-bundle checkout to `ref: v1.0.0` for reproducible builds
- Add `if: ${{ secrets.NETMHC_BUNDLE_ACCESS_TOKEN != '' }}` conditional to all netmhc-bundle-dependent steps (checkout, apt install, environment setup/tool verification) so the workflow doesn't fail in forks or contexts without the secret
- Split the former "Run unit tests" step into a conditional "Set up netmhc-bundle environment" step (with tool verification) and a standalone "Run unit tests" step that conditionally configures netmhc-bundle paths if the directory exists

## Test plan
- [ ] Verify CI passes on this PR (in the openvax org where the secret exists)
- [ ] Verify that forked repos without `NETMHC_BUNDLE_ACCESS_TOKEN` skip netmhc-bundle steps gracefully and still run tests
- [ ] Confirm netmhc-bundle is checked out at the v1.0.0 tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)