### PR TITLE
Remove Python 2 compat, require numpy 2+

### DIFF
--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -27,7 +27,7 @@ from .random_predictor import RandomBindingPredictor
 from .netmhcstabpan import NetMHCstabpan
 from .unsupported_allele import UnsupportedAllele
 
-__version__ = "3.0.0"
+__version__ = "3.0.1"
 
 __all__ = [
     "Pred",

--- a/mhctools/allele_normalization.py
+++ b/mhctools/allele_normalization.py
@@ -7,8 +7,6 @@ This module preserves the subset of mhcnames behavior relied on by mhctools:
 - AlleleParseError
 """
 
-from __future__ import print_function, division, absolute_import
-
 from collections import namedtuple
 
 from mhcgnomes import Allele, Pair, ParseError, parse

--- a/mhctools/base_commandline_predictor.py
+++ b/mhctools/base_commandline_predictor.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
 from collections import defaultdict
 import logging
 from subprocess import check_output

--- a/mhctools/binding_prediction_collection.py
+++ b/mhctools/binding_prediction_collection.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
-
 import pandas as pd
 from sercol import Collection
 

--- a/mhctools/cli/__init__.py
+++ b/mhctools/cli/__init__.py
@@ -16,8 +16,6 @@
 Commandline interface for MHC Binding Prediction
 """
 
-from __future__ import print_function, division, absolute_import
-
 from .args import (
     mhc_binding_predictor_from_args,
     mhc_alleles_from_args,

--- a/mhctools/cli/args.py
+++ b/mhctools/cli/args.py
@@ -17,7 +17,6 @@
 Commandline options for MHC Binding Prediction
 """
 
-from __future__ import print_function, division, absolute_import
 from argparse import ArgumentParser
 import logging
 

--- a/mhctools/cli/parsing_helpers.py
+++ b/mhctools/cli/parsing_helpers.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
-
 def parse_int_list(string):
     """
     Parses a string of numbers and ranges into a list of integers. Ranges

--- a/mhctools/cli/script.py
+++ b/mhctools/cli/script.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
 import sys
 
 import pandas as pd

--- a/mhctools/netmhc3.py
+++ b/mhctools/netmhc3.py
@@ -10,8 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
-
 from .base_commandline_predictor import BaseCommandlinePredictor
 from .parsing import parse_netmhc3_stdout
 

--- a/mhctools/netmhc_cons.py
+++ b/mhctools/netmhc_cons.py
@@ -10,8 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
-
 from .base_commandline_predictor import BaseCommandlinePredictor
 from .parsing import parse_netmhccons_stdout
 

--- a/mhctools/netmhc_pan28.py
+++ b/mhctools/netmhc_pan28.py
@@ -10,8 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
-
 from .base_commandline_predictor import BaseCommandlinePredictor
 from .parsing import parse_netmhcpan28_stdout, parse_netmhcpan_to_preds
 

--- a/mhctools/netmhc_pan4.py
+++ b/mhctools/netmhc_pan4.py
@@ -10,8 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
-
 from .base_commandline_predictor import BaseCommandlinePredictor
 from .parsing import parse_netmhcpan4_stdout, parse_netmhcpan_to_preds
 from functools import partial

--- a/mhctools/parsing.py
+++ b/mhctools/parsing.py
@@ -10,8 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
-
 import logging
 import re
 

--- a/mhctools/process_helpers.py
+++ b/mhctools/process_helpers.py
@@ -10,7 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
 import logging
 import os
 from subprocess import Popen, CalledProcessError

--- a/mhctools/unsupported_allele.py
+++ b/mhctools/unsupported_allele.py
@@ -12,7 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import
-
 class UnsupportedAllele(ValueError):
     pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
 dependencies = [
-  "numpy>=1.7",
+  "numpy>=2.0.0,<3.0.0",
   "pandas>=0.13.1",
   "varcode>=0.5.9",
   "pyensembl>=2.3.0,<3.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.7
+numpy>=2.0.0,<3.0.0
 pandas>=0.13.1
 pyensembl>=2.3.0,<3.0.0
 varcode>=0.5.9


### PR DESCRIPTION
## Summary
- Remove `from __future__ import` Python 2 compat from 14 files
- Update numpy pin from >=1.7 to >=2.0.0,<3.0.0
- Bump version to 3.0.1

## Test plan
- CI passes