### PR TITLE
Remove numpy<2.0 cap

### DIFF
--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -24,7 +24,7 @@ from .random_predictor import RandomBindingPredictor
 from .netmhcstabpan import NetMHCstabpan
 from .unsupported_allele import UnsupportedAllele
 
-__version__ = "2.0.0"
+__version__ = "2.1.0"
 
 __all__ = [
     "BindingPrediction",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
 dependencies = [
-  "numpy>=1.7,<2.0",
+  "numpy>=1.7",
   "pandas>=0.13.1",
   "varcode>=0.5.9",
   "pyensembl>=2.3.0,<3.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.7,<2.0
+numpy>=1.7
 pandas>=0.13.1
 pyensembl>=2.3.0,<3.0.0
 varcode>=0.5.9


### PR DESCRIPTION
Drop the numpy<2.0 upper bound now that mhcflurry 2.2.0 supports numpy 2.x. Bumps version to 2.1.0.