### PR TITLE
Bump version to 2.0.0

### DIFF
--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -24,7 +24,7 @@ from .random_predictor import RandomBindingPredictor
 from .netmhcstabpan import NetMHCstabpan
 from .unsupported_allele import UnsupportedAllele
 
-__version__ = "1.9.1"
+__version__ = "2.0.0"
 
 __all__ = [
     "BindingPrediction",


### PR DESCRIPTION
Version bump for the mhcnames to mhcgnomes migration and mhcgnomes >= 3.4.0 requirement.