### PR TITLE
Pin netmhc-bundle to v1.0.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,6 +65,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: openvax/netmhc-bundle
+          ref: v1.0.0
           token: ${{ secrets.NETMHC_BUNDLE_ACCESS_TOKEN }}
           path: netmhc-bundle
 


### PR DESCRIPTION
Pin netmhc-bundle checkout to v1.0.0 for reproducible CI builds. Supersedes #172 (which targets the old workflow structure).