### PR TITLE
Add pepsickle proteasomal cleavage predictor

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e ".[dev]"
+          python -m pip install -e ".[dev,pepsickle]"
 
       - name: Run lint checks
         run: ./lint.sh
@@ -46,6 +46,9 @@ jobs:
             tests/test_binding_prediction_collection.py \
             tests/test_cli_parsing_helpers.py \
             tests/test_mhc_formats.py \
+            tests/test_pred.py \
+            tests/test_processing_predictor.py \
+            tests/test_pepsickle.py \
             tests/test_random.py
 
   integration-netmhc:

--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -12,6 +12,7 @@ from .iedb import (
 from .mixmhcpred import MixMHCpred
 from .mhcflurry import MHCflurry
 from .netchop import NetChop
+from .pepsickle import Pepsickle
 from .netmhc import NetMHC
 from .netmhc3 import NetMHC3
 from .netmhc4 import NetMHC4
@@ -45,6 +46,7 @@ __all__ = [
     "MixMHCpred",
     "MHCflurry",
     "NetChop",
+    "Pepsickle",
     "NetMHC",
     "NetMHC3",
     "NetMHC4",

--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -11,6 +11,7 @@ from .iedb import (
 )
 from .mixmhcpred import MixMHCpred
 from .mhcflurry import MHCflurry
+from .processing_predictor import ProcessingPredictor
 from .netchop import NetChop
 from .pepsickle import Pepsickle
 from .netmhc import NetMHC
@@ -45,6 +46,7 @@ __all__ = [
     "IedbNetMHCIIpan",
     "MixMHCpred",
     "MHCflurry",
+    "ProcessingPredictor",
     "NetChop",
     "Pepsickle",
     "NetMHC",

--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -11,7 +11,16 @@ from .iedb import (
 )
 from .mixmhcpred import MixMHCpred
 from .mhcflurry import MHCflurry
-from .processing_predictor import ProcessingPredictor
+from .processing_predictor import (
+    ProcessingPredictor,
+    score_cterm,
+    score_nterm_cterm,
+    score_cterm_anti_max_internal,
+    score_cterm_anti_mean_internal,
+    score_nterm_cterm_anti_max_internal,
+    score_nterm_cterm_anti_mean_internal,
+)
+from .proteasome_predictor import ProteasomePredictor
 from .netchop import NetChop
 from .pepsickle import Pepsickle
 from .netmhc import NetMHC
@@ -47,6 +56,13 @@ __all__ = [
     "MixMHCpred",
     "MHCflurry",
     "ProcessingPredictor",
+    "ProteasomePredictor",
+    "score_cterm",
+    "score_nterm_cterm",
+    "score_cterm_anti_max_internal",
+    "score_cterm_anti_mean_internal",
+    "score_nterm_cterm_anti_max_internal",
+    "score_nterm_cterm_anti_mean_internal",
     "NetChop",
     "Pepsickle",
     "NetMHC",

--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -13,6 +13,8 @@ from .mixmhcpred import MixMHCpred
 from .mhcflurry import MHCflurry
 from .processing_predictor import (
     ProcessingPredictor,
+    SCORING_MODES,
+    resolve_scoring,
     score_cterm,
     score_nterm_cterm,
     score_cterm_anti_max_internal,
@@ -57,6 +59,8 @@ __all__ = [
     "MHCflurry",
     "ProcessingPredictor",
     "ProteasomePredictor",
+    "SCORING_MODES",
+    "resolve_scoring",
     "score_cterm",
     "score_nterm_cterm",
     "score_cterm_anti_max_internal",

--- a/mhctools/netchop.py
+++ b/mhctools/netchop.py
@@ -14,12 +14,12 @@ import logging
 import subprocess
 import tempfile
 
-from .processing_predictor import ProcessingPredictor
+from .proteasome_predictor import ProteasomePredictor
 
 logger = logging.getLogger(__name__)
 
 
-class NetChop(ProcessingPredictor):
+class NetChop(ProteasomePredictor):
     """
     Wrapper around the netChop command-line tool.
 
@@ -30,8 +30,9 @@ class NetChop(ProcessingPredictor):
     default_peptide_lengths : list of int, optional
         Peptide lengths used when scanning proteins. Default ``[9]``.
 
-    scoring : str
-        Aggregation method (see :class:`ProcessingPredictor`).
+    scoring : callable, optional
+        See :class:`ProcessingPredictor`.  Default:
+        ``score_cterm_anti_max_internal``.
 
     program_name : str
         Name or path of the netChop executable (default ``"netChop"``).
@@ -40,9 +41,9 @@ class NetChop(ProcessingPredictor):
     def __init__(
             self,
             default_peptide_lengths=None,
-            scoring="nterm_cterm_max_internal",
+            scoring=None,
             program_name="netChop"):
-        ProcessingPredictor.__init__(
+        ProteasomePredictor.__init__(
             self,
             default_peptide_lengths=default_peptide_lengths,
             scoring=scoring,
@@ -50,8 +51,10 @@ class NetChop(ProcessingPredictor):
         self.program_name = program_name
 
     def __str__(self):
-        return "%s(program_name=%r, scoring=%r)" % (
-            self.__class__.__name__, self.program_name, self.scoring)
+        return "%s(program_name=%r, scoring=%s)" % (
+            self.__class__.__name__,
+            self.program_name,
+            getattr(self.scoring, "__name__", repr(self.scoring)))
 
     def _predictor_name(self):
         return "netchop"

--- a/mhctools/netchop.py
+++ b/mhctools/netchop.py
@@ -10,56 +10,90 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-import subprocess
 import logging
+import subprocess
 import tempfile
 
+from .processing_predictor import ProcessingPredictor
 
-class NetChop(object):
+logger = logging.getLogger(__name__)
+
+
+class NetChop(ProcessingPredictor):
     """
-    Wrapper around netChop tool. Assumes netChop is in your PATH.
+    Wrapper around the netChop command-line tool.
+
+    Assumes ``netChop`` (or a custom *program_name*) is on your PATH.
+
+    Parameters
+    ----------
+    default_peptide_lengths : list of int, optional
+        Peptide lengths used when scanning proteins. Default ``[9]``.
+
+    scoring : str
+        Aggregation method (see :class:`ProcessingPredictor`).
+
+    program_name : str
+        Name or path of the netChop executable (default ``"netChop"``).
     """
 
-    def predict(self, sequences):
+    def __init__(
+            self,
+            default_peptide_lengths=None,
+            scoring="nterm_cterm_max_internal",
+            program_name="netChop"):
+        ProcessingPredictor.__init__(
+            self,
+            default_peptide_lengths=default_peptide_lengths,
+            scoring=scoring,
+        )
+        self.program_name = program_name
+
+    def __str__(self):
+        return "%s(program_name=%r, scoring=%r)" % (
+            self.__class__.__name__, self.program_name, self.scoring)
+
+    def _predictor_name(self):
+        return "netchop"
+
+    def cleavage_probs(self, sequence):
         """
-        Return netChop predictions for each position in each sequence.
-
-        Parameters
-        -----------
-        sequences : list of string
-            Amino acid sequences to predict cleavage for
+        Run netChop on a single sequence.
 
         Returns
-        -----------
-        list of list of float
-
-        The i'th list corresponds to the i'th sequence. Each list gives
-        the cleavage probability for each position in the sequence.
+        -------
+        list of float
+            Per-position cleavage probabilities.
         """
-        with tempfile.NamedTemporaryFile(suffix=".fsa", mode="w") as input_fd:
-            for (i, sequence) in enumerate(sequences):
-                input_fd.write("> %d\n" % i)
-                input_fd.write(sequence)
-                input_fd.write("\n")
-            input_fd.flush()
+        with tempfile.NamedTemporaryFile(suffix=".fsa", mode="w") as fd:
+            fd.write("> seq\n")
+            fd.write(sequence)
+            fd.write("\n")
+            fd.flush()
             try:
-                output = subprocess.check_output(["netChop", input_fd.name])
+                output = subprocess.check_output([self.program_name, fd.name])
             except subprocess.CalledProcessError as e:
-                logging.error("Error calling netChop: %s:\n%s" % (e, e.output))
+                logger.error(
+                    "Error calling %s: %s:\n%s",
+                    self.program_name, e, e.output)
                 raise
-
         parsed = self.parse_netchop(output)
-        assert len(parsed) == len(sequences), \
-            "Expected %d results but got %d" % (
-                len(sequences), len(parsed))
-        assert [len(x) for x in parsed] == [len(x) for x in sequences]
-        return parsed
+        assert len(parsed) == 1, \
+            "Expected 1 result from netChop, got %d" % len(parsed)
+        assert len(parsed[0]) == len(sequence), \
+            "Expected %d scores, got %d" % (len(sequence), len(parsed[0]))
+        return parsed[0]
 
     @staticmethod
     def parse_netchop(netchop_output):
         """
         Parse netChop stdout.
+
+        Returns
+        -------
+        list of list of float
+            One inner list per input sequence, with per-position
+            cleavage scores.
         """
         line_iterator = iter(netchop_output.decode().split("\n"))
         scores = []

--- a/mhctools/pepsickle.py
+++ b/mhctools/pepsickle.py
@@ -1,0 +1,255 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import defaultdict
+
+from .base_predictor import BasePredictor
+from .pred import Pred, Kind, PeptidePreds
+
+
+class Pepsickle(BasePredictor):
+    """
+    Wrapper around the pepsickle proteasomal cleavage predictor.
+
+    Pepsickle predicts proteasomal cleavage probabilities for each position
+    in a protein sequence. This wrapper exposes those predictions through
+    the standard mhctools predictor API.
+
+    For ``predict(peptides)``, returns the C-terminal cleavage probability
+    for each peptide (i.e. the probability that the proteasome cleaves after
+    the last residue, which is the relevant cleavage event for generating
+    that peptide).
+
+    For ``predict_proteins()``, runs pepsickle on the full protein so that
+    flanking-sequence context is available, then extracts per-peptide
+    C-terminal cleavage scores.
+
+    Parameters
+    ----------
+    alleles : list of str, optional
+        Not used by cleavage predictors but accepted for API compatibility.
+
+    default_peptide_lengths : list of int, optional
+        Peptide lengths used when scanning proteins. Default ``[9]``.
+
+    model_type : str
+        Pepsickle model to use. One of ``"epitope"`` (default),
+        ``"in-vitro"`` (gradient-boosted), or ``"in-vitro-2"`` (neural net).
+
+    proteasome_type : str
+        ``"C"`` for constitutive (default) or ``"I"`` for immunoproteasome.
+        Only used by in-vitro models; ignored by the epitope model.
+
+    threshold : float
+        Cleavage probability threshold (default 0.5).
+
+    human_only : bool
+        If True, use human-only trained models instead of all-mammal models.
+    """
+
+    VALID_MODEL_TYPES = ("epitope", "in-vitro", "in-vitro-2")
+    VALID_PROTEASOME_TYPES = ("C", "I")
+
+    def __init__(
+            self,
+            alleles=None,
+            default_peptide_lengths=None,
+            model_type="epitope",
+            proteasome_type="C",
+            threshold=0.5,
+            human_only=False):
+        if alleles is None:
+            alleles = []
+        if default_peptide_lengths is None:
+            default_peptide_lengths = [9]
+        if model_type not in self.VALID_MODEL_TYPES:
+            raise ValueError(
+                "model_type must be one of %s, got %r" % (
+                    self.VALID_MODEL_TYPES, model_type))
+        if proteasome_type not in self.VALID_PROTEASOME_TYPES:
+            raise ValueError(
+                "proteasome_type must be 'C' or 'I', got %r" % proteasome_type)
+        BasePredictor.__init__(
+            self,
+            alleles=alleles,
+            default_peptide_lengths=default_peptide_lengths,
+            min_peptide_length=None,
+            max_peptide_length=None,
+            allow_X_in_peptides=True,
+        )
+        self.model_type = model_type
+        self.proteasome_type = proteasome_type
+        self.threshold = threshold
+        self.human_only = human_only
+        self._model = None
+
+    def __str__(self):
+        return "%s(model_type=%r, proteasome_type=%r)" % (
+            self.__class__.__name__,
+            self.model_type,
+            self.proteasome_type)
+
+    def _load_model(self):
+        if self._model is None:
+            from pepsickle.model_functions import (
+                initialize_epitope_model,
+                initialize_digestion_model,
+                initialize_digestion_gb_model,
+            )
+            if self.model_type == "epitope":
+                self._model = initialize_epitope_model(
+                    human_only=self.human_only)
+            elif self.model_type == "in-vitro":
+                self._model = initialize_digestion_gb_model()
+            elif self.model_type == "in-vitro-2":
+                self._model = initialize_digestion_model(
+                    human_only=self.human_only)
+        return self._model
+
+    def _default_pred_kind(self):
+        return Kind.proteasome_cleavage
+
+    def predict(self, peptides):
+        """
+        Predict C-terminal cleavage probability for each peptide.
+
+        Parameters
+        ----------
+        peptides : list of str
+
+        Returns
+        -------
+        list of PeptidePreds
+        """
+        self._check_peptide_inputs(peptides)
+        from pepsickle.model_functions import predict_protein_cleavage_locations
+        model = self._load_model()
+        results = []
+        for peptide in peptides:
+            preds_raw = predict_protein_cleavage_locations(
+                peptide,
+                model,
+                mod_type=self.model_type,
+                proteasome_type=self.proteasome_type,
+                threshold=self.threshold,
+            )
+            # C-terminal cleavage score is at the last position
+            if preds_raw:
+                score = preds_raw[-1][2]
+            else:
+                score = 0.0
+            pred = Pred(
+                kind=Kind.proteasome_cleavage,
+                score=score,
+                peptide=peptide,
+                predictor_name="pepsickle",
+            )
+            results.append(PeptidePreds(preds=(pred,)))
+        return results
+
+    def predict_proteins(self, sequence_dict, peptide_lengths=None):
+        """
+        Predict cleavage for peptides derived from full protein sequences.
+
+        Runs pepsickle on each full protein (preserving flanking context)
+        and extracts the C-terminal cleavage score for every sub-peptide.
+
+        Parameters
+        ----------
+        sequence_dict : dict or str
+            Mapping of sequence names to amino acid strings, or a single
+            sequence string.
+
+        peptide_lengths : list of int, optional
+
+        Returns
+        -------
+        dict mapping sequence_name -> list of PeptidePreds
+        """
+        if isinstance(sequence_dict, str):
+            sequence_dict = {"seq": sequence_dict}
+        elif isinstance(sequence_dict, (list, tuple)):
+            sequence_dict = {seq: seq for seq in sequence_dict}
+
+        peptide_lengths = self._check_peptide_lengths(peptide_lengths)
+
+        from pepsickle.model_functions import predict_protein_cleavage_locations
+        model = self._load_model()
+
+        results = defaultdict(list)
+        for name, sequence in sequence_dict.items():
+            preds_raw = predict_protein_cleavage_locations(
+                sequence,
+                model,
+                protein_id=name,
+                mod_type=self.model_type,
+                proteasome_type=self.proteasome_type,
+                threshold=self.threshold,
+            )
+            # Build 1-based position -> cleavage probability map
+            cleavage_scores = {entry[0]: entry[2] for entry in preds_raw}
+
+            for peptide_length in peptide_lengths:
+                for i in range(len(sequence) - peptide_length + 1):
+                    peptide = sequence[i:i + peptide_length]
+                    # C-terminal residue is at 1-based position (i + peptide_length)
+                    c_term_pos = i + peptide_length
+                    score = cleavage_scores.get(c_term_pos, 0.0)
+                    pred = Pred(
+                        kind=Kind.proteasome_cleavage,
+                        score=score,
+                        peptide=peptide,
+                        source_sequence_name=name,
+                        offset=i,
+                        predictor_name="pepsickle",
+                    )
+                    results[name].append(PeptidePreds(preds=(pred,)))
+        return dict(results)
+
+    def predict_cleavage_sites(self, sequence_dict):
+        """
+        Return per-position cleavage probabilities for full protein sequences.
+
+        This is a pepsickle-specific method that exposes the full cleavage
+        profile rather than summarising it per peptide.
+
+        Parameters
+        ----------
+        sequence_dict : dict or str
+            Mapping of sequence names to amino acid strings, or a single
+            sequence string.
+
+        Returns
+        -------
+        dict mapping sequence_name -> list of (position, residue, probability)
+            position is 1-based.
+        """
+        if isinstance(sequence_dict, str):
+            sequence_dict = {"seq": sequence_dict}
+
+        from pepsickle.model_functions import predict_protein_cleavage_locations
+        model = self._load_model()
+
+        results = {}
+        for name, sequence in sequence_dict.items():
+            preds_raw = predict_protein_cleavage_locations(
+                sequence,
+                model,
+                protein_id=name,
+                mod_type=self.model_type,
+                proteasome_type=self.proteasome_type,
+                threshold=self.threshold,
+            )
+            results[name] = [
+                (entry[0], entry[1], entry[2]) for entry in preds_raw
+            ]
+        return results

--- a/mhctools/pepsickle.py
+++ b/mhctools/pepsickle.py
@@ -10,10 +10,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .processing_predictor import ProcessingPredictor
+from .proteasome_predictor import ProteasomePredictor
 
 
-class Pepsickle(ProcessingPredictor):
+class Pepsickle(ProteasomePredictor):
     """
     Wrapper around the pepsickle proteasomal cleavage predictor.
 
@@ -22,8 +22,9 @@ class Pepsickle(ProcessingPredictor):
     default_peptide_lengths : list of int, optional
         Peptide lengths used when scanning proteins. Default ``[9]``.
 
-    scoring : str
-        Aggregation method (see :class:`ProcessingPredictor`).
+    scoring : callable, optional
+        See :class:`ProcessingPredictor`.  Default:
+        ``score_cterm_anti_max_internal``.
 
     model_type : str
         Pepsickle model to use. One of ``"epitope"`` (default),
@@ -47,7 +48,7 @@ class Pepsickle(ProcessingPredictor):
     def __init__(
             self,
             default_peptide_lengths=None,
-            scoring="nterm_cterm_max_internal",
+            scoring=None,
             model_type="epitope",
             proteasome_type="C",
             threshold=0.5,
@@ -59,7 +60,7 @@ class Pepsickle(ProcessingPredictor):
         if proteasome_type not in self.VALID_PROTEASOME_TYPES:
             raise ValueError(
                 "proteasome_type must be 'C' or 'I', got %r" % proteasome_type)
-        ProcessingPredictor.__init__(
+        ProteasomePredictor.__init__(
             self,
             default_peptide_lengths=default_peptide_lengths,
             scoring=scoring,
@@ -71,11 +72,11 @@ class Pepsickle(ProcessingPredictor):
         self._model = None
 
     def __str__(self):
-        return "%s(model_type=%r, proteasome_type=%r, scoring=%r)" % (
+        return "%s(model_type=%r, proteasome_type=%r, scoring=%s)" % (
             self.__class__.__name__,
             self.model_type,
             self.proteasome_type,
-            self.scoring)
+            getattr(self.scoring, "__name__", repr(self.scoring)))
 
     def _predictor_name(self):
         return "pepsickle"

--- a/mhctools/pepsickle.py
+++ b/mhctools/pepsickle.py
@@ -10,36 +10,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import defaultdict
-
-from .base_predictor import BasePredictor
-from .pred import Pred, Kind, PeptidePreds
+from .processing_predictor import ProcessingPredictor
 
 
-class Pepsickle(BasePredictor):
+class Pepsickle(ProcessingPredictor):
     """
     Wrapper around the pepsickle proteasomal cleavage predictor.
 
-    Pepsickle predicts proteasomal cleavage probabilities for each position
-    in a protein sequence. This wrapper exposes those predictions through
-    the standard mhctools predictor API.
-
-    For ``predict(peptides)``, returns the C-terminal cleavage probability
-    for each peptide (i.e. the probability that the proteasome cleaves after
-    the last residue, which is the relevant cleavage event for generating
-    that peptide).
-
-    For ``predict_proteins()``, runs pepsickle on the full protein so that
-    flanking-sequence context is available, then extracts per-peptide
-    C-terminal cleavage scores.
-
     Parameters
     ----------
-    alleles : list of str, optional
-        Not used by cleavage predictors but accepted for API compatibility.
-
     default_peptide_lengths : list of int, optional
         Peptide lengths used when scanning proteins. Default ``[9]``.
+
+    scoring : str
+        Aggregation method (see :class:`ProcessingPredictor`).
 
     model_type : str
         Pepsickle model to use. One of ``"epitope"`` (default),
@@ -50,10 +34,11 @@ class Pepsickle(BasePredictor):
         Only used by in-vitro models; ignored by the epitope model.
 
     threshold : float
-        Cleavage probability threshold (default 0.5).
+        Cleavage probability threshold used by pepsickle internally
+        (default 0.5).
 
     human_only : bool
-        If True, use human-only trained models instead of all-mammal models.
+        If True, use human-only trained models instead of all-mammal.
     """
 
     VALID_MODEL_TYPES = ("epitope", "in-vitro", "in-vitro-2")
@@ -61,16 +46,12 @@ class Pepsickle(BasePredictor):
 
     def __init__(
             self,
-            alleles=None,
             default_peptide_lengths=None,
+            scoring="nterm_cterm_max_internal",
             model_type="epitope",
             proteasome_type="C",
             threshold=0.5,
             human_only=False):
-        if alleles is None:
-            alleles = []
-        if default_peptide_lengths is None:
-            default_peptide_lengths = [9]
         if model_type not in self.VALID_MODEL_TYPES:
             raise ValueError(
                 "model_type must be one of %s, got %r" % (
@@ -78,13 +59,10 @@ class Pepsickle(BasePredictor):
         if proteasome_type not in self.VALID_PROTEASOME_TYPES:
             raise ValueError(
                 "proteasome_type must be 'C' or 'I', got %r" % proteasome_type)
-        BasePredictor.__init__(
+        ProcessingPredictor.__init__(
             self,
-            alleles=alleles,
             default_peptide_lengths=default_peptide_lengths,
-            min_peptide_length=None,
-            max_peptide_length=None,
-            allow_X_in_peptides=True,
+            scoring=scoring,
         )
         self.model_type = model_type
         self.proteasome_type = proteasome_type
@@ -93,10 +71,14 @@ class Pepsickle(BasePredictor):
         self._model = None
 
     def __str__(self):
-        return "%s(model_type=%r, proteasome_type=%r)" % (
+        return "%s(model_type=%r, proteasome_type=%r, scoring=%r)" % (
             self.__class__.__name__,
             self.model_type,
-            self.proteasome_type)
+            self.proteasome_type,
+            self.scoring)
+
+    def _predictor_name(self):
+        return "pepsickle"
 
     def _load_model(self):
         if self._model is None:
@@ -115,141 +97,14 @@ class Pepsickle(BasePredictor):
                     human_only=self.human_only)
         return self._model
 
-    def _default_pred_kind(self):
-        return Kind.proteasome_cleavage
-
-    def predict(self, peptides):
-        """
-        Predict C-terminal cleavage probability for each peptide.
-
-        Parameters
-        ----------
-        peptides : list of str
-
-        Returns
-        -------
-        list of PeptidePreds
-        """
-        self._check_peptide_inputs(peptides)
+    def cleavage_probs(self, sequence):
         from pepsickle.model_functions import predict_protein_cleavage_locations
         model = self._load_model()
-        results = []
-        for peptide in peptides:
-            preds_raw = predict_protein_cleavage_locations(
-                peptide,
-                model,
-                mod_type=self.model_type,
-                proteasome_type=self.proteasome_type,
-                threshold=self.threshold,
-            )
-            # C-terminal cleavage score is at the last position
-            if preds_raw:
-                score = preds_raw[-1][2]
-            else:
-                score = 0.0
-            pred = Pred(
-                kind=Kind.proteasome_cleavage,
-                score=score,
-                peptide=peptide,
-                predictor_name="pepsickle",
-            )
-            results.append(PeptidePreds(preds=(pred,)))
-        return results
-
-    def predict_proteins(self, sequence_dict, peptide_lengths=None):
-        """
-        Predict cleavage for peptides derived from full protein sequences.
-
-        Runs pepsickle on each full protein (preserving flanking context)
-        and extracts the C-terminal cleavage score for every sub-peptide.
-
-        Parameters
-        ----------
-        sequence_dict : dict or str
-            Mapping of sequence names to amino acid strings, or a single
-            sequence string.
-
-        peptide_lengths : list of int, optional
-
-        Returns
-        -------
-        dict mapping sequence_name -> list of PeptidePreds
-        """
-        if isinstance(sequence_dict, str):
-            sequence_dict = {"seq": sequence_dict}
-        elif isinstance(sequence_dict, (list, tuple)):
-            sequence_dict = {seq: seq for seq in sequence_dict}
-
-        peptide_lengths = self._check_peptide_lengths(peptide_lengths)
-
-        from pepsickle.model_functions import predict_protein_cleavage_locations
-        model = self._load_model()
-
-        results = defaultdict(list)
-        for name, sequence in sequence_dict.items():
-            preds_raw = predict_protein_cleavage_locations(
-                sequence,
-                model,
-                protein_id=name,
-                mod_type=self.model_type,
-                proteasome_type=self.proteasome_type,
-                threshold=self.threshold,
-            )
-            # Build 1-based position -> cleavage probability map
-            cleavage_scores = {entry[0]: entry[2] for entry in preds_raw}
-
-            for peptide_length in peptide_lengths:
-                for i in range(len(sequence) - peptide_length + 1):
-                    peptide = sequence[i:i + peptide_length]
-                    # C-terminal residue is at 1-based position (i + peptide_length)
-                    c_term_pos = i + peptide_length
-                    score = cleavage_scores.get(c_term_pos, 0.0)
-                    pred = Pred(
-                        kind=Kind.proteasome_cleavage,
-                        score=score,
-                        peptide=peptide,
-                        source_sequence_name=name,
-                        offset=i,
-                        predictor_name="pepsickle",
-                    )
-                    results[name].append(PeptidePreds(preds=(pred,)))
-        return dict(results)
-
-    def predict_cleavage_sites(self, sequence_dict):
-        """
-        Return per-position cleavage probabilities for full protein sequences.
-
-        This is a pepsickle-specific method that exposes the full cleavage
-        profile rather than summarising it per peptide.
-
-        Parameters
-        ----------
-        sequence_dict : dict or str
-            Mapping of sequence names to amino acid strings, or a single
-            sequence string.
-
-        Returns
-        -------
-        dict mapping sequence_name -> list of (position, residue, probability)
-            position is 1-based.
-        """
-        if isinstance(sequence_dict, str):
-            sequence_dict = {"seq": sequence_dict}
-
-        from pepsickle.model_functions import predict_protein_cleavage_locations
-        model = self._load_model()
-
-        results = {}
-        for name, sequence in sequence_dict.items():
-            preds_raw = predict_protein_cleavage_locations(
-                sequence,
-                model,
-                protein_id=name,
-                mod_type=self.model_type,
-                proteasome_type=self.proteasome_type,
-                threshold=self.threshold,
-            )
-            results[name] = [
-                (entry[0], entry[1], entry[2]) for entry in preds_raw
-            ]
-        return results
+        preds_raw = predict_protein_cleavage_locations(
+            sequence,
+            model,
+            mod_type=self.model_type,
+            proteasome_type=self.proteasome_type,
+            threshold=self.threshold,
+        )
+        return [entry[2] for entry in preds_raw]

--- a/mhctools/processing_predictor.py
+++ b/mhctools/processing_predictor.py
@@ -11,8 +11,25 @@
 # limitations under the License.
 
 """
-Base class for antigen-processing predictors that produce per-position
-cleavage probabilities and aggregate them into peptide-level scores.
+Base class for antigen-processing predictors and built-in scoring functions.
+
+Scoring functions
+-----------------
+A scoring function combines three components extracted from a per-position
+cleavage profile into a single peptide-level score::
+
+    score = scoring(c_term, n_term, internal_probs)
+
+*c_term* (float)
+    Cleavage probability after the peptide's last residue.
+*n_term* (float or None)
+    Cleavage probability after the residue immediately upstream of the
+    peptide. ``None`` when the peptide starts at position 0 (no upstream
+    residue).
+*internal_probs* (list of float)
+    Cleavage probabilities at positions *within* the peptide (excluding
+    the C-terminal position). Cleavage at any of these would destroy the
+    peptide.
 """
 
 from collections import defaultdict
@@ -20,14 +37,86 @@ from collections import defaultdict
 from .pred import Pred, Kind, PeptidePreds
 
 
+# ------------------------------------------------------------------
+# Built-in scoring functions
+# ------------------------------------------------------------------
+
+def _geomean(*values):
+    product = 1.0
+    for v in values:
+        product *= v
+    return product ** (1.0 / len(values))
+
+
+def score_cterm(c_term, n_term, internal):
+    """C-terminal cleavage probability only."""
+    return c_term
+
+
+def score_nterm_cterm(c_term, n_term, internal):
+    """Geometric mean of N- and C-terminal cleavage.
+
+    Falls back to C-terminal only when *n_term* is ``None``.
+    """
+    if n_term is None:
+        return c_term
+    return _geomean(c_term, n_term)
+
+
+def score_cterm_anti_max_internal(c_term, n_term, internal):
+    """``c_term * (1 - max(internal))``."""
+    max_i = max(internal) if internal else 0.0
+    return c_term * (1.0 - max_i)
+
+
+def score_cterm_anti_mean_internal(c_term, n_term, internal):
+    """``c_term * (1 - mean(internal))``."""
+    mean_i = sum(internal) / len(internal) if internal else 0.0
+    return c_term * (1.0 - mean_i)
+
+
+def score_nterm_cterm_anti_max_internal(c_term, n_term, internal):
+    """Geometric mean of C-term, N-term, and ``1 - max(internal)``.
+
+    N-term is omitted from the mean when ``None``.
+    """
+    max_i = max(internal) if internal else 0.0
+    components = [c_term, 1.0 - max_i]
+    if n_term is not None:
+        components.append(n_term)
+    return _geomean(*components)
+
+
+def score_nterm_cterm_anti_mean_internal(c_term, n_term, internal):
+    """Geometric mean of C-term, N-term, and ``1 - mean(internal)``.
+
+    N-term is omitted from the mean when ``None``.
+    """
+    mean_i = sum(internal) / len(internal) if internal else 0.0
+    components = [c_term, 1.0 - mean_i]
+    if n_term is not None:
+        components.append(n_term)
+    return _geomean(*components)
+
+
+# ------------------------------------------------------------------
+# ProcessingPredictor
+# ------------------------------------------------------------------
+
 class ProcessingPredictor:
     """
     Base class for antigen-processing predictors.
 
-    Subclasses must implement :meth:`cleavage_probs`, which returns a
-    list of per-position cleavage probabilities for a protein sequence.
-    This class provides the aggregation logic that converts those
-    per-position probabilities into peptide-level processing scores.
+    Subclasses implement :meth:`cleavage_probs` (per-position cleavage
+    probabilities for a sequence).  This class provides:
+
+    * **Component helpers** that extract C-terminal, N-terminal, and
+      internal cleavage components from a probability vector.
+    * **Configurable scoring** via a callable that combines those
+      components into a single peptide-level score.
+    * **Flanking-sequence support** so cleavage models see context around
+      the peptide (optional for ``predict``, automatic for
+      ``predict_proteins``).
 
     Unlike :class:`BasePredictor`, this class has **no allele parameter**
     because antigen processing is allele-independent.
@@ -37,45 +126,24 @@ class ProcessingPredictor:
     default_peptide_lengths : list of int, optional
         Peptide lengths used when scanning proteins. Default ``[9]``.
 
-    scoring : str
-        How to aggregate per-position cleavage probabilities into a
-        single peptide processing score (all use geometric mean):
-
-        * ``"cterm"`` -- C-terminal cleavage probability only.
-        * ``"nterm_cterm"`` -- N- and C-terminal cleavage.
-        * ``"cterm_max_internal"`` -- C-terminal and (1 - max internal).
-        * ``"cterm_mean_internal"`` -- C-terminal and (1 - mean internal).
-        * ``"nterm_cterm_max_internal"`` -- N-term, C-term, and
-          (1 - max internal).
-        * ``"nterm_cterm_mean_internal"`` -- N-term, C-term, and
-          (1 - mean internal).
-
-        When the N-terminal cleavage site falls outside the sequence
-        (``offset == 0`` or isolated peptides), the N-term component is
-        omitted from the geometric mean.
+    scoring : callable, optional
+        ``scoring(c_term, n_term, internal_probs) -> float``.
+        See module docstring for the signature contract.
+        Default: :func:`score_nterm_cterm_anti_max_internal`.
     """
-
-    SCORING_METHODS = (
-        "cterm",
-        "nterm_cterm",
-        "cterm_max_internal",
-        "cterm_mean_internal",
-        "nterm_cterm_max_internal",
-        "nterm_cterm_mean_internal",
-    )
 
     def __init__(
             self,
             default_peptide_lengths=None,
-            scoring="nterm_cterm_max_internal"):
+            scoring=None):
         if default_peptide_lengths is None:
             default_peptide_lengths = [9]
         if isinstance(default_peptide_lengths, int):
             default_peptide_lengths = [default_peptide_lengths]
-        if scoring not in self.SCORING_METHODS:
-            raise ValueError(
-                "scoring must be one of %s, got %r" % (
-                    self.SCORING_METHODS, scoring))
+        if scoring is None:
+            scoring = score_nterm_cterm_anti_max_internal
+        if not callable(scoring):
+            raise TypeError("scoring must be callable, got %r" % type(scoring))
         self.default_peptide_lengths = default_peptide_lengths
         self.scoring = scoring
 
@@ -83,7 +151,8 @@ class ProcessingPredictor:
         return str(self)
 
     def __str__(self):
-        return "%s(scoring=%r)" % (self.__class__.__name__, self.scoring)
+        return "%s(scoring=%s)" % (
+            self.__class__.__name__, getattr(self.scoring, "__name__", repr(self.scoring)))
 
     # ------------------------------------------------------------------
     # Abstract
@@ -96,120 +165,137 @@ class ProcessingPredictor:
         Position *i* represents the probability of cleavage **after**
         residue *i* (0-based).
 
-        Parameters
-        ----------
-        sequence : str
-            Amino acid sequence.
-
-        Returns
-        -------
-        list of float
-            One probability per residue, in ``[0, 1]``.
+        Must be implemented by subclasses.
         """
         raise NotImplementedError(
             "%s must implement cleavage_probs" % self.__class__.__name__)
+
+    # ------------------------------------------------------------------
+    # Component helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def c_term_prob(probs, offset, length):
+        """Cleavage probability after the peptide's last residue."""
+        return probs[offset + length - 1]
+
+    @staticmethod
+    def n_term_prob(probs, offset, length):
+        """Cleavage probability upstream of the peptide, or ``None``."""
+        return probs[offset - 1] if offset > 0 else None
+
+    @staticmethod
+    def internal_probs(probs, offset, length):
+        """Cleavage probabilities at positions within the peptide
+        (excluding C-terminal)."""
+        return probs[offset:offset + length - 1]
+
+    @staticmethod
+    def max_internal_prob(probs, offset, length):
+        """Maximum internal cleavage probability."""
+        internal = probs[offset:offset + length - 1]
+        return max(internal) if internal else 0.0
+
+    @staticmethod
+    def mean_internal_prob(probs, offset, length):
+        """Mean internal cleavage probability."""
+        internal = probs[offset:offset + length - 1]
+        return sum(internal) / len(internal) if internal else 0.0
 
     # ------------------------------------------------------------------
     # Scoring
     # ------------------------------------------------------------------
 
     def _peptide_score(self, probs, offset, length):
-        """
-        Aggregate per-position cleavage probabilities into a single
-        peptide processing score.
+        """Extract components and delegate to ``self.scoring``."""
+        c = self.c_term_prob(probs, offset, length)
+        n = self.n_term_prob(probs, offset, length)
+        internal = self.internal_probs(probs, offset, length)
+        return self.scoring(c, n, internal)
 
-        Components (depending on ``self.scoring``):
+    def _pred_kind(self):
+        """Kind value for Pred objects.  Override in subclasses."""
+        return Kind.antigen_processing
 
-        * **C-terminal** -- ``probs[offset + length - 1]``: cleavage
-          after the last residue of the peptide.
-        * **N-terminal** -- ``probs[offset - 1]`` (when ``offset > 0``):
-          cleavage after the residue immediately upstream.
-        * **Internal** -- ``probs[offset : offset + length - 1]``:
-          cleavage within the peptide (destroying it).  Enters the
-          formula as ``1 - summary(internal)``.
-        """
-        c_term = probs[offset + length - 1]
-
-        n_term = probs[offset - 1] if offset > 0 else None
-
-        internal = probs[offset:offset + length - 1]
-
-        components = [c_term]
-
-        if "nterm" in self.scoring and n_term is not None:
-            components.append(n_term)
-
-        if "internal" in self.scoring and internal:
-            if "max" in self.scoring:
-                summary = max(internal)
-            else:
-                summary = sum(internal) / len(internal)
-            components.append(1.0 - summary)
-
-        product = 1.0
-        for c in components:
-            product *= c
-        return product ** (1.0 / len(components))
+    def _predictor_name(self):
+        return self.__class__.__name__.lower()
 
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
 
-    def predict(self, peptides):
+    def predict(self, peptides, n_flanks=None, c_flanks=None):
         """
-        Predict antigen-processing scores for isolated peptides.
-
-        .. note::
-
-           For short peptides the C-terminal position may lack downstream
-           flanking context, producing unreliable scores.  Prefer
-           :meth:`predict_proteins` when the source protein is available.
+        Predict processing scores for peptides.
 
         Parameters
         ----------
         peptides : list of str
+
+        n_flanks : list of str, optional
+            N-terminal flanking sequences, one per peptide.  When
+            provided the cleavage model sees ``n_flank + peptide +
+            c_flank`` so that edge positions get proper context.
+
+        c_flanks : list of str, optional
+            C-terminal flanking sequences, one per peptide.
 
         Returns
         -------
         list of PeptidePreds
         """
         results = []
-        for peptide in peptides:
-            probs = self.cleavage_probs(peptide)
-            score = self._peptide_score(probs, offset=0, length=len(peptide))
+        for i, peptide in enumerate(peptides):
+            n_flank = n_flanks[i] if n_flanks else ""
+            c_flank = c_flanks[i] if c_flanks else ""
+
+            full_seq = n_flank + peptide + c_flank
+            probs = self.cleavage_probs(full_seq)
+
+            offset = len(n_flank)
+            score = self._peptide_score(probs, offset, len(peptide))
             pred = Pred(
-                kind=Kind.antigen_processing,
+                kind=self._pred_kind(),
                 score=score,
                 peptide=peptide,
+                n_flank=n_flank,
+                c_flank=c_flank,
                 predictor_name=self._predictor_name(),
             )
             results.append(PeptidePreds(preds=(pred,)))
         return results
 
-    def predict_dataframe(self, peptides, sample_name=""):
+    def predict_dataframe(self, peptides, n_flanks=None, c_flanks=None,
+                          sample_name=""):
         """``predict()`` flattened to a DataFrame."""
         import pandas as pd
         from .pred import COLUMNS
-        dfs = [pp.to_dataframe(sample_name) for pp in self.predict(peptides)]
+        dfs = [pp.to_dataframe(sample_name)
+               for pp in self.predict(peptides, n_flanks, c_flanks)]
         if not dfs:
             return pd.DataFrame(columns=COLUMNS)
         return pd.concat(dfs, ignore_index=True)
 
-    def predict_proteins(self, sequence_dict, peptide_lengths=None):
+    def predict_proteins(self, sequence_dict, peptide_lengths=None,
+                         flank_length=0):
         """
         Run cleavage prediction on full protein sequences and aggregate
         into peptide-level processing scores.
 
-        This is the preferred entry-point because flanking-sequence
-        context produces more accurate cleavage probabilities.
+        This is the preferred entry-point because the full protein gives
+        the cleavage model proper flanking context at every position.
 
         Parameters
         ----------
         sequence_dict : dict or str
-            Mapping of sequence names to amino acid strings, or a single
-            sequence string.
 
         peptide_lengths : list of int, optional
+
+        flank_length : int
+            How many residues of flanking context to record in each
+            :class:`Pred`'s ``n_flank`` / ``c_flank`` fields (default 0).
+            This does **not** affect the cleavage model — it always sees
+            the full protein.
 
         Returns
         -------
@@ -229,10 +315,18 @@ class ProcessingPredictor:
                 for i in range(len(sequence) - plen + 1):
                     peptide = sequence[i:i + plen]
                     score = self._peptide_score(probs, offset=i, length=plen)
+                    if flank_length:
+                        n_flank = sequence[max(0, i - flank_length):i]
+                        c_flank = sequence[i + plen:i + plen + flank_length]
+                    else:
+                        n_flank = ""
+                        c_flank = ""
                     pred = Pred(
-                        kind=Kind.antigen_processing,
+                        kind=self._pred_kind(),
                         score=score,
                         peptide=peptide,
+                        n_flank=n_flank,
+                        c_flank=c_flank,
                         source_sequence_name=name,
                         offset=i,
                         predictor_name=self._predictor_name(),
@@ -241,13 +335,14 @@ class ProcessingPredictor:
         return dict(results)
 
     def predict_proteins_dataframe(
-            self, sequence_dict, peptide_lengths=None, sample_name=""):
+            self, sequence_dict, peptide_lengths=None,
+            flank_length=0, sample_name=""):
         """``predict_proteins()`` flattened to a DataFrame."""
         import pandas as pd
         from .pred import COLUMNS
         dfs = []
         for name, pp_list in self.predict_proteins(
-                sequence_dict, peptide_lengths).items():
+                sequence_dict, peptide_lengths, flank_length).items():
             for pp in pp_list:
                 dfs.append(pp.to_dataframe(sample_name))
         if not dfs:
@@ -257,10 +352,6 @@ class ProcessingPredictor:
     def predict_cleavage_sites(self, sequence_dict):
         """
         Return raw per-position cleavage probabilities.
-
-        Parameters
-        ----------
-        sequence_dict : dict or str
 
         Returns
         -------
@@ -276,9 +367,6 @@ class ProcessingPredictor:
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
-
-    def _predictor_name(self):
-        return self.__class__.__name__.lower()
 
     def _resolve_peptide_lengths(self, peptide_lengths):
         if peptide_lengths is None:

--- a/mhctools/processing_predictor.py
+++ b/mhctools/processing_predictor.py
@@ -99,6 +99,34 @@ def score_nterm_cterm_anti_mean_internal(c_term, n_term, internal):
     return _geomean(*components)
 
 
+SCORING_MODES = {
+    "cterm": score_cterm,
+    "nterm_cterm": score_nterm_cterm,
+    "cterm_max_internal": score_cterm_anti_max_internal,
+    "cterm_mean_internal": score_cterm_anti_mean_internal,
+    "nterm_cterm_max_internal": score_nterm_cterm_anti_max_internal,
+    "nterm_cterm_mean_internal": score_nterm_cterm_anti_mean_internal,
+}
+
+
+def resolve_scoring(scoring):
+    """Resolve a scoring argument to a callable.
+
+    Accepts a string mode name (see :data:`SCORING_MODES`), a callable,
+    or ``None`` (returns ``None`` so the caller can apply its default).
+    """
+    if scoring is None or callable(scoring):
+        return scoring
+    if isinstance(scoring, str):
+        if scoring not in SCORING_MODES:
+            raise ValueError(
+                "Unknown scoring mode %r, choose from %s" % (
+                    scoring, list(SCORING_MODES)))
+        return SCORING_MODES[scoring]
+    raise TypeError(
+        "scoring must be a string mode, callable, or None — got %r" % type(scoring))
+
+
 # ------------------------------------------------------------------
 # ProcessingPredictor
 # ------------------------------------------------------------------
@@ -126,10 +154,12 @@ class ProcessingPredictor:
     default_peptide_lengths : list of int, optional
         Peptide lengths used when scanning proteins. Default ``[9]``.
 
-    scoring : callable, optional
-        ``scoring(c_term, n_term, internal_probs) -> float``.
-        See module docstring for the signature contract.
-        Default: :func:`score_nterm_cterm_anti_max_internal`.
+    scoring : str or callable, optional
+        Either a mode name (``"cterm"``, ``"nterm_cterm"``,
+        ``"cterm_max_internal"``, ``"cterm_mean_internal"``,
+        ``"nterm_cterm_max_internal"``, ``"nterm_cterm_mean_internal"``)
+        or a callable ``(c_term, n_term, internal_probs) -> float``.
+        Default: ``"nterm_cterm_max_internal"``.
     """
 
     def __init__(
@@ -140,10 +170,9 @@ class ProcessingPredictor:
             default_peptide_lengths = [9]
         if isinstance(default_peptide_lengths, int):
             default_peptide_lengths = [default_peptide_lengths]
+        scoring = resolve_scoring(scoring)
         if scoring is None:
             scoring = score_nterm_cterm_anti_max_internal
-        if not callable(scoring):
-            raise TypeError("scoring must be callable, got %r" % type(scoring))
         self.default_peptide_lengths = default_peptide_lengths
         self.scoring = scoring
 

--- a/mhctools/processing_predictor.py
+++ b/mhctools/processing_predictor.py
@@ -1,0 +1,290 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Base class for antigen-processing predictors that produce per-position
+cleavage probabilities and aggregate them into peptide-level scores.
+"""
+
+from collections import defaultdict
+
+from .pred import Pred, Kind, PeptidePreds
+
+
+class ProcessingPredictor:
+    """
+    Base class for antigen-processing predictors.
+
+    Subclasses must implement :meth:`cleavage_probs`, which returns a
+    list of per-position cleavage probabilities for a protein sequence.
+    This class provides the aggregation logic that converts those
+    per-position probabilities into peptide-level processing scores.
+
+    Unlike :class:`BasePredictor`, this class has **no allele parameter**
+    because antigen processing is allele-independent.
+
+    Parameters
+    ----------
+    default_peptide_lengths : list of int, optional
+        Peptide lengths used when scanning proteins. Default ``[9]``.
+
+    scoring : str
+        How to aggregate per-position cleavage probabilities into a
+        single peptide processing score (all use geometric mean):
+
+        * ``"cterm"`` -- C-terminal cleavage probability only.
+        * ``"nterm_cterm"`` -- N- and C-terminal cleavage.
+        * ``"cterm_max_internal"`` -- C-terminal and (1 - max internal).
+        * ``"cterm_mean_internal"`` -- C-terminal and (1 - mean internal).
+        * ``"nterm_cterm_max_internal"`` -- N-term, C-term, and
+          (1 - max internal).
+        * ``"nterm_cterm_mean_internal"`` -- N-term, C-term, and
+          (1 - mean internal).
+
+        When the N-terminal cleavage site falls outside the sequence
+        (``offset == 0`` or isolated peptides), the N-term component is
+        omitted from the geometric mean.
+    """
+
+    SCORING_METHODS = (
+        "cterm",
+        "nterm_cterm",
+        "cterm_max_internal",
+        "cterm_mean_internal",
+        "nterm_cterm_max_internal",
+        "nterm_cterm_mean_internal",
+    )
+
+    def __init__(
+            self,
+            default_peptide_lengths=None,
+            scoring="nterm_cterm_max_internal"):
+        if default_peptide_lengths is None:
+            default_peptide_lengths = [9]
+        if isinstance(default_peptide_lengths, int):
+            default_peptide_lengths = [default_peptide_lengths]
+        if scoring not in self.SCORING_METHODS:
+            raise ValueError(
+                "scoring must be one of %s, got %r" % (
+                    self.SCORING_METHODS, scoring))
+        self.default_peptide_lengths = default_peptide_lengths
+        self.scoring = scoring
+
+    def __repr__(self):
+        return str(self)
+
+    def __str__(self):
+        return "%s(scoring=%r)" % (self.__class__.__name__, self.scoring)
+
+    # ------------------------------------------------------------------
+    # Abstract
+    # ------------------------------------------------------------------
+
+    def cleavage_probs(self, sequence):
+        """
+        Return per-position cleavage probabilities for *sequence*.
+
+        Position *i* represents the probability of cleavage **after**
+        residue *i* (0-based).
+
+        Parameters
+        ----------
+        sequence : str
+            Amino acid sequence.
+
+        Returns
+        -------
+        list of float
+            One probability per residue, in ``[0, 1]``.
+        """
+        raise NotImplementedError(
+            "%s must implement cleavage_probs" % self.__class__.__name__)
+
+    # ------------------------------------------------------------------
+    # Scoring
+    # ------------------------------------------------------------------
+
+    def _peptide_score(self, probs, offset, length):
+        """
+        Aggregate per-position cleavage probabilities into a single
+        peptide processing score.
+
+        Components (depending on ``self.scoring``):
+
+        * **C-terminal** -- ``probs[offset + length - 1]``: cleavage
+          after the last residue of the peptide.
+        * **N-terminal** -- ``probs[offset - 1]`` (when ``offset > 0``):
+          cleavage after the residue immediately upstream.
+        * **Internal** -- ``probs[offset : offset + length - 1]``:
+          cleavage within the peptide (destroying it).  Enters the
+          formula as ``1 - summary(internal)``.
+        """
+        c_term = probs[offset + length - 1]
+
+        n_term = probs[offset - 1] if offset > 0 else None
+
+        internal = probs[offset:offset + length - 1]
+
+        components = [c_term]
+
+        if "nterm" in self.scoring and n_term is not None:
+            components.append(n_term)
+
+        if "internal" in self.scoring and internal:
+            if "max" in self.scoring:
+                summary = max(internal)
+            else:
+                summary = sum(internal) / len(internal)
+            components.append(1.0 - summary)
+
+        product = 1.0
+        for c in components:
+            product *= c
+        return product ** (1.0 / len(components))
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def predict(self, peptides):
+        """
+        Predict antigen-processing scores for isolated peptides.
+
+        .. note::
+
+           For short peptides the C-terminal position may lack downstream
+           flanking context, producing unreliable scores.  Prefer
+           :meth:`predict_proteins` when the source protein is available.
+
+        Parameters
+        ----------
+        peptides : list of str
+
+        Returns
+        -------
+        list of PeptidePreds
+        """
+        results = []
+        for peptide in peptides:
+            probs = self.cleavage_probs(peptide)
+            score = self._peptide_score(probs, offset=0, length=len(peptide))
+            pred = Pred(
+                kind=Kind.antigen_processing,
+                score=score,
+                peptide=peptide,
+                predictor_name=self._predictor_name(),
+            )
+            results.append(PeptidePreds(preds=(pred,)))
+        return results
+
+    def predict_dataframe(self, peptides, sample_name=""):
+        """``predict()`` flattened to a DataFrame."""
+        import pandas as pd
+        from .pred import COLUMNS
+        dfs = [pp.to_dataframe(sample_name) for pp in self.predict(peptides)]
+        if not dfs:
+            return pd.DataFrame(columns=COLUMNS)
+        return pd.concat(dfs, ignore_index=True)
+
+    def predict_proteins(self, sequence_dict, peptide_lengths=None):
+        """
+        Run cleavage prediction on full protein sequences and aggregate
+        into peptide-level processing scores.
+
+        This is the preferred entry-point because flanking-sequence
+        context produces more accurate cleavage probabilities.
+
+        Parameters
+        ----------
+        sequence_dict : dict or str
+            Mapping of sequence names to amino acid strings, or a single
+            sequence string.
+
+        peptide_lengths : list of int, optional
+
+        Returns
+        -------
+        dict mapping sequence_name -> list of PeptidePreds
+        """
+        if isinstance(sequence_dict, str):
+            sequence_dict = {"seq": sequence_dict}
+        elif isinstance(sequence_dict, (list, tuple)):
+            sequence_dict = {seq: seq for seq in sequence_dict}
+
+        peptide_lengths = self._resolve_peptide_lengths(peptide_lengths)
+
+        results = defaultdict(list)
+        for name, sequence in sequence_dict.items():
+            probs = self.cleavage_probs(sequence)
+            for plen in peptide_lengths:
+                for i in range(len(sequence) - plen + 1):
+                    peptide = sequence[i:i + plen]
+                    score = self._peptide_score(probs, offset=i, length=plen)
+                    pred = Pred(
+                        kind=Kind.antigen_processing,
+                        score=score,
+                        peptide=peptide,
+                        source_sequence_name=name,
+                        offset=i,
+                        predictor_name=self._predictor_name(),
+                    )
+                    results[name].append(PeptidePreds(preds=(pred,)))
+        return dict(results)
+
+    def predict_proteins_dataframe(
+            self, sequence_dict, peptide_lengths=None, sample_name=""):
+        """``predict_proteins()`` flattened to a DataFrame."""
+        import pandas as pd
+        from .pred import COLUMNS
+        dfs = []
+        for name, pp_list in self.predict_proteins(
+                sequence_dict, peptide_lengths).items():
+            for pp in pp_list:
+                dfs.append(pp.to_dataframe(sample_name))
+        if not dfs:
+            return pd.DataFrame(columns=COLUMNS)
+        return pd.concat(dfs, ignore_index=True)
+
+    def predict_cleavage_sites(self, sequence_dict):
+        """
+        Return raw per-position cleavage probabilities.
+
+        Parameters
+        ----------
+        sequence_dict : dict or str
+
+        Returns
+        -------
+        dict mapping sequence_name -> list of float
+        """
+        if isinstance(sequence_dict, str):
+            sequence_dict = {"seq": sequence_dict}
+        return {
+            name: self.cleavage_probs(seq)
+            for name, seq in sequence_dict.items()
+        }
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _predictor_name(self):
+        return self.__class__.__name__.lower()
+
+    def _resolve_peptide_lengths(self, peptide_lengths):
+        if peptide_lengths is None:
+            peptide_lengths = self.default_peptide_lengths
+        if isinstance(peptide_lengths, int):
+            peptide_lengths = [peptide_lengths]
+        if not peptide_lengths:
+            raise ValueError("peptide_lengths must be a non-empty list of ints")
+        return peptide_lengths

--- a/mhctools/proteasome_predictor.py
+++ b/mhctools/proteasome_predictor.py
@@ -1,0 +1,39 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .pred import Kind
+from .processing_predictor import ProcessingPredictor, score_cterm_anti_max_internal
+
+
+class ProteasomePredictor(ProcessingPredictor):
+    """
+    Base class for proteasome-cleavage predictors.
+
+    Defaults *scoring* to :func:`score_cterm_anti_max_internal`
+    (``c_term * (1 - max(internal))``) and emits
+    :attr:`Kind.proteasome_cleavage` predictions.
+
+    Subclasses must implement :meth:`cleavage_probs`.
+    """
+
+    def __init__(self, default_peptide_lengths=None, scoring=None, **kwargs):
+        if scoring is None:
+            scoring = score_cterm_anti_max_internal
+        ProcessingPredictor.__init__(
+            self,
+            default_peptide_lengths=default_peptide_lengths,
+            scoring=scoring,
+            **kwargs,
+        )
+
+    def _pred_kind(self):
+        return Kind.proteasome_cleavage

--- a/mhctools/proteasome_predictor.py
+++ b/mhctools/proteasome_predictor.py
@@ -11,14 +11,14 @@
 # limitations under the License.
 
 from .pred import Kind
-from .processing_predictor import ProcessingPredictor, score_cterm_anti_max_internal
+from .processing_predictor import ProcessingPredictor, resolve_scoring
 
 
 class ProteasomePredictor(ProcessingPredictor):
     """
     Base class for proteasome-cleavage predictors.
 
-    Defaults *scoring* to :func:`score_cterm_anti_max_internal`
+    Defaults *scoring* to ``"cterm_max_internal"``
     (``c_term * (1 - max(internal))``) and emits
     :attr:`Kind.proteasome_cleavage` predictions.
 
@@ -26,8 +26,9 @@ class ProteasomePredictor(ProcessingPredictor):
     """
 
     def __init__(self, default_peptide_lengths=None, scoring=None, **kwargs):
+        scoring = resolve_scoring(scoring)
         if scoring is None:
-            scoring = score_cterm_anti_max_internal
+            scoring = "cterm_max_internal"
         ProcessingPredictor.__init__(
             self,
             default_peptide_lengths=default_peptide_lengths,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+pepsickle = [
+  "pepsickle",
+]
 dev = [
   "build",
   "ruff",

--- a/tests/test_netchop.py
+++ b/tests/test_netchop.py
@@ -13,6 +13,7 @@
 import pytest
 from numpy import testing
 from mhctools import NetChop
+from mhctools.proteasome_predictor import ProteasomePredictor
 from mhctools.pred import Kind, PeptidePreds
 from .arch import apple_silicon
 
@@ -22,6 +23,10 @@ MSLLTEVETPIRNEWGCRCNDSSDPLVVAASIIGIVHLILWIIDRLFSKSIYRIFKHGLKRGPSTEGVPESMREEYREEQ
 MDSHTVSSFQVDCFLWHVRKQVADQDLGDAPFLDRLRRDQKSLKGRGSTLGLNIETATCVGKQIVERILKEESDEAFKMTMASALASRYLTDMTIEEMSRDWFMLMPKQKVAGPLCVRMDQAIMDKNIILKANFSVIFDRLENLTLLRAFTEEGAIVGEISPLPSLPGHTNEDVKNAIGVLIGGLEWNDNTVRVSETLQRFTWRSSNETGGPPFTPTQKRKMAGTIRSEV
 MDSHTVSSFQDILMRMSKMQLGSSSGDLNGMITQFESLKLYRDSLGEAVMRLGDLHSLQHRNGKWREQLGQKFEEIRWLIEEVRHKLKTTENSFEQITFMQALQLLFEVEQEIRTFSFQLI
 """.strip().split()
+
+
+def test_is_proteasome_predictor():
+    assert issubclass(NetChop, ProteasomePredictor)
 
 
 @pytest.mark.skipif(apple_silicon, reason="Can't run netChop on arm64 architecture")
@@ -53,7 +58,7 @@ def test_predict_proteins():
     assert all(isinstance(pp, PeptidePreds) for pp in pp_list)
     for pp in pp_list:
         pred = pp.preds[0]
-        assert pred.kind == Kind.antigen_processing
+        assert pred.kind == Kind.proteasome_cleavage
         assert pred.source_sequence_name == "pep0"
         assert pred.predictor_name == "netchop"
         assert 0.0 <= pred.score <= 1.0

--- a/tests/test_netchop.py
+++ b/tests/test_netchop.py
@@ -10,9 +10,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest 
+import pytest
 from numpy import testing
 from mhctools import NetChop
+from mhctools.pred import Kind, PeptidePreds
 from .arch import apple_silicon
 
 # Peptides from http://tools.iedb.org/netchop/example/
@@ -24,19 +25,35 @@ MDSHTVSSFQDILMRMSKMQLGSSSGDLNGMITQFESLKLYRDSLGEAVMRLGDLHSLQHRNGKWREQLGQKFEEIRWLI
 
 
 @pytest.mark.skipif(apple_silicon, reason="Can't run netChop on arm64 architecture")
-def test_simple():
+def test_cleavage_probs():
     obj = NetChop()
-    result = obj.predict(peptides)
-    assert len(result) == 3
-    assert len(result[0]) == len(peptides[0])
-    assert len(result[1]) == len(peptides[1])
-    assert len(result[2]) == len(peptides[2])
+    for pep in peptides:
+        probs = obj.cleavage_probs(pep)
+        assert len(probs) == len(pep)
 
-    # These numbers are from running http://tools.iedb.org/netchop
-    # via the web interface on 12/19/2016.
-    testing.assert_almost_equal(result[0][95], 0.976629)
-    testing.assert_almost_equal(result[0][22], 0.022000)
-    testing.assert_almost_equal(result[1][146], 0.977417)
-    testing.assert_almost_equal(result[1][84], 0.285210)
-    testing.assert_almost_equal(result[2][0], 0.547588)
-    testing.assert_almost_equal(result[2][84], 0.104684)
+    # Spot-check values from http://tools.iedb.org/netchop (12/19/2016)
+    probs0 = obj.cleavage_probs(peptides[0])
+    probs1 = obj.cleavage_probs(peptides[1])
+    probs2 = obj.cleavage_probs(peptides[2])
+    testing.assert_almost_equal(probs0[95], 0.976629)
+    testing.assert_almost_equal(probs0[22], 0.022000)
+    testing.assert_almost_equal(probs1[146], 0.977417)
+    testing.assert_almost_equal(probs1[84], 0.285210)
+    testing.assert_almost_equal(probs2[0], 0.547588)
+    testing.assert_almost_equal(probs2[84], 0.104684)
+
+
+@pytest.mark.skipif(apple_silicon, reason="Can't run netChop on arm64 architecture")
+def test_predict_proteins():
+    obj = NetChop()
+    result = obj.predict_proteins({"pep0": peptides[0]})
+    assert "pep0" in result
+    pp_list = result["pep0"]
+    assert isinstance(pp_list, list)
+    assert all(isinstance(pp, PeptidePreds) for pp in pp_list)
+    for pp in pp_list:
+        pred = pp.preds[0]
+        assert pred.kind == Kind.antigen_processing
+        assert pred.source_sequence_name == "pep0"
+        assert pred.predictor_name == "netchop"
+        assert 0.0 <= pred.score <= 1.0

--- a/tests/test_pepsickle.py
+++ b/tests/test_pepsickle.py
@@ -1,0 +1,159 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from mhctools.pepsickle import Pepsickle
+from mhctools.pred import Kind, PeptidePreds, COLUMNS
+
+pepsickle = pytest.importorskip("pepsickle")
+
+
+@pytest.fixture(scope="module")
+def predictor():
+    return Pepsickle()
+
+
+@pytest.fixture(scope="module")
+def predictor_invitro():
+    return Pepsickle(model_type="in-vitro", proteasome_type="C")
+
+
+PROTEIN = "MFVFLVLLPLVSSQCVNLTTRTQLPPAYTNSFTRGVY"
+PEPTIDES = ["SIINFEKL", "GILGFVFTL", "NLVPMVATV"]
+
+
+def test_init_defaults():
+    p = Pepsickle()
+    assert p.model_type == "epitope"
+    assert p.proteasome_type == "C"
+    assert p.threshold == 0.5
+    assert p.human_only is False
+    assert p.alleles == []
+    assert p.default_peptide_lengths == [9]
+
+
+def test_init_invalid_model_type():
+    with pytest.raises(ValueError, match="model_type"):
+        Pepsickle(model_type="bad")
+
+
+def test_init_invalid_proteasome_type():
+    with pytest.raises(ValueError, match="proteasome_type"):
+        Pepsickle(proteasome_type="X")
+
+
+def test_str():
+    p = Pepsickle()
+    s = str(p)
+    assert "Pepsickle" in s
+    assert "epitope" in s
+
+
+def test_predict_returns_peptide_preds(predictor):
+    results = predictor.predict(PEPTIDES)
+    assert isinstance(results, list)
+    assert len(results) == len(PEPTIDES)
+    for pp in results:
+        assert isinstance(pp, PeptidePreds)
+        assert len(pp.preds) == 1
+        pred = pp.preds[0]
+        assert pred.kind == Kind.proteasome_cleavage
+        assert 0.0 <= pred.score <= 1.0
+        assert pred.predictor_name == "pepsickle"
+
+
+def test_predict_proteins_scores_vary(predictor):
+    # Isolated peptides lack flanking context so C-terminal scores are edge-
+    # affected.  predict_proteins on a full protein should produce varying
+    # scores across sub-peptides.
+    result = predictor.predict_proteins({"spike": PROTEIN})
+    scores = [pp.preds[0].score for pp in result["spike"]]
+    assert len(set(round(s, 4) for s in scores)) > 1
+
+
+def test_predict_dataframe(predictor):
+    df = predictor.predict_dataframe(PEPTIDES)
+    assert list(df.columns) == list(COLUMNS)
+    assert len(df) == len(PEPTIDES)
+    assert (df["kind"] == "proteasome_cleavage").all()
+    assert (df["predictor_name"] == "pepsickle").all()
+
+
+def test_predict_proteins(predictor):
+    result = predictor.predict_proteins({"spike": PROTEIN})
+    assert "spike" in result
+    preds_list = result["spike"]
+    assert isinstance(preds_list, list)
+    assert all(isinstance(pp, PeptidePreds) for pp in preds_list)
+    expected_count = len(PROTEIN) - 9 + 1
+    assert len(preds_list) == expected_count
+    for pp in preds_list:
+        pred = pp.preds[0]
+        assert pred.kind == Kind.proteasome_cleavage
+        assert pred.source_sequence_name == "spike"
+        assert 0.0 <= pred.score <= 1.0
+
+
+def test_predict_proteins_dataframe(predictor):
+    df = predictor.predict_proteins_dataframe(
+        {"spike": PROTEIN}, sample_name="sample1")
+    assert list(df.columns) == list(COLUMNS)
+    assert (df["source_sequence_name"] == "spike").all()
+    assert (df["sample_name"] == "sample1").all()
+
+
+def test_predict_proteins_string_input(predictor):
+    result = predictor.predict_proteins(PROTEIN)
+    assert "seq" in result
+
+
+def test_predict_proteins_multiple_lengths(predictor):
+    p = Pepsickle(default_peptide_lengths=[8, 9, 10])
+    result = p.predict_proteins({"s": PROTEIN})
+    preds_list = result["s"]
+    expected = sum(len(PROTEIN) - k + 1 for k in [8, 9, 10])
+    assert len(preds_list) == expected
+
+
+def test_predict_cleavage_sites(predictor):
+    result = predictor.predict_cleavage_sites({"spike": PROTEIN})
+    assert "spike" in result
+    sites = result["spike"]
+    assert len(sites) == len(PROTEIN)
+    for pos, residue, prob in sites:
+        assert isinstance(pos, int)
+        assert pos >= 1
+        assert isinstance(residue, str)
+        assert 0.0 <= prob <= 1.0
+
+
+def test_predict_cleavage_sites_string(predictor):
+    result = predictor.predict_cleavage_sites(PROTEIN)
+    assert "seq" in result
+
+
+@pytest.mark.xfail(
+    reason="pepsickle in-vitro GB model requires older sklearn pickle format",
+    raises=ModuleNotFoundError,
+)
+def test_invitro_model(predictor_invitro):
+    results = predictor_invitro.predict(PEPTIDES)
+    assert len(results) == len(PEPTIDES)
+    for pp in results:
+        assert pp.preds[0].kind == Kind.proteasome_cleavage
+        assert 0.0 <= pp.preds[0].score <= 1.0
+
+
+def test_default_pred_kind():
+    p = Pepsickle()
+    assert p._default_pred_kind() == Kind.proteasome_cleavage

--- a/tests/test_pepsickle.py
+++ b/tests/test_pepsickle.py
@@ -13,6 +13,12 @@
 import pytest
 
 from mhctools.pepsickle import Pepsickle
+from mhctools.processing_predictor import (
+    score_cterm,
+    score_cterm_anti_max_internal,
+    score_nterm_cterm_anti_max_internal,
+)
+from mhctools.proteasome_predictor import ProteasomePredictor
 from mhctools.pred import Kind, PeptidePreds, COLUMNS
 
 pepsickle = pytest.importorskip("pepsickle")
@@ -21,11 +27,6 @@ pepsickle = pytest.importorskip("pepsickle")
 @pytest.fixture(scope="module")
 def predictor():
     return Pepsickle()
-
-
-@pytest.fixture(scope="module")
-def predictor_invitro():
-    return Pepsickle(model_type="in-vitro", proteasome_type="C")
 
 
 PROTEIN = "MFVFLVLLPLVSSQCVNLTTRTQLPPAYTNSFTRGVY"
@@ -41,8 +42,12 @@ def test_init_defaults():
     assert p.threshold == 0.5
     assert p.human_only is False
     assert p.default_peptide_lengths == [9]
-    assert p.scoring == "nterm_cterm_max_internal"
+    assert p.scoring is score_cterm_anti_max_internal
     assert not hasattr(p, "alleles")
+
+
+def test_is_proteasome_predictor():
+    assert isinstance(Pepsickle(), ProteasomePredictor)
 
 
 def test_init_invalid_model_type():
@@ -55,14 +60,13 @@ def test_init_invalid_proteasome_type():
         Pepsickle(proteasome_type="X")
 
 
-def test_init_invalid_scoring():
-    with pytest.raises(ValueError, match="scoring"):
-        Pepsickle(scoring="bad")
+def test_init_custom_scoring():
+    p = Pepsickle(scoring=score_cterm)
+    assert p.scoring is score_cterm
 
 
 def test_str():
-    p = Pepsickle()
-    s = str(p)
+    s = str(Pepsickle())
     assert "Pepsickle" in s
     assert "epitope" in s
 
@@ -85,16 +89,29 @@ def test_predict_returns_peptide_preds(predictor):
         assert isinstance(pp, PeptidePreds)
         assert len(pp.preds) == 1
         pred = pp.preds[0]
-        assert pred.kind == Kind.antigen_processing
+        assert pred.kind == Kind.proteasome_cleavage
         assert 0.0 <= pred.score <= 1.0
         assert pred.predictor_name == "pepsickle"
+
+
+def test_predict_with_flanks(predictor):
+    # With flanking context, C-terminal should get non-zero scores
+    results = predictor.predict(
+        ["SIINFEKL"],
+        n_flanks=["MFVFLVLL"],
+        c_flanks=["PLVSSQCV"],
+    )
+    pred = results[0].preds[0]
+    assert pred.n_flank == "MFVFLVLL"
+    assert pred.c_flank == "PLVSSQCV"
+    assert pred.kind == Kind.proteasome_cleavage
 
 
 def test_predict_dataframe(predictor):
     df = predictor.predict_dataframe(PEPTIDES)
     assert list(df.columns) == list(COLUMNS)
     assert len(df) == len(PEPTIDES)
-    assert (df["kind"] == "antigen_processing").all()
+    assert (df["kind"] == "proteasome_cleavage").all()
     assert (df["predictor_name"] == "pepsickle").all()
 
 
@@ -104,13 +121,12 @@ def test_predict_proteins(predictor):
     result = predictor.predict_proteins({"spike": PROTEIN})
     assert "spike" in result
     preds_list = result["spike"]
-    assert isinstance(preds_list, list)
     assert all(isinstance(pp, PeptidePreds) for pp in preds_list)
     expected_count = len(PROTEIN) - 9 + 1
     assert len(preds_list) == expected_count
     for pp in preds_list:
         pred = pp.preds[0]
-        assert pred.kind == Kind.antigen_processing
+        assert pred.kind == Kind.proteasome_cleavage
         assert pred.source_sequence_name == "spike"
         assert 0.0 <= pred.score <= 1.0
 
@@ -119,6 +135,15 @@ def test_predict_proteins_scores_vary(predictor):
     result = predictor.predict_proteins({"spike": PROTEIN})
     scores = [pp.preds[0].score for pp in result["spike"]]
     assert len(set(round(s, 4) for s in scores)) > 1
+
+
+def test_predict_proteins_with_flank_length(predictor):
+    result = predictor.predict_proteins({"spike": PROTEIN}, flank_length=5)
+    preds_list = result["spike"]
+    # Check that flanks are recorded
+    mid = preds_list[len(preds_list) // 2].preds[0]
+    assert len(mid.n_flank) > 0
+    assert len(mid.c_flank) > 0
 
 
 def test_predict_proteins_dataframe(predictor):
@@ -137,52 +162,42 @@ def test_predict_proteins_string_input(predictor):
 def test_predict_proteins_multiple_lengths(predictor):
     p = Pepsickle(default_peptide_lengths=[8, 9, 10])
     result = p.predict_proteins({"s": PROTEIN})
-    preds_list = result["s"]
     expected = sum(len(PROTEIN) - k + 1 for k in [8, 9, 10])
-    assert len(preds_list) == expected
+    assert len(result["s"]) == expected
 
 
 # -- predict_cleavage_sites --
 
 def test_predict_cleavage_sites(predictor):
     result = predictor.predict_cleavage_sites({"spike": PROTEIN})
-    assert "spike" in result
     probs = result["spike"]
     assert len(probs) == len(PROTEIN)
     assert all(0.0 <= p <= 1.0 for p in probs)
 
 
-def test_predict_cleavage_sites_string(predictor):
-    result = predictor.predict_cleavage_sites(PROTEIN)
-    assert "seq" in result
-
-
-# -- scoring methods --
+# -- scoring --
 
 def test_scoring_cterm_only():
-    p = Pepsickle(scoring="cterm")
+    p = Pepsickle(scoring=score_cterm)
     result = p.predict_proteins({"s": PROTEIN})
     probs = p.cleavage_probs(PROTEIN)
-    pp = result["s"][0]
     # First 9-mer: offset=0, c_term = probs[8]
-    assert pp.preds[0].score == pytest.approx(probs[8])
+    first = result["s"][0].preds[0]
+    assert first.score == pytest.approx(probs[8])
 
 
 def test_scoring_methods_produce_different_scores():
-    methods = ["cterm", "nterm_cterm", "cterm_max_internal",
-               "nterm_cterm_max_internal"]
-    scores_by_method = {}
-    for method in methods:
-        p = Pepsickle(scoring=method)
+    fns = [score_cterm, score_cterm_anti_max_internal,
+           score_nterm_cterm_anti_max_internal]
+    scores_by_fn = {}
+    for fn in fns:
+        p = Pepsickle(scoring=fn)
         result = p.predict_proteins({"s": PROTEIN})
-        # Use a peptide with offset > 0 so n_term is available
-        scores = [pp.preds[0].score for pp in result["s"]]
-        scores_by_method[method] = scores
-    # At least some methods should give different results
-    unique_score_lists = set(
-        tuple(round(s, 6) for s in v) for v in scores_by_method.values()
-    )
-    assert len(unique_score_lists) > 1
+        scores_by_fn[fn.__name__] = [
+            pp.preds[0].score for pp in result["s"]]
+    unique = set(
+        tuple(round(s, 6) for s in v) for v in scores_by_fn.values())
+    assert len(unique) > 1
 
 
 # -- in-vitro model --
@@ -191,9 +206,9 @@ def test_scoring_methods_produce_different_scores():
     reason="pepsickle in-vitro GB model requires older sklearn pickle format",
     raises=ModuleNotFoundError,
 )
-def test_invitro_model(predictor_invitro):
-    results = predictor_invitro.predict(PEPTIDES)
+def test_invitro_model():
+    p = Pepsickle(model_type="in-vitro", proteasome_type="C")
+    results = p.predict(PEPTIDES)
     assert len(results) == len(PEPTIDES)
     for pp in results:
-        assert pp.preds[0].kind == Kind.antigen_processing
-        assert 0.0 <= pp.preds[0].score <= 1.0
+        assert pp.preds[0].kind == Kind.proteasome_cleavage

--- a/tests/test_pepsickle.py
+++ b/tests/test_pepsickle.py
@@ -32,14 +32,17 @@ PROTEIN = "MFVFLVLLPLVSSQCVNLTTRTQLPPAYTNSFTRGVY"
 PEPTIDES = ["SIINFEKL", "GILGFVFTL", "NLVPMVATV"]
 
 
+# -- init --
+
 def test_init_defaults():
     p = Pepsickle()
     assert p.model_type == "epitope"
     assert p.proteasome_type == "C"
     assert p.threshold == 0.5
     assert p.human_only is False
-    assert p.alleles == []
     assert p.default_peptide_lengths == [9]
+    assert p.scoring == "nterm_cterm_max_internal"
+    assert not hasattr(p, "alleles")
 
 
 def test_init_invalid_model_type():
@@ -52,12 +55,27 @@ def test_init_invalid_proteasome_type():
         Pepsickle(proteasome_type="X")
 
 
+def test_init_invalid_scoring():
+    with pytest.raises(ValueError, match="scoring"):
+        Pepsickle(scoring="bad")
+
+
 def test_str():
     p = Pepsickle()
     s = str(p)
     assert "Pepsickle" in s
     assert "epitope" in s
 
+
+# -- cleavage_probs --
+
+def test_cleavage_probs(predictor):
+    probs = predictor.cleavage_probs(PROTEIN)
+    assert len(probs) == len(PROTEIN)
+    assert all(0.0 <= p <= 1.0 for p in probs)
+
+
+# -- predict --
 
 def test_predict_returns_peptide_preds(predictor):
     results = predictor.predict(PEPTIDES)
@@ -67,27 +85,20 @@ def test_predict_returns_peptide_preds(predictor):
         assert isinstance(pp, PeptidePreds)
         assert len(pp.preds) == 1
         pred = pp.preds[0]
-        assert pred.kind == Kind.proteasome_cleavage
+        assert pred.kind == Kind.antigen_processing
         assert 0.0 <= pred.score <= 1.0
         assert pred.predictor_name == "pepsickle"
-
-
-def test_predict_proteins_scores_vary(predictor):
-    # Isolated peptides lack flanking context so C-terminal scores are edge-
-    # affected.  predict_proteins on a full protein should produce varying
-    # scores across sub-peptides.
-    result = predictor.predict_proteins({"spike": PROTEIN})
-    scores = [pp.preds[0].score for pp in result["spike"]]
-    assert len(set(round(s, 4) for s in scores)) > 1
 
 
 def test_predict_dataframe(predictor):
     df = predictor.predict_dataframe(PEPTIDES)
     assert list(df.columns) == list(COLUMNS)
     assert len(df) == len(PEPTIDES)
-    assert (df["kind"] == "proteasome_cleavage").all()
+    assert (df["kind"] == "antigen_processing").all()
     assert (df["predictor_name"] == "pepsickle").all()
 
+
+# -- predict_proteins --
 
 def test_predict_proteins(predictor):
     result = predictor.predict_proteins({"spike": PROTEIN})
@@ -99,9 +110,15 @@ def test_predict_proteins(predictor):
     assert len(preds_list) == expected_count
     for pp in preds_list:
         pred = pp.preds[0]
-        assert pred.kind == Kind.proteasome_cleavage
+        assert pred.kind == Kind.antigen_processing
         assert pred.source_sequence_name == "spike"
         assert 0.0 <= pred.score <= 1.0
+
+
+def test_predict_proteins_scores_vary(predictor):
+    result = predictor.predict_proteins({"spike": PROTEIN})
+    scores = [pp.preds[0].score for pp in result["spike"]]
+    assert len(set(round(s, 4) for s in scores)) > 1
 
 
 def test_predict_proteins_dataframe(predictor):
@@ -125,22 +142,50 @@ def test_predict_proteins_multiple_lengths(predictor):
     assert len(preds_list) == expected
 
 
+# -- predict_cleavage_sites --
+
 def test_predict_cleavage_sites(predictor):
     result = predictor.predict_cleavage_sites({"spike": PROTEIN})
     assert "spike" in result
-    sites = result["spike"]
-    assert len(sites) == len(PROTEIN)
-    for pos, residue, prob in sites:
-        assert isinstance(pos, int)
-        assert pos >= 1
-        assert isinstance(residue, str)
-        assert 0.0 <= prob <= 1.0
+    probs = result["spike"]
+    assert len(probs) == len(PROTEIN)
+    assert all(0.0 <= p <= 1.0 for p in probs)
 
 
 def test_predict_cleavage_sites_string(predictor):
     result = predictor.predict_cleavage_sites(PROTEIN)
     assert "seq" in result
 
+
+# -- scoring methods --
+
+def test_scoring_cterm_only():
+    p = Pepsickle(scoring="cterm")
+    result = p.predict_proteins({"s": PROTEIN})
+    probs = p.cleavage_probs(PROTEIN)
+    pp = result["s"][0]
+    # First 9-mer: offset=0, c_term = probs[8]
+    assert pp.preds[0].score == pytest.approx(probs[8])
+
+
+def test_scoring_methods_produce_different_scores():
+    methods = ["cterm", "nterm_cterm", "cterm_max_internal",
+               "nterm_cterm_max_internal"]
+    scores_by_method = {}
+    for method in methods:
+        p = Pepsickle(scoring=method)
+        result = p.predict_proteins({"s": PROTEIN})
+        # Use a peptide with offset > 0 so n_term is available
+        scores = [pp.preds[0].score for pp in result["s"]]
+        scores_by_method[method] = scores
+    # At least some methods should give different results
+    unique_score_lists = set(
+        tuple(round(s, 6) for s in v) for v in scores_by_method.values()
+    )
+    assert len(unique_score_lists) > 1
+
+
+# -- in-vitro model --
 
 @pytest.mark.xfail(
     reason="pepsickle in-vitro GB model requires older sklearn pickle format",
@@ -150,10 +195,5 @@ def test_invitro_model(predictor_invitro):
     results = predictor_invitro.predict(PEPTIDES)
     assert len(results) == len(PEPTIDES)
     for pp in results:
-        assert pp.preds[0].kind == Kind.proteasome_cleavage
+        assert pp.preds[0].kind == Kind.antigen_processing
         assert 0.0 <= pp.preds[0].score <= 1.0
-
-
-def test_default_pred_kind():
-    p = Pepsickle()
-    assert p._default_pred_kind() == Kind.proteasome_cleavage

--- a/tests/test_pepsickle.py
+++ b/tests/test_pepsickle.py
@@ -60,8 +60,13 @@ def test_init_invalid_proteasome_type():
         Pepsickle(proteasome_type="X")
 
 
-def test_init_custom_scoring():
+def test_init_custom_scoring_callable():
     p = Pepsickle(scoring=score_cterm)
+    assert p.scoring is score_cterm
+
+
+def test_init_custom_scoring_string():
+    p = Pepsickle(scoring="cterm")
     assert p.scoring is score_cterm
 
 

--- a/tests/test_processing_predictor.py
+++ b/tests/test_processing_predictor.py
@@ -22,6 +22,8 @@ import pytest
 
 from mhctools.processing_predictor import (
     ProcessingPredictor,
+    SCORING_MODES,
+    resolve_scoring,
     score_cterm,
     score_nterm_cterm,
     score_cterm_anti_max_internal,
@@ -135,13 +137,55 @@ class TestInit:
         p = StubPredictor({}, scoring=fn)
         assert p.scoring is fn
 
-    def test_non_callable_scoring_raises(self):
-        with pytest.raises(TypeError, match="callable"):
+    def test_invalid_string_scoring_raises(self):
+        with pytest.raises(ValueError, match="Unknown scoring mode"):
             StubPredictor({}, scoring="not_a_function")
 
-    def test_non_callable_scoring_int_raises(self):
-        with pytest.raises(TypeError, match="callable"):
+    def test_string_mode_scoring(self):
+        p = StubPredictor({}, scoring="cterm")
+        assert p.scoring is score_cterm
+
+    def test_all_string_modes(self):
+        for name, fn in SCORING_MODES.items():
+            p = StubPredictor({}, scoring=name)
+            assert p.scoring is fn, name
+
+    def test_invalid_string_mode_raises(self):
+        with pytest.raises(ValueError, match="Unknown scoring mode"):
+            StubPredictor({}, scoring="bad_mode")
+
+    def test_non_string_non_callable_scoring_raises(self):
+        with pytest.raises(TypeError):
             StubPredictor({}, scoring=42)
+
+
+# ======================================================================
+# resolve_scoring()
+# ======================================================================
+
+class TestResolveScoring:
+
+    def test_none_returns_none(self):
+        assert resolve_scoring(None) is None
+
+    def test_callable_passthrough(self):
+        fn = lambda c, n, i: c
+        assert resolve_scoring(fn) is fn
+
+    def test_string_mode(self):
+        assert resolve_scoring("cterm") is score_cterm
+
+    def test_all_modes(self):
+        for name, fn in SCORING_MODES.items():
+            assert resolve_scoring(name) is fn
+
+    def test_invalid_string(self):
+        with pytest.raises(ValueError, match="Unknown scoring mode"):
+            resolve_scoring("invalid")
+
+    def test_non_string_non_callable(self):
+        with pytest.raises(TypeError):
+            resolve_scoring(42)
 
 
 # ======================================================================

--- a/tests/test_processing_predictor.py
+++ b/tests/test_processing_predictor.py
@@ -10,15 +10,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import math
 import pytest
 
-from mhctools.processing_predictor import ProcessingPredictor
+from mhctools.processing_predictor import (
+    ProcessingPredictor,
+    score_cterm,
+    score_nterm_cterm,
+    score_cterm_anti_max_internal,
+    score_cterm_anti_mean_internal,
+    score_nterm_cterm_anti_max_internal,
+    score_nterm_cterm_anti_mean_internal,
+    _geomean,
+)
+from mhctools.proteasome_predictor import ProteasomePredictor
 from mhctools.pred import Kind, PeptidePreds, COLUMNS
 
 
 class StubPredictor(ProcessingPredictor):
     """Predictor with fixed per-position cleavage probs for testing."""
+
+    def __init__(self, probs_map, **kwargs):
+        super().__init__(**kwargs)
+        self.probs_map = probs_map
+
+    def cleavage_probs(self, sequence):
+        if sequence in self.probs_map:
+            return self.probs_map[sequence]
+        return [0.5] * len(sequence)
+
+
+class StubProteasome(ProteasomePredictor):
+    """ProteasomePredictor with fixed cleavage probs."""
 
     def __init__(self, probs_map, **kwargs):
         super().__init__(**kwargs)
@@ -36,115 +58,179 @@ PROTEIN = "ABCDEFGHIJKL"
 PROBS = [0.1, 0.2, 0.8, 0.3, 0.05, 0.4, 0.1, 0.9, 0.2, 0.6, 0.3, 0.7]
 
 
-def _geomean(*values):
-    product = 1.0
-    for v in values:
-        product *= v
-    return product ** (1.0 / len(values))
-
-
 # -- init --
 
 def test_init_defaults():
     p = StubPredictor({})
     assert p.default_peptide_lengths == [9]
-    assert p.scoring == "nterm_cterm_max_internal"
+    assert p.scoring is score_nterm_cterm_anti_max_internal
     assert not hasattr(p, "alleles")
 
 
-def test_init_invalid_scoring():
-    with pytest.raises(ValueError, match="scoring"):
-        StubPredictor({}, scoring="garbage")
+def test_init_custom_scoring():
+    p = StubPredictor({}, scoring=score_cterm)
+    assert p.scoring is score_cterm
 
 
-# -- _peptide_score math --
+def test_init_lambda_scoring():
+    fn = lambda c, n, i: c
+    p = StubPredictor({}, scoring=fn)
+    assert p.scoring is fn
+
+
+def test_init_non_callable_scoring_raises():
+    with pytest.raises(TypeError, match="callable"):
+        StubPredictor({}, scoring="not_a_function")
+
+
+# -- component helpers --
+
+def test_c_term_prob():
+    assert ProcessingPredictor.c_term_prob(PROBS, 2, 4) == 0.4
+
+
+def test_n_term_prob():
+    assert ProcessingPredictor.n_term_prob(PROBS, 2, 4) == 0.2
+
+
+def test_n_term_prob_offset_zero():
+    assert ProcessingPredictor.n_term_prob(PROBS, 0, 4) is None
+
+
+def test_internal_probs():
+    assert ProcessingPredictor.internal_probs(PROBS, 2, 4) == [0.8, 0.3, 0.05]
+
+
+def test_max_internal_prob():
+    assert ProcessingPredictor.max_internal_prob(PROBS, 2, 4) == 0.8
+
+
+def test_mean_internal_prob():
+    expected = (0.8 + 0.3 + 0.05) / 3
+    assert ProcessingPredictor.mean_internal_prob(PROBS, 2, 4) == pytest.approx(expected)
+
+
+def test_max_internal_empty():
+    assert ProcessingPredictor.max_internal_prob(PROBS, 0, 1) == 0.0
+
+
+def test_mean_internal_empty():
+    assert ProcessingPredictor.mean_internal_prob(PROBS, 0, 1) == 0.0
+
+
+# -- scoring functions --
+
+class TestScoringFunctions:
+
+    def test_score_cterm(self):
+        assert score_cterm(0.4, 0.2, [0.8, 0.3, 0.05]) == 0.4
+
+    def test_score_nterm_cterm(self):
+        expected = _geomean(0.4, 0.2)
+        assert score_nterm_cterm(0.4, 0.2, [0.8]) == pytest.approx(expected)
+
+    def test_score_nterm_cterm_no_nterm(self):
+        assert score_nterm_cterm(0.4, None, [0.8]) == 0.4
+
+    def test_score_cterm_anti_max_internal(self):
+        assert score_cterm_anti_max_internal(0.4, 0.2, [0.8, 0.3, 0.05]) == \
+            pytest.approx(0.4 * (1.0 - 0.8))
+
+    def test_score_cterm_anti_mean_internal(self):
+        mean_i = (0.8 + 0.3 + 0.05) / 3
+        assert score_cterm_anti_mean_internal(0.4, 0.2, [0.8, 0.3, 0.05]) == \
+            pytest.approx(0.4 * (1.0 - mean_i))
+
+    def test_score_nterm_cterm_anti_max_internal(self):
+        expected = _geomean(0.4, 0.2, 1.0 - 0.8)
+        assert score_nterm_cterm_anti_max_internal(0.4, 0.2, [0.8, 0.3]) == \
+            pytest.approx(expected)
+
+    def test_score_nterm_cterm_anti_max_internal_no_nterm(self):
+        expected = _geomean(0.4, 1.0 - 0.8)
+        assert score_nterm_cterm_anti_max_internal(0.4, None, [0.8, 0.3]) == \
+            pytest.approx(expected)
+
+    def test_score_nterm_cterm_anti_mean_internal(self):
+        mean_i = (0.8 + 0.3) / 2
+        expected = _geomean(0.4, 0.2, 1.0 - mean_i)
+        assert score_nterm_cterm_anti_mean_internal(0.4, 0.2, [0.8, 0.3]) == \
+            pytest.approx(expected)
+
+    def test_empty_internal(self):
+        # length-1 peptide: no internal positions
+        assert score_cterm_anti_max_internal(0.4, 0.2, []) == \
+            pytest.approx(0.4 * 1.0)
+
+    def test_zero_cterm_propagates(self):
+        assert score_cterm_anti_max_internal(0.0, 0.5, [0.3]) == 0.0
+
+
+# -- _peptide_score integration --
 
 class TestPeptideScore:
-    """Test aggregation formulas on a known cleavage profile."""
 
     def _make(self, scoring):
         return StubPredictor({PROTEIN: PROBS}, scoring=scoring)
 
     def test_cterm(self):
-        p = self._make("cterm")
-        # peptide at offset=2, length=4 → CDEF → c_term = probs[5] = 0.4
+        p = self._make(score_cterm)
         assert p._peptide_score(PROBS, 2, 4) == pytest.approx(0.4)
 
     def test_nterm_cterm(self):
-        p = self._make("nterm_cterm")
-        # offset=2, length=4 → n_term=probs[1]=0.2, c_term=probs[5]=0.4
+        p = self._make(score_nterm_cterm)
         expected = _geomean(0.4, 0.2)
         assert p._peptide_score(PROBS, 2, 4) == pytest.approx(expected)
 
     def test_nterm_cterm_offset_zero(self):
-        p = self._make("nterm_cterm")
-        # offset=0 → no n_term, falls back to cterm only
-        # c_term = probs[3] = 0.3
-        assert p._peptide_score(PROBS, 0, 4) == pytest.approx(0.3)
+        p = self._make(score_nterm_cterm)
+        # offset=0 → n_term is None → falls back to cterm
+        assert p._peptide_score(PROBS, 0, 4) == pytest.approx(PROBS[3])
 
-    def test_cterm_max_internal(self):
-        p = self._make("cterm_max_internal")
-        # offset=2, length=4 → c_term=0.4, internal=[0.8, 0.3, 0.05]
-        # max_internal=0.8, anti=0.2
-        expected = _geomean(0.4, 1.0 - 0.8)
-        assert p._peptide_score(PROBS, 2, 4) == pytest.approx(expected)
-
-    def test_cterm_mean_internal(self):
-        p = self._make("cterm_mean_internal")
-        # internal=[0.8, 0.3, 0.05], mean=0.383333...
-        expected = _geomean(0.4, 1.0 - (0.8 + 0.3 + 0.05) / 3)
-        assert p._peptide_score(PROBS, 2, 4) == pytest.approx(expected)
-
-    def test_nterm_cterm_max_internal(self):
-        p = self._make("nterm_cterm_max_internal")
-        # n=0.2, c=0.4, max_internal=0.8, anti=0.2
-        expected = _geomean(0.4, 0.2, 1.0 - 0.8)
-        assert p._peptide_score(PROBS, 2, 4) == pytest.approx(expected)
-
-    def test_nterm_cterm_mean_internal(self):
-        p = self._make("nterm_cterm_mean_internal")
-        mean_i = (0.8 + 0.3 + 0.05) / 3
-        expected = _geomean(0.4, 0.2, 1.0 - mean_i)
-        assert p._peptide_score(PROBS, 2, 4) == pytest.approx(expected)
-
-    def test_length_2_no_internal(self):
-        # length=2 → internal has only 1 position (offset to offset+length-2)
-        p = self._make("cterm_max_internal")
-        # offset=3, length=2 → DEFG? No, peptide DE → internal=[probs[3]]=0.3
-        # c_term=probs[4]=0.05
-        expected = _geomean(0.05, 1.0 - 0.3)
-        assert p._peptide_score(PROBS, 3, 2) == pytest.approx(expected)
-
-    def test_zero_cterm(self):
-        p = self._make("nterm_cterm_max_internal")
-        # If c_term is 0, score should be 0
-        probs = [0.5, 0.5, 0.0]  # c_term at pos 2 = 0
-        score = p._peptide_score(probs, 0, 3)
-        assert score == pytest.approx(0.0)
+    def test_custom_scoring(self):
+        def my_scoring(c, n, internal):
+            return c * 2
+        p = self._make(my_scoring)
+        assert p._peptide_score(PROBS, 2, 4) == pytest.approx(0.8)
 
 
-# -- predict --
+# -- predict with flanking --
 
-def test_predict():
+def test_predict_no_flanks():
     stub = StubPredictor({})
     results = stub.predict(["ABCD", "EFGH"])
     assert len(results) == 2
     for pp in results:
         assert isinstance(pp, PeptidePreds)
-        assert len(pp.preds) == 1
         assert pp.preds[0].kind == Kind.antigen_processing
+        assert pp.preds[0].n_flank == ""
+        assert pp.preds[0].c_flank == ""
 
 
-def test_predict_dataframe():
+def test_predict_with_flanks():
+    # With flanking, the model sees the concatenated sequence
+    full_seq = "XXABCDYY"
+    probs_full = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
+    stub = StubPredictor({full_seq: probs_full}, scoring=score_cterm)
+    results = stub.predict(["ABCD"], n_flanks=["XX"], c_flanks=["YY"])
+    assert len(results) == 1
+    pred = results[0].preds[0]
+    assert pred.n_flank == "XX"
+    assert pred.c_flank == "YY"
+    # c_term for peptide at offset=2, length=4 → probs_full[5] = 0.6
+    assert pred.score == pytest.approx(0.6)
+
+
+def test_predict_dataframe_with_flanks():
     stub = StubPredictor({})
-    df = stub.predict_dataframe(["ABCD"], sample_name="s1")
+    df = stub.predict_dataframe(
+        ["ABCD"], n_flanks=["XX"], c_flanks=["YY"], sample_name="s1")
     assert list(df.columns) == list(COLUMNS)
-    assert len(df) == 1
-    assert df.iloc[0]["kind"] == "antigen_processing"
-    assert df.iloc[0]["sample_name"] == "s1"
+    assert df.iloc[0]["n_flank"] == "XX"
+    assert df.iloc[0]["c_flank"] == "YY"
 
 
-# -- predict_proteins --
+# -- predict_proteins with flank_length --
 
 def test_predict_proteins():
     stub = StubPredictor({PROTEIN: PROBS}, default_peptide_lengths=[4])
@@ -153,10 +239,6 @@ def test_predict_proteins():
     pp_list = result["p"]
     expected_count = len(PROTEIN) - 4 + 1
     assert len(pp_list) == expected_count
-    for pp in pp_list:
-        pred = pp.preds[0]
-        assert pred.kind == Kind.antigen_processing
-        assert pred.source_sequence_name == "p"
 
 
 def test_predict_proteins_string():
@@ -165,12 +247,37 @@ def test_predict_proteins_string():
     assert "seq" in result
 
 
+def test_predict_proteins_flank_length():
+    stub = StubPredictor({PROTEIN: PROBS}, default_peptide_lengths=[4])
+    result = stub.predict_proteins({"p": PROTEIN}, flank_length=2)
+    pp_list = result["p"]
+    # First peptide at offset=0: n_flank="" (nothing before), c_flank="EF"
+    first = pp_list[0].preds[0]
+    assert first.n_flank == ""
+    assert first.c_flank == "EF"
+    # Second peptide at offset=1: n_flank="A", c_flank="FG"
+    second = pp_list[1].preds[0]
+    assert second.n_flank == "A"
+    assert second.c_flank == "FG"
+    # Last peptide: c_flank truncated at protein end
+    last = pp_list[-1].preds[0]
+    assert last.c_flank == ""
+    assert last.n_flank == "GH"
+
+
+def test_predict_proteins_no_flank_length():
+    stub = StubPredictor({PROTEIN: PROBS}, default_peptide_lengths=[4])
+    result = stub.predict_proteins({"p": PROTEIN})
+    for pp in result["p"]:
+        assert pp.preds[0].n_flank == ""
+        assert pp.preds[0].c_flank == ""
+
+
 def test_predict_proteins_dataframe():
     stub = StubPredictor({PROTEIN: PROBS}, default_peptide_lengths=[4])
     df = stub.predict_proteins_dataframe({"p": PROTEIN}, sample_name="s1")
     assert list(df.columns) == list(COLUMNS)
     assert (df["source_sequence_name"] == "p").all()
-    assert (df["sample_name"] == "s1").all()
 
 
 # -- predict_cleavage_sites --
@@ -181,7 +288,24 @@ def test_predict_cleavage_sites():
     assert result["p"] == PROBS
 
 
-def test_predict_cleavage_sites_string():
-    stub = StubPredictor({PROTEIN: PROBS})
-    result = stub.predict_cleavage_sites(PROTEIN)
-    assert "seq" in result
+# -- ProteasomePredictor --
+
+def test_proteasome_default_scoring():
+    p = StubProteasome({PROTEIN: PROBS})
+    assert p.scoring is score_cterm_anti_max_internal
+
+
+def test_proteasome_pred_kind():
+    p = StubProteasome({PROTEIN: PROBS}, default_peptide_lengths=[4])
+    result = p.predict_proteins({"p": PROTEIN})
+    for pp in result["p"]:
+        assert pp.preds[0].kind == Kind.proteasome_cleavage
+
+
+def test_proteasome_custom_scoring():
+    p = StubProteasome({PROTEIN: PROBS}, scoring=score_cterm)
+    assert p.scoring is score_cterm
+    result = p.predict_proteins({"p": PROTEIN}, peptide_lengths=[4])
+    first = result["p"][0].preds[0]
+    # offset=0, length=4, cterm = PROBS[3] = 0.3
+    assert first.score == pytest.approx(0.3)

--- a/tests/test_processing_predictor.py
+++ b/tests/test_processing_predictor.py
@@ -10,6 +10,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Comprehensive unit tests for the antigen-processing prediction framework:
+ProcessingPredictor, ProteasomePredictor, scoring functions, component
+helpers, flanking support, and edge cases.
+"""
+
+import math
+
 import pytest
 
 from mhctools.processing_predictor import (
@@ -26,8 +34,12 @@ from mhctools.proteasome_predictor import ProteasomePredictor
 from mhctools.pred import Kind, PeptidePreds, COLUMNS
 
 
+# ======================================================================
+# Test fixtures / stubs
+# ======================================================================
+
 class StubPredictor(ProcessingPredictor):
-    """Predictor with fixed per-position cleavage probs for testing."""
+    """ProcessingPredictor with fixed per-position cleavage probs."""
 
     def __init__(self, probs_map, **kwargs):
         super().__init__(**kwargs)
@@ -57,255 +69,831 @@ PROTEIN = "ABCDEFGHIJKL"
 #          0    1    2    3    4    5    6    7    8    9   10   11
 PROBS = [0.1, 0.2, 0.8, 0.3, 0.05, 0.4, 0.1, 0.9, 0.2, 0.6, 0.3, 0.7]
 
+# A second protein for multi-protein tests
+PROTEIN2 = "MNOPQR"
+PROBS2 = [0.3, 0.5, 0.7, 0.1, 0.9, 0.4]
 
-# -- init --
+ALL_SCORING_FNS = [
+    score_cterm,
+    score_nterm_cterm,
+    score_cterm_anti_max_internal,
+    score_cterm_anti_mean_internal,
+    score_nterm_cterm_anti_max_internal,
+    score_nterm_cterm_anti_mean_internal,
+]
 
-def test_init_defaults():
+
+# ======================================================================
+# _geomean
+# ======================================================================
+
+class TestGeomean:
+
+    def test_single_value(self):
+        assert _geomean(0.5) == pytest.approx(0.5)
+
+    def test_two_values(self):
+        assert _geomean(0.25, 1.0) == pytest.approx(math.sqrt(0.25))
+
+    def test_three_values(self):
+        assert _geomean(0.8, 0.2, 0.5) == pytest.approx(
+            (0.8 * 0.2 * 0.5) ** (1.0 / 3))
+
+    def test_zero_propagates(self):
+        assert _geomean(0.0, 0.5, 0.9) == 0.0
+
+    def test_all_ones(self):
+        assert _geomean(1.0, 1.0, 1.0) == pytest.approx(1.0)
+
+
+# ======================================================================
+# ProcessingPredictor.__init__
+# ======================================================================
+
+class TestInit:
+
+    def test_defaults(self):
+        p = StubPredictor({})
+        assert p.default_peptide_lengths == [9]
+        assert p.scoring is score_nterm_cterm_anti_max_internal
+        assert not hasattr(p, "alleles")
+
+    def test_custom_peptide_lengths_list(self):
+        p = StubPredictor({}, default_peptide_lengths=[8, 10, 11])
+        assert p.default_peptide_lengths == [8, 10, 11]
+
+    def test_peptide_lengths_int_coerced_to_list(self):
+        p = StubPredictor({}, default_peptide_lengths=10)
+        assert p.default_peptide_lengths == [10]
+
+    def test_custom_scoring(self):
+        p = StubPredictor({}, scoring=score_cterm)
+        assert p.scoring is score_cterm
+
+    def test_lambda_scoring(self):
+        fn = lambda c, n, i: c
+        p = StubPredictor({}, scoring=fn)
+        assert p.scoring is fn
+
+    def test_non_callable_scoring_raises(self):
+        with pytest.raises(TypeError, match="callable"):
+            StubPredictor({}, scoring="not_a_function")
+
+    def test_non_callable_scoring_int_raises(self):
+        with pytest.raises(TypeError, match="callable"):
+            StubPredictor({}, scoring=42)
+
+
+# ======================================================================
+# __str__ / __repr__
+# ======================================================================
+
+class TestRepr:
+
+    def test_str_contains_class_name(self):
+        p = StubPredictor({})
+        assert "StubPredictor" in str(p)
+
+    def test_str_contains_scoring_name(self):
+        p = StubPredictor({}, scoring=score_cterm)
+        assert "score_cterm" in str(p)
+
+    def test_str_lambda_scoring(self):
+        p = StubPredictor({}, scoring=lambda c, n, i: c)
+        s = str(p)
+        assert "StubPredictor" in s
+        # lambda has no __name__ in the usual sense, should still work
+        assert "lambda" in s or "function" in s or "<" in s
+
+    def test_repr_equals_str(self):
+        p = StubPredictor({})
+        assert repr(p) == str(p)
+
+
+# ======================================================================
+# Abstract method
+# ======================================================================
+
+def test_cleavage_probs_abstract():
+    with pytest.raises(NotImplementedError, match="ProcessingPredictor"):
+        ProcessingPredictor().cleavage_probs("ABC")
+
+
+# ======================================================================
+# _pred_kind / _predictor_name
+# ======================================================================
+
+def test_processing_predictor_pred_kind():
     p = StubPredictor({})
-    assert p.default_peptide_lengths == [9]
-    assert p.scoring is score_nterm_cterm_anti_max_internal
-    assert not hasattr(p, "alleles")
+    assert p._pred_kind() == Kind.antigen_processing
 
 
-def test_init_custom_scoring():
-    p = StubPredictor({}, scoring=score_cterm)
-    assert p.scoring is score_cterm
+def test_predictor_name_default():
+    p = StubPredictor({})
+    assert p._predictor_name() == "stubpredictor"
 
 
-def test_init_lambda_scoring():
-    fn = lambda c, n, i: c
-    p = StubPredictor({}, scoring=fn)
-    assert p.scoring is fn
+# ======================================================================
+# Component helpers
+# ======================================================================
+
+class TestComponentHelpers:
+    """Test c_term_prob, n_term_prob, internal_probs, max/mean variants."""
+
+    # -- c_term_prob --
+
+    def test_c_term_first_peptide(self):
+        # offset=0, length=4 → probs[3]
+        assert ProcessingPredictor.c_term_prob(PROBS, 0, 4) == 0.3
+
+    def test_c_term_middle_peptide(self):
+        # offset=2, length=4 → probs[5]
+        assert ProcessingPredictor.c_term_prob(PROBS, 2, 4) == 0.4
+
+    def test_c_term_last_peptide(self):
+        # offset=8, length=4 → probs[11]
+        assert ProcessingPredictor.c_term_prob(PROBS, 8, 4) == 0.7
+
+    def test_c_term_length_1(self):
+        assert ProcessingPredictor.c_term_prob(PROBS, 5, 1) == 0.4
+
+    # -- n_term_prob --
+
+    def test_n_term_offset_zero(self):
+        assert ProcessingPredictor.n_term_prob(PROBS, 0, 4) is None
+
+    def test_n_term_offset_one(self):
+        # offset=1 → probs[0]
+        assert ProcessingPredictor.n_term_prob(PROBS, 1, 4) == 0.1
+
+    def test_n_term_middle(self):
+        # offset=5 → probs[4]
+        assert ProcessingPredictor.n_term_prob(PROBS, 5, 3) == 0.05
+
+    # -- internal_probs --
+
+    def test_internal_probs_normal(self):
+        # offset=2, length=4 → probs[2:5] = [0.8, 0.3, 0.05]
+        assert ProcessingPredictor.internal_probs(PROBS, 2, 4) == [0.8, 0.3, 0.05]
+
+    def test_internal_probs_length_1(self):
+        # length=1 → empty (no positions before c_term)
+        assert ProcessingPredictor.internal_probs(PROBS, 3, 1) == []
+
+    def test_internal_probs_length_2(self):
+        # offset=3, length=2 → probs[3:4] = [0.3]
+        assert ProcessingPredictor.internal_probs(PROBS, 3, 2) == [0.3]
+
+    def test_internal_probs_long_peptide(self):
+        # offset=0, length=6 → probs[0:5]
+        assert ProcessingPredictor.internal_probs(PROBS, 0, 6) == \
+            [0.1, 0.2, 0.8, 0.3, 0.05]
+
+    # -- max_internal_prob --
+
+    def test_max_internal_normal(self):
+        assert ProcessingPredictor.max_internal_prob(PROBS, 2, 4) == 0.8
+
+    def test_max_internal_empty(self):
+        assert ProcessingPredictor.max_internal_prob(PROBS, 0, 1) == 0.0
+
+    def test_max_internal_single(self):
+        assert ProcessingPredictor.max_internal_prob(PROBS, 3, 2) == 0.3
+
+    # -- mean_internal_prob --
+
+    def test_mean_internal_normal(self):
+        expected = (0.8 + 0.3 + 0.05) / 3
+        assert ProcessingPredictor.mean_internal_prob(PROBS, 2, 4) == \
+            pytest.approx(expected)
+
+    def test_mean_internal_empty(self):
+        assert ProcessingPredictor.mean_internal_prob(PROBS, 0, 1) == 0.0
+
+    def test_mean_internal_single(self):
+        assert ProcessingPredictor.mean_internal_prob(PROBS, 3, 2) == \
+            pytest.approx(0.3)
 
 
-def test_init_non_callable_scoring_raises():
-    with pytest.raises(TypeError, match="callable"):
-        StubPredictor({}, scoring="not_a_function")
-
-
-# -- component helpers --
-
-def test_c_term_prob():
-    assert ProcessingPredictor.c_term_prob(PROBS, 2, 4) == 0.4
-
-
-def test_n_term_prob():
-    assert ProcessingPredictor.n_term_prob(PROBS, 2, 4) == 0.2
-
-
-def test_n_term_prob_offset_zero():
-    assert ProcessingPredictor.n_term_prob(PROBS, 0, 4) is None
-
-
-def test_internal_probs():
-    assert ProcessingPredictor.internal_probs(PROBS, 2, 4) == [0.8, 0.3, 0.05]
-
-
-def test_max_internal_prob():
-    assert ProcessingPredictor.max_internal_prob(PROBS, 2, 4) == 0.8
-
-
-def test_mean_internal_prob():
-    expected = (0.8 + 0.3 + 0.05) / 3
-    assert ProcessingPredictor.mean_internal_prob(PROBS, 2, 4) == pytest.approx(expected)
-
-
-def test_max_internal_empty():
-    assert ProcessingPredictor.max_internal_prob(PROBS, 0, 1) == 0.0
-
-
-def test_mean_internal_empty():
-    assert ProcessingPredictor.mean_internal_prob(PROBS, 0, 1) == 0.0
-
-
-# -- scoring functions --
+# ======================================================================
+# Built-in scoring functions
+# ======================================================================
 
 class TestScoringFunctions:
+    """Test each scoring function's formula directly."""
 
-    def test_score_cterm(self):
-        assert score_cterm(0.4, 0.2, [0.8, 0.3, 0.05]) == 0.4
+    # -- score_cterm --
 
-    def test_score_nterm_cterm(self):
+    def test_cterm_ignores_nterm_and_internal(self):
+        assert score_cterm(0.7, 0.3, [0.5, 0.6]) == 0.7
+
+    def test_cterm_zero(self):
+        assert score_cterm(0.0, 0.9, [0.1]) == 0.0
+
+    def test_cterm_one(self):
+        assert score_cterm(1.0, 0.0, []) == 1.0
+
+    # -- score_nterm_cterm --
+
+    def test_nterm_cterm_both_present(self):
         expected = _geomean(0.4, 0.2)
         assert score_nterm_cterm(0.4, 0.2, [0.8]) == pytest.approx(expected)
 
-    def test_score_nterm_cterm_no_nterm(self):
+    def test_nterm_cterm_none_nterm(self):
         assert score_nterm_cterm(0.4, None, [0.8]) == 0.4
 
-    def test_score_cterm_anti_max_internal(self):
-        assert score_cterm_anti_max_internal(0.4, 0.2, [0.8, 0.3, 0.05]) == \
-            pytest.approx(0.4 * (1.0 - 0.8))
+    def test_nterm_cterm_equal(self):
+        # geomean(x, x) == x
+        assert score_nterm_cterm(0.6, 0.6, []) == pytest.approx(0.6)
 
-    def test_score_cterm_anti_mean_internal(self):
+    # -- score_cterm_anti_max_internal --
+
+    def test_cterm_anti_max_internal(self):
+        assert score_cterm_anti_max_internal(0.4, 0.2, [0.8, 0.3, 0.05]) == \
+            pytest.approx(0.4 * 0.2)
+
+    def test_cterm_anti_max_internal_empty(self):
+        assert score_cterm_anti_max_internal(0.4, 0.2, []) == \
+            pytest.approx(0.4)
+
+    def test_cterm_anti_max_internal_single(self):
+        assert score_cterm_anti_max_internal(0.5, None, [0.3]) == \
+            pytest.approx(0.5 * 0.7)
+
+    def test_cterm_anti_max_internal_all_one_internal(self):
+        # max internal = 1.0 → anti = 0 → score = 0
+        assert score_cterm_anti_max_internal(0.9, None, [1.0, 0.5]) == 0.0
+
+    # -- score_cterm_anti_mean_internal --
+
+    def test_cterm_anti_mean_internal(self):
         mean_i = (0.8 + 0.3 + 0.05) / 3
         assert score_cterm_anti_mean_internal(0.4, 0.2, [0.8, 0.3, 0.05]) == \
             pytest.approx(0.4 * (1.0 - mean_i))
 
-    def test_score_nterm_cterm_anti_max_internal(self):
+    def test_cterm_anti_mean_internal_empty(self):
+        assert score_cterm_anti_mean_internal(0.5, 0.3, []) == \
+            pytest.approx(0.5)
+
+    def test_cterm_anti_mean_internal_uniform(self):
+        # All internal probs equal → mean == that value
+        assert score_cterm_anti_mean_internal(0.6, None, [0.2, 0.2, 0.2]) == \
+            pytest.approx(0.6 * 0.8)
+
+    # -- score_nterm_cterm_anti_max_internal --
+
+    def test_nterm_cterm_anti_max_full(self):
         expected = _geomean(0.4, 0.2, 1.0 - 0.8)
         assert score_nterm_cterm_anti_max_internal(0.4, 0.2, [0.8, 0.3]) == \
             pytest.approx(expected)
 
-    def test_score_nterm_cterm_anti_max_internal_no_nterm(self):
+    def test_nterm_cterm_anti_max_no_nterm(self):
         expected = _geomean(0.4, 1.0 - 0.8)
         assert score_nterm_cterm_anti_max_internal(0.4, None, [0.8, 0.3]) == \
             pytest.approx(expected)
 
-    def test_score_nterm_cterm_anti_mean_internal(self):
+    def test_nterm_cterm_anti_max_empty_internal(self):
+        expected = _geomean(0.4, 0.2, 1.0)  # anti = 1.0
+        assert score_nterm_cterm_anti_max_internal(0.4, 0.2, []) == \
+            pytest.approx(expected)
+
+    # -- score_nterm_cterm_anti_mean_internal --
+
+    def test_nterm_cterm_anti_mean_full(self):
         mean_i = (0.8 + 0.3) / 2
         expected = _geomean(0.4, 0.2, 1.0 - mean_i)
         assert score_nterm_cterm_anti_mean_internal(0.4, 0.2, [0.8, 0.3]) == \
             pytest.approx(expected)
 
-    def test_empty_internal(self):
-        # length-1 peptide: no internal positions
-        assert score_cterm_anti_max_internal(0.4, 0.2, []) == \
-            pytest.approx(0.4 * 1.0)
+    def test_nterm_cterm_anti_mean_no_nterm(self):
+        mean_i = (0.8 + 0.3) / 2
+        expected = _geomean(0.4, 1.0 - mean_i)
+        assert score_nterm_cterm_anti_mean_internal(0.4, None, [0.8, 0.3]) == \
+            pytest.approx(expected)
 
-    def test_zero_cterm_propagates(self):
-        assert score_cterm_anti_max_internal(0.0, 0.5, [0.3]) == 0.0
+    def test_nterm_cterm_anti_mean_empty_internal(self):
+        expected = _geomean(0.4, 0.2, 1.0)
+        assert score_nterm_cterm_anti_mean_internal(0.4, 0.2, []) == \
+            pytest.approx(expected)
+
+    # -- cross-function edge cases --
+
+    def test_zero_cterm_propagates_through_all(self):
+        for fn in ALL_SCORING_FNS:
+            assert fn(0.0, 0.5, [0.3]) == 0.0, fn.__name__
+
+    def test_all_zeros(self):
+        for fn in ALL_SCORING_FNS:
+            assert fn(0.0, 0.0, [0.0]) == 0.0, fn.__name__
+
+    def test_perfect_scores(self):
+        # c=1, n=1, no internal → should be 1.0 for all
+        for fn in ALL_SCORING_FNS:
+            assert fn(1.0, 1.0, []) == pytest.approx(1.0), fn.__name__
 
 
-# -- _peptide_score integration --
+# ======================================================================
+# Scoring monotonicity
+# ======================================================================
+
+class TestScoringMonotonicity:
+    """Higher c_term should raise scores; higher internal should lower scores."""
+
+    @pytest.mark.parametrize("fn", ALL_SCORING_FNS, ids=lambda f: f.__name__)
+    def test_higher_cterm_gives_higher_score(self, fn):
+        low = fn(0.2, 0.5, [0.3])
+        high = fn(0.8, 0.5, [0.3])
+        assert high >= low
+
+    @pytest.mark.parametrize("fn", [
+        score_cterm_anti_max_internal,
+        score_cterm_anti_mean_internal,
+        score_nterm_cterm_anti_max_internal,
+        score_nterm_cterm_anti_mean_internal,
+    ], ids=lambda f: f.__name__)
+    def test_higher_internal_gives_lower_score(self, fn):
+        low_internal = fn(0.5, 0.5, [0.1])
+        high_internal = fn(0.5, 0.5, [0.9])
+        assert low_internal >= high_internal
+
+
+# ======================================================================
+# _peptide_score integration
+# ======================================================================
 
 class TestPeptideScore:
+    """Verify _peptide_score extracts components and delegates correctly."""
 
     def _make(self, scoring):
         return StubPredictor({PROTEIN: PROBS}, scoring=scoring)
 
-    def test_cterm(self):
-        p = self._make(score_cterm)
-        assert p._peptide_score(PROBS, 2, 4) == pytest.approx(0.4)
+    @pytest.mark.parametrize("fn", ALL_SCORING_FNS, ids=lambda f: f.__name__)
+    def test_all_scoring_functions_at_offset_2_length_4(self, fn):
+        p = self._make(fn)
+        # offset=2, length=4
+        # c=PROBS[5]=0.4, n=PROBS[1]=0.2, internal=PROBS[2:5]=[0.8,0.3,0.05]
+        actual = p._peptide_score(PROBS, 2, 4)
+        expected = fn(0.4, 0.2, [0.8, 0.3, 0.05])
+        assert actual == pytest.approx(expected)
 
-    def test_nterm_cterm(self):
-        p = self._make(score_nterm_cterm)
-        expected = _geomean(0.4, 0.2)
-        assert p._peptide_score(PROBS, 2, 4) == pytest.approx(expected)
-
-    def test_nterm_cterm_offset_zero(self):
-        p = self._make(score_nterm_cterm)
-        # offset=0 → n_term is None → falls back to cterm
-        assert p._peptide_score(PROBS, 0, 4) == pytest.approx(PROBS[3])
+    @pytest.mark.parametrize("fn", ALL_SCORING_FNS, ids=lambda f: f.__name__)
+    def test_all_scoring_functions_at_offset_0(self, fn):
+        p = self._make(fn)
+        # offset=0, length=4 → c=PROBS[3]=0.3, n=None, internal=[0.1,0.2,0.8]
+        actual = p._peptide_score(PROBS, 0, 4)
+        expected = fn(0.3, None, [0.1, 0.2, 0.8])
+        assert actual == pytest.approx(expected)
 
     def test_custom_scoring(self):
         def my_scoring(c, n, internal):
-            return c * 2
+            return c + (n or 0) + sum(internal)
         p = self._make(my_scoring)
-        assert p._peptide_score(PROBS, 2, 4) == pytest.approx(0.8)
+        # offset=2, length=4: c=0.4, n=0.2, internal=[0.8,0.3,0.05]
+        assert p._peptide_score(PROBS, 2, 4) == pytest.approx(
+            0.4 + 0.2 + 0.8 + 0.3 + 0.05)
+
+    def test_length_1_peptide(self):
+        p = self._make(score_cterm_anti_max_internal)
+        # offset=5, length=1 → c=0.4, internal=[]
+        # score = 0.4 * (1 - 0) = 0.4
+        assert p._peptide_score(PROBS, 5, 1) == pytest.approx(0.4)
 
 
-# -- predict with flanking --
+# ======================================================================
+# predict()
+# ======================================================================
 
-def test_predict_no_flanks():
-    stub = StubPredictor({})
-    results = stub.predict(["ABCD", "EFGH"])
-    assert len(results) == 2
-    for pp in results:
-        assert isinstance(pp, PeptidePreds)
-        assert pp.preds[0].kind == Kind.antigen_processing
-        assert pp.preds[0].n_flank == ""
-        assert pp.preds[0].c_flank == ""
+class TestPredict:
 
+    def test_basic(self):
+        stub = StubPredictor({})
+        results = stub.predict(["ABCD", "EFGH"])
+        assert len(results) == 2
+        for pp in results:
+            assert isinstance(pp, PeptidePreds)
+            assert len(pp.preds) == 1
+            assert pp.preds[0].kind == Kind.antigen_processing
+            assert pp.preds[0].predictor_name == "stubpredictor"
 
-def test_predict_with_flanks():
-    # With flanking, the model sees the concatenated sequence
-    full_seq = "XXABCDYY"
-    probs_full = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
-    stub = StubPredictor({full_seq: probs_full}, scoring=score_cterm)
-    results = stub.predict(["ABCD"], n_flanks=["XX"], c_flanks=["YY"])
-    assert len(results) == 1
-    pred = results[0].preds[0]
-    assert pred.n_flank == "XX"
-    assert pred.c_flank == "YY"
-    # c_term for peptide at offset=2, length=4 → probs_full[5] = 0.6
-    assert pred.score == pytest.approx(0.6)
+    def test_empty_list(self):
+        stub = StubPredictor({})
+        results = stub.predict([])
+        assert results == []
 
+    def test_no_flanks_records_empty_strings(self):
+        stub = StubPredictor({})
+        results = stub.predict(["ABCD"])
+        pred = results[0].preds[0]
+        assert pred.n_flank == ""
+        assert pred.c_flank == ""
 
-def test_predict_dataframe_with_flanks():
-    stub = StubPredictor({})
-    df = stub.predict_dataframe(
-        ["ABCD"], n_flanks=["XX"], c_flanks=["YY"], sample_name="s1")
-    assert list(df.columns) == list(COLUMNS)
-    assert df.iloc[0]["n_flank"] == "XX"
-    assert df.iloc[0]["c_flank"] == "YY"
+    def test_with_both_flanks(self):
+        full_seq = "XXABCDYY"
+        probs = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
+        stub = StubPredictor({full_seq: probs}, scoring=score_cterm)
+        results = stub.predict(["ABCD"], n_flanks=["XX"], c_flanks=["YY"])
+        pred = results[0].preds[0]
+        assert pred.n_flank == "XX"
+        assert pred.c_flank == "YY"
+        assert pred.peptide == "ABCD"
+        # c_term for peptide at offset=2, length=4 → probs[5] = 0.6
+        assert pred.score == pytest.approx(0.6)
 
+    def test_with_only_n_flanks(self):
+        full_seq = "XXABCD"
+        probs = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]
+        stub = StubPredictor({full_seq: probs}, scoring=score_cterm)
+        results = stub.predict(["ABCD"], n_flanks=["XX"])
+        pred = results[0].preds[0]
+        assert pred.n_flank == "XX"
+        assert pred.c_flank == ""
+        # c_term at offset=2, length=4 → probs[5] = 0.6
+        assert pred.score == pytest.approx(0.6)
 
-# -- predict_proteins with flank_length --
+    def test_with_only_c_flanks(self):
+        full_seq = "ABCDYY"
+        probs = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6]
+        stub = StubPredictor({full_seq: probs}, scoring=score_cterm)
+        results = stub.predict(["ABCD"], c_flanks=["YY"])
+        pred = results[0].preds[0]
+        assert pred.n_flank == ""
+        assert pred.c_flank == "YY"
+        # c_term at offset=0, length=4 → probs[3] = 0.4
+        assert pred.score == pytest.approx(0.4)
 
-def test_predict_proteins():
-    stub = StubPredictor({PROTEIN: PROBS}, default_peptide_lengths=[4])
-    result = stub.predict_proteins({"p": PROTEIN})
-    assert "p" in result
-    pp_list = result["p"]
-    expected_count = len(PROTEIN) - 4 + 1
-    assert len(pp_list) == expected_count
+    def test_flanks_change_nterm_availability(self):
+        """With n_flank, the scoring function receives a non-None n_term."""
+        calls = []
 
+        def spy_scoring(c, n, internal):
+            calls.append((c, n, internal))
+            return c
 
-def test_predict_proteins_string():
-    stub = StubPredictor({PROTEIN: PROBS}, default_peptide_lengths=[4])
-    result = stub.predict_proteins(PROTEIN)
-    assert "seq" in result
+        # Without flank
+        stub = StubPredictor({}, scoring=spy_scoring)
+        stub.predict(["ABCD"])
+        assert calls[-1][1] is None  # n_term is None
 
+        # With flank
+        stub.predict(["ABCD"], n_flanks=["X"])
+        assert calls[-1][1] is not None  # n_term is set
 
-def test_predict_proteins_flank_length():
-    stub = StubPredictor({PROTEIN: PROBS}, default_peptide_lengths=[4])
-    result = stub.predict_proteins({"p": PROTEIN}, flank_length=2)
-    pp_list = result["p"]
-    # First peptide at offset=0: n_flank="" (nothing before), c_flank="EF"
-    first = pp_list[0].preds[0]
-    assert first.n_flank == ""
-    assert first.c_flank == "EF"
-    # Second peptide at offset=1: n_flank="A", c_flank="FG"
-    second = pp_list[1].preds[0]
-    assert second.n_flank == "A"
-    assert second.c_flank == "FG"
-    # Last peptide: c_flank truncated at protein end
-    last = pp_list[-1].preds[0]
-    assert last.c_flank == ""
-    assert last.n_flank == "GH"
+    def test_multiple_peptides_with_flanks(self):
+        stub = StubPredictor({}, scoring=score_cterm)
+        results = stub.predict(
+            ["ABC", "DEF"],
+            n_flanks=["X", "YY"],
+            c_flanks=["Z", "WW"],
+        )
+        assert len(results) == 2
+        assert results[0].preds[0].n_flank == "X"
+        assert results[0].preds[0].c_flank == "Z"
+        assert results[1].preds[0].n_flank == "YY"
+        assert results[1].preds[0].c_flank == "WW"
 
-
-def test_predict_proteins_no_flank_length():
-    stub = StubPredictor({PROTEIN: PROBS}, default_peptide_lengths=[4])
-    result = stub.predict_proteins({"p": PROTEIN})
-    for pp in result["p"]:
-        assert pp.preds[0].n_flank == ""
-        assert pp.preds[0].c_flank == ""
-
-
-def test_predict_proteins_dataframe():
-    stub = StubPredictor({PROTEIN: PROBS}, default_peptide_lengths=[4])
-    df = stub.predict_proteins_dataframe({"p": PROTEIN}, sample_name="s1")
-    assert list(df.columns) == list(COLUMNS)
-    assert (df["source_sequence_name"] == "p").all()
-
-
-# -- predict_cleavage_sites --
-
-def test_predict_cleavage_sites():
-    stub = StubPredictor({PROTEIN: PROBS})
-    result = stub.predict_cleavage_sites({"p": PROTEIN})
-    assert result["p"] == PROBS
-
-
-# -- ProteasomePredictor --
-
-def test_proteasome_default_scoring():
-    p = StubProteasome({PROTEIN: PROBS})
-    assert p.scoring is score_cterm_anti_max_internal
-
-
-def test_proteasome_pred_kind():
-    p = StubProteasome({PROTEIN: PROBS}, default_peptide_lengths=[4])
-    result = p.predict_proteins({"p": PROTEIN})
-    for pp in result["p"]:
-        assert pp.preds[0].kind == Kind.proteasome_cleavage
+    def test_score_uses_scoring_function(self):
+        """Verify the full chain: probs → components → scoring → Pred."""
+        probs = [0.1, 0.2, 0.3, 0.4, 0.5]
+        stub = StubPredictor({"ABCDE": probs}, scoring=score_cterm_anti_max_internal)
+        results = stub.predict(["ABCDE"])
+        pred = results[0].preds[0]
+        # offset=0, length=5 → c=probs[4]=0.5, internal=probs[0:4]=[0.1,0.2,0.3,0.4]
+        # max_internal = 0.4, score = 0.5 * (1 - 0.4) = 0.3
+        assert pred.score == pytest.approx(0.3)
 
 
-def test_proteasome_custom_scoring():
-    p = StubProteasome({PROTEIN: PROBS}, scoring=score_cterm)
-    assert p.scoring is score_cterm
-    result = p.predict_proteins({"p": PROTEIN}, peptide_lengths=[4])
-    first = result["p"][0].preds[0]
-    # offset=0, length=4, cterm = PROBS[3] = 0.3
-    assert first.score == pytest.approx(0.3)
+# ======================================================================
+# predict_dataframe()
+# ======================================================================
+
+class TestPredictDataframe:
+
+    def test_basic(self):
+        stub = StubPredictor({})
+        df = stub.predict_dataframe(["ABCD"])
+        assert list(df.columns) == list(COLUMNS)
+        assert len(df) == 1
+        assert df.iloc[0]["kind"] == "antigen_processing"
+
+    def test_sample_name(self):
+        stub = StubPredictor({})
+        df = stub.predict_dataframe(["ABCD"], sample_name="s1")
+        assert df.iloc[0]["sample_name"] == "s1"
+
+    def test_with_flanks_recorded(self):
+        stub = StubPredictor({})
+        df = stub.predict_dataframe(
+            ["ABCD"], n_flanks=["XX"], c_flanks=["YY"], sample_name="s1")
+        assert df.iloc[0]["n_flank"] == "XX"
+        assert df.iloc[0]["c_flank"] == "YY"
+
+    def test_empty_input(self):
+        stub = StubPredictor({})
+        df = stub.predict_dataframe([])
+        assert list(df.columns) == list(COLUMNS)
+        assert len(df) == 0
+
+    def test_multiple_peptides(self):
+        stub = StubPredictor({})
+        df = stub.predict_dataframe(["ABC", "DEF", "GHI"])
+        assert len(df) == 3
+        assert list(df["peptide"]) == ["ABC", "DEF", "GHI"]
+
+
+# ======================================================================
+# predict_proteins()
+# ======================================================================
+
+class TestPredictProteins:
+
+    def test_basic(self):
+        stub = StubPredictor({PROTEIN: PROBS}, default_peptide_lengths=[4])
+        result = stub.predict_proteins({"p": PROTEIN})
+        assert "p" in result
+        pp_list = result["p"]
+        expected_count = len(PROTEIN) - 4 + 1  # 9
+        assert len(pp_list) == expected_count
+
+    def test_peptide_strings_correct(self):
+        stub = StubPredictor({PROTEIN: PROBS}, default_peptide_lengths=[4])
+        result = stub.predict_proteins({"p": PROTEIN})
+        peptides = [pp.preds[0].peptide for pp in result["p"]]
+        expected = [PROTEIN[i:i+4] for i in range(len(PROTEIN) - 3)]
+        assert peptides == expected
+
+    def test_offsets_correct(self):
+        stub = StubPredictor({PROTEIN: PROBS}, default_peptide_lengths=[4])
+        result = stub.predict_proteins({"p": PROTEIN})
+        offsets = [pp.preds[0].offset for pp in result["p"]]
+        assert offsets == list(range(len(PROTEIN) - 3))
+
+    def test_source_sequence_name(self):
+        stub = StubPredictor({PROTEIN: PROBS}, default_peptide_lengths=[4])
+        result = stub.predict_proteins({"myprotein": PROTEIN})
+        for pp in result["myprotein"]:
+            assert pp.preds[0].source_sequence_name == "myprotein"
+
+    def test_scores_match_manual_computation(self):
+        stub = StubPredictor({PROTEIN: PROBS},
+                             default_peptide_lengths=[4],
+                             scoring=score_cterm)
+        result = stub.predict_proteins({"p": PROTEIN})
+        for pp in result["p"]:
+            pred = pp.preds[0]
+            # cterm score = PROBS[offset + 4 - 1]
+            assert pred.score == pytest.approx(PROBS[pred.offset + 3])
+
+    def test_string_input(self):
+        stub = StubPredictor({PROTEIN: PROBS}, default_peptide_lengths=[4])
+        result = stub.predict_proteins(PROTEIN)
+        assert "seq" in result
+        assert len(result["seq"]) == len(PROTEIN) - 3
+
+    def test_list_input(self):
+        stub = StubPredictor({PROTEIN: PROBS}, default_peptide_lengths=[4])
+        result = stub.predict_proteins([PROTEIN])
+        assert PROTEIN in result
+
+    def test_multiple_proteins(self):
+        stub = StubPredictor(
+            {PROTEIN: PROBS, PROTEIN2: PROBS2},
+            default_peptide_lengths=[3])
+        result = stub.predict_proteins({"a": PROTEIN, "b": PROTEIN2})
+        assert len(result["a"]) == len(PROTEIN) - 2
+        assert len(result["b"]) == len(PROTEIN2) - 2
+
+    def test_multiple_peptide_lengths(self):
+        stub = StubPredictor({PROTEIN: PROBS},
+                             default_peptide_lengths=[3, 4, 5])
+        result = stub.predict_proteins({"p": PROTEIN})
+        expected = sum(len(PROTEIN) - k + 1 for k in [3, 4, 5])
+        assert len(result["p"]) == expected
+
+    def test_peptide_lengths_override(self):
+        stub = StubPredictor({PROTEIN: PROBS}, default_peptide_lengths=[9])
+        result = stub.predict_proteins({"p": PROTEIN}, peptide_lengths=[3])
+        assert len(result["p"]) == len(PROTEIN) - 2
+
+    # -- flank_length --
+
+    def test_flank_length_zero_no_flanks(self):
+        stub = StubPredictor({PROTEIN: PROBS}, default_peptide_lengths=[4])
+        result = stub.predict_proteins({"p": PROTEIN}, flank_length=0)
+        for pp in result["p"]:
+            assert pp.preds[0].n_flank == ""
+            assert pp.preds[0].c_flank == ""
+
+    def test_flank_length_records_flanks(self):
+        stub = StubPredictor({PROTEIN: PROBS}, default_peptide_lengths=[4])
+        result = stub.predict_proteins({"p": PROTEIN}, flank_length=2)
+        pp_list = result["p"]
+
+        # First peptide (offset=0): no n_flank, c_flank="EF"
+        first = pp_list[0].preds[0]
+        assert first.n_flank == ""
+        assert first.c_flank == "EF"
+
+        # Second peptide (offset=1): n_flank="A", c_flank="FG"
+        second = pp_list[1].preds[0]
+        assert second.n_flank == "A"
+        assert second.c_flank == "FG"
+
+        # Third peptide (offset=2): n_flank="AB", c_flank="GH"
+        third = pp_list[2].preds[0]
+        assert third.n_flank == "AB"
+        assert third.c_flank == "GH"
+
+        # Last peptide (offset=8): n_flank="GH", c_flank=""
+        last = pp_list[-1].preds[0]
+        assert last.n_flank == "GH"
+        assert last.c_flank == ""
+
+    def test_flank_length_does_not_change_scores(self):
+        """flank_length is cosmetic — scores come from the full protein."""
+        stub = StubPredictor({PROTEIN: PROBS}, default_peptide_lengths=[4])
+        without = stub.predict_proteins({"p": PROTEIN}, flank_length=0)
+        with_flanks = stub.predict_proteins({"p": PROTEIN}, flank_length=5)
+        scores_a = [pp.preds[0].score for pp in without["p"]]
+        scores_b = [pp.preds[0].score for pp in with_flanks["p"]]
+        for a, b in zip(scores_a, scores_b):
+            assert a == pytest.approx(b)
+
+
+# ======================================================================
+# predict_proteins_dataframe()
+# ======================================================================
+
+class TestPredictProteinsDataframe:
+
+    def test_basic(self):
+        stub = StubPredictor({PROTEIN: PROBS}, default_peptide_lengths=[4])
+        df = stub.predict_proteins_dataframe({"p": PROTEIN}, sample_name="s1")
+        assert list(df.columns) == list(COLUMNS)
+        assert (df["source_sequence_name"] == "p").all()
+        assert (df["sample_name"] == "s1").all()
+
+    def test_with_flank_length(self):
+        stub = StubPredictor({PROTEIN: PROBS}, default_peptide_lengths=[4])
+        df = stub.predict_proteins_dataframe(
+            {"p": PROTEIN}, flank_length=3, sample_name="s1")
+        # Middle peptides should have non-empty flanks
+        mid = df.iloc[len(df) // 2]
+        assert len(mid["n_flank"]) > 0
+        assert len(mid["c_flank"]) > 0
+
+    def test_empty_protein(self):
+        stub = StubPredictor({}, default_peptide_lengths=[4])
+        df = stub.predict_proteins_dataframe({"p": "AB"})
+        assert list(df.columns) == list(COLUMNS)
+        assert len(df) == 0
+
+
+# ======================================================================
+# predict_cleavage_sites()
+# ======================================================================
+
+class TestPredictCleavageSites:
+
+    def test_dict_input(self):
+        stub = StubPredictor({PROTEIN: PROBS})
+        result = stub.predict_cleavage_sites({"p": PROTEIN})
+        assert result["p"] == PROBS
+
+    def test_string_input(self):
+        stub = StubPredictor({PROTEIN: PROBS})
+        result = stub.predict_cleavage_sites(PROTEIN)
+        assert "seq" in result
+        assert result["seq"] == PROBS
+
+    def test_multiple_sequences(self):
+        stub = StubPredictor({PROTEIN: PROBS, PROTEIN2: PROBS2})
+        result = stub.predict_cleavage_sites({"a": PROTEIN, "b": PROTEIN2})
+        assert result["a"] == PROBS
+        assert result["b"] == PROBS2
+
+
+# ======================================================================
+# _resolve_peptide_lengths()
+# ======================================================================
+
+class TestResolvePeptideLengths:
+
+    def test_none_uses_default(self):
+        stub = StubPredictor({}, default_peptide_lengths=[8, 10])
+        assert stub._resolve_peptide_lengths(None) == [8, 10]
+
+    def test_int_coerced_to_list(self):
+        stub = StubPredictor({})
+        assert stub._resolve_peptide_lengths(11) == [11]
+
+    def test_list_passed_through(self):
+        stub = StubPredictor({})
+        assert stub._resolve_peptide_lengths([7, 8]) == [7, 8]
+
+    def test_empty_raises(self):
+        stub = StubPredictor({})
+        with pytest.raises(ValueError, match="non-empty"):
+            stub._resolve_peptide_lengths([])
+
+
+# ======================================================================
+# ProteasomePredictor
+# ======================================================================
+
+class TestProteasomePredictor:
+
+    def test_default_scoring(self):
+        p = StubProteasome({})
+        assert p.scoring is score_cterm_anti_max_internal
+
+    def test_custom_scoring(self):
+        p = StubProteasome({}, scoring=score_cterm)
+        assert p.scoring is score_cterm
+
+    def test_pred_kind(self):
+        p = StubProteasome({})
+        assert p._pred_kind() == Kind.proteasome_cleavage
+
+    def test_predict_uses_proteasome_kind(self):
+        p = StubProteasome({})
+        results = p.predict(["ABCD"])
+        assert results[0].preds[0].kind == Kind.proteasome_cleavage
+
+    def test_predict_proteins_uses_proteasome_kind(self):
+        p = StubProteasome({PROTEIN: PROBS}, default_peptide_lengths=[4])
+        result = p.predict_proteins({"p": PROTEIN})
+        for pp in result["p"]:
+            assert pp.preds[0].kind == Kind.proteasome_cleavage
+
+    def test_inherits_from_processing_predictor(self):
+        assert issubclass(ProteasomePredictor, ProcessingPredictor)
+
+    def test_scoring_formula_matches(self):
+        """Verify the default scoring matches c_term * (1 - max_internal)."""
+        p = StubProteasome({PROTEIN: PROBS}, default_peptide_lengths=[4])
+        result = p.predict_proteins({"p": PROTEIN})
+        for pp in result["p"]:
+            pred = pp.preds[0]
+            c = PROBS[pred.offset + 3]
+            internal = PROBS[pred.offset:pred.offset + 3]
+            max_i = max(internal) if internal else 0.0
+            expected = c * (1.0 - max_i)
+            assert pred.score == pytest.approx(expected)
+
+    def test_predict_with_flanks(self):
+        """Flanking works through the ProteasomePredictor layer."""
+        full_seq = "XXABCDYY"
+        probs = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
+        p = StubProteasome({full_seq: probs}, scoring=score_cterm)
+        results = p.predict(["ABCD"], n_flanks=["XX"], c_flanks=["YY"])
+        pred = results[0].preds[0]
+        assert pred.kind == Kind.proteasome_cleavage
+        assert pred.n_flank == "XX"
+        assert pred.c_flank == "YY"
+
+
+# ======================================================================
+# Integration: scoring consistency across predict() and predict_proteins()
+# ======================================================================
+
+class TestScoringConsistency:
+    """
+    When predict() is given flanks that reconstruct the full protein,
+    the score at that position should match predict_proteins().
+    """
+
+    def test_flanked_predict_matches_predict_proteins(self):
+        stub = StubPredictor(
+            {PROTEIN: PROBS},
+            default_peptide_lengths=[4],
+            scoring=score_cterm_anti_max_internal,
+        )
+
+        # Get scores from predict_proteins
+        protein_result = stub.predict_proteins({"p": PROTEIN})
+        protein_scores = {
+            pp.preds[0].offset: pp.preds[0].score
+            for pp in protein_result["p"]
+        }
+
+        # Reconstruct the same predictions via predict() with flanks
+        for offset in range(len(PROTEIN) - 3):
+            peptide = PROTEIN[offset:offset + 4]
+            n_flank = PROTEIN[:offset]
+            c_flank = PROTEIN[offset + 4:]
+            # The full_seq is the original protein
+            results = stub.predict(
+                [peptide], n_flanks=[n_flank], c_flanks=[c_flank])
+            pred_score = results[0].preds[0].score
+            assert pred_score == pytest.approx(protein_scores[offset]), \
+                f"Mismatch at offset {offset}"
+
+    @pytest.mark.parametrize("fn", ALL_SCORING_FNS, ids=lambda f: f.__name__)
+    def test_predict_proteins_all_scoring_functions(self, fn):
+        """Every scoring function should produce valid results."""
+        stub = StubPredictor(
+            {PROTEIN: PROBS}, default_peptide_lengths=[4], scoring=fn)
+        result = stub.predict_proteins({"p": PROTEIN})
+        for pp in result["p"]:
+            # Should be a finite number
+            assert math.isfinite(pp.preds[0].score), fn.__name__

--- a/tests/test_processing_predictor.py
+++ b/tests/test_processing_predictor.py
@@ -132,8 +132,9 @@ class TestInit:
         p = StubPredictor({}, scoring=score_cterm)
         assert p.scoring is score_cterm
 
-    def test_lambda_scoring(self):
-        fn = lambda c, n, i: c
+    def test_callable_scoring(self):
+        def fn(c, n, i):
+            return c
         p = StubPredictor({}, scoring=fn)
         assert p.scoring is fn
 
@@ -169,7 +170,8 @@ class TestResolveScoring:
         assert resolve_scoring(None) is None
 
     def test_callable_passthrough(self):
-        fn = lambda c, n, i: c
+        def fn(c, n, i):
+            return c
         assert resolve_scoring(fn) is fn
 
     def test_string_mode(self):
@@ -202,12 +204,13 @@ class TestRepr:
         p = StubPredictor({}, scoring=score_cterm)
         assert "score_cterm" in str(p)
 
-    def test_str_lambda_scoring(self):
-        p = StubPredictor({}, scoring=lambda c, n, i: c)
+    def test_str_custom_scoring(self):
+        def my_fn(c, n, i):
+            return c
+        p = StubPredictor({}, scoring=my_fn)
         s = str(p)
         assert "StubPredictor" in s
-        # lambda has no __name__ in the usual sense, should still work
-        assert "lambda" in s or "function" in s or "<" in s
+        assert "my_fn" in s
 
     def test_repr_equals_str(self):
         p = StubPredictor({})

--- a/tests/test_processing_predictor.py
+++ b/tests/test_processing_predictor.py
@@ -1,0 +1,187 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+import pytest
+
+from mhctools.processing_predictor import ProcessingPredictor
+from mhctools.pred import Kind, PeptidePreds, COLUMNS
+
+
+class StubPredictor(ProcessingPredictor):
+    """Predictor with fixed per-position cleavage probs for testing."""
+
+    def __init__(self, probs_map, **kwargs):
+        super().__init__(**kwargs)
+        self.probs_map = probs_map
+
+    def cleavage_probs(self, sequence):
+        if sequence in self.probs_map:
+            return self.probs_map[sequence]
+        return [0.5] * len(sequence)
+
+
+# A 12-residue "protein" with known cleavage probs
+PROTEIN = "ABCDEFGHIJKL"
+#          0    1    2    3    4    5    6    7    8    9   10   11
+PROBS = [0.1, 0.2, 0.8, 0.3, 0.05, 0.4, 0.1, 0.9, 0.2, 0.6, 0.3, 0.7]
+
+
+def _geomean(*values):
+    product = 1.0
+    for v in values:
+        product *= v
+    return product ** (1.0 / len(values))
+
+
+# -- init --
+
+def test_init_defaults():
+    p = StubPredictor({})
+    assert p.default_peptide_lengths == [9]
+    assert p.scoring == "nterm_cterm_max_internal"
+    assert not hasattr(p, "alleles")
+
+
+def test_init_invalid_scoring():
+    with pytest.raises(ValueError, match="scoring"):
+        StubPredictor({}, scoring="garbage")
+
+
+# -- _peptide_score math --
+
+class TestPeptideScore:
+    """Test aggregation formulas on a known cleavage profile."""
+
+    def _make(self, scoring):
+        return StubPredictor({PROTEIN: PROBS}, scoring=scoring)
+
+    def test_cterm(self):
+        p = self._make("cterm")
+        # peptide at offset=2, length=4 → CDEF → c_term = probs[5] = 0.4
+        assert p._peptide_score(PROBS, 2, 4) == pytest.approx(0.4)
+
+    def test_nterm_cterm(self):
+        p = self._make("nterm_cterm")
+        # offset=2, length=4 → n_term=probs[1]=0.2, c_term=probs[5]=0.4
+        expected = _geomean(0.4, 0.2)
+        assert p._peptide_score(PROBS, 2, 4) == pytest.approx(expected)
+
+    def test_nterm_cterm_offset_zero(self):
+        p = self._make("nterm_cterm")
+        # offset=0 → no n_term, falls back to cterm only
+        # c_term = probs[3] = 0.3
+        assert p._peptide_score(PROBS, 0, 4) == pytest.approx(0.3)
+
+    def test_cterm_max_internal(self):
+        p = self._make("cterm_max_internal")
+        # offset=2, length=4 → c_term=0.4, internal=[0.8, 0.3, 0.05]
+        # max_internal=0.8, anti=0.2
+        expected = _geomean(0.4, 1.0 - 0.8)
+        assert p._peptide_score(PROBS, 2, 4) == pytest.approx(expected)
+
+    def test_cterm_mean_internal(self):
+        p = self._make("cterm_mean_internal")
+        # internal=[0.8, 0.3, 0.05], mean=0.383333...
+        expected = _geomean(0.4, 1.0 - (0.8 + 0.3 + 0.05) / 3)
+        assert p._peptide_score(PROBS, 2, 4) == pytest.approx(expected)
+
+    def test_nterm_cterm_max_internal(self):
+        p = self._make("nterm_cterm_max_internal")
+        # n=0.2, c=0.4, max_internal=0.8, anti=0.2
+        expected = _geomean(0.4, 0.2, 1.0 - 0.8)
+        assert p._peptide_score(PROBS, 2, 4) == pytest.approx(expected)
+
+    def test_nterm_cterm_mean_internal(self):
+        p = self._make("nterm_cterm_mean_internal")
+        mean_i = (0.8 + 0.3 + 0.05) / 3
+        expected = _geomean(0.4, 0.2, 1.0 - mean_i)
+        assert p._peptide_score(PROBS, 2, 4) == pytest.approx(expected)
+
+    def test_length_2_no_internal(self):
+        # length=2 → internal has only 1 position (offset to offset+length-2)
+        p = self._make("cterm_max_internal")
+        # offset=3, length=2 → DEFG? No, peptide DE → internal=[probs[3]]=0.3
+        # c_term=probs[4]=0.05
+        expected = _geomean(0.05, 1.0 - 0.3)
+        assert p._peptide_score(PROBS, 3, 2) == pytest.approx(expected)
+
+    def test_zero_cterm(self):
+        p = self._make("nterm_cterm_max_internal")
+        # If c_term is 0, score should be 0
+        probs = [0.5, 0.5, 0.0]  # c_term at pos 2 = 0
+        score = p._peptide_score(probs, 0, 3)
+        assert score == pytest.approx(0.0)
+
+
+# -- predict --
+
+def test_predict():
+    stub = StubPredictor({})
+    results = stub.predict(["ABCD", "EFGH"])
+    assert len(results) == 2
+    for pp in results:
+        assert isinstance(pp, PeptidePreds)
+        assert len(pp.preds) == 1
+        assert pp.preds[0].kind == Kind.antigen_processing
+
+
+def test_predict_dataframe():
+    stub = StubPredictor({})
+    df = stub.predict_dataframe(["ABCD"], sample_name="s1")
+    assert list(df.columns) == list(COLUMNS)
+    assert len(df) == 1
+    assert df.iloc[0]["kind"] == "antigen_processing"
+    assert df.iloc[0]["sample_name"] == "s1"
+
+
+# -- predict_proteins --
+
+def test_predict_proteins():
+    stub = StubPredictor({PROTEIN: PROBS}, default_peptide_lengths=[4])
+    result = stub.predict_proteins({"p": PROTEIN})
+    assert "p" in result
+    pp_list = result["p"]
+    expected_count = len(PROTEIN) - 4 + 1
+    assert len(pp_list) == expected_count
+    for pp in pp_list:
+        pred = pp.preds[0]
+        assert pred.kind == Kind.antigen_processing
+        assert pred.source_sequence_name == "p"
+
+
+def test_predict_proteins_string():
+    stub = StubPredictor({PROTEIN: PROBS}, default_peptide_lengths=[4])
+    result = stub.predict_proteins(PROTEIN)
+    assert "seq" in result
+
+
+def test_predict_proteins_dataframe():
+    stub = StubPredictor({PROTEIN: PROBS}, default_peptide_lengths=[4])
+    df = stub.predict_proteins_dataframe({"p": PROTEIN}, sample_name="s1")
+    assert list(df.columns) == list(COLUMNS)
+    assert (df["source_sequence_name"] == "p").all()
+    assert (df["sample_name"] == "s1").all()
+
+
+# -- predict_cleavage_sites --
+
+def test_predict_cleavage_sites():
+    stub = StubPredictor({PROTEIN: PROBS})
+    result = stub.predict_cleavage_sites({"p": PROTEIN})
+    assert result["p"] == PROBS
+
+
+def test_predict_cleavage_sites_string():
+    stub = StubPredictor({PROTEIN: PROBS})
+    result = stub.predict_cleavage_sites(PROTEIN)
+    assert "seq" in result


### PR DESCRIPTION
## Summary
- Wraps the [pepsickle](https://github.com/pdxgx/pepsickle) library as a `BasePredictor` subclass producing `Kind.proteasome_cleavage` predictions
- `predict(peptides)` returns C-terminal cleavage probability per peptide
- `predict_proteins()` runs pepsickle on full protein sequences (proper flanking context) then extracts per-peptide C-terminal cleavage scores
- `predict_cleavage_sites()` exposes raw per-position cleavage profiles
- Supports all three pepsickle model types: `epitope` (default), `in-vitro` (gradient-boosted), `in-vitro-2` (neural net), with configurable proteasome type (C/I) and human-only mode
- Added as optional dependency: `pip install mhctools[pepsickle]`

## Test plan
- [x] 15 tests in `tests/test_pepsickle.py` (14 pass, 1 xfail for sklearn version compat with in-vitro GB model)
- [x] Existing `test_pred.py` suite passes (23 tests)
- [ ] Verify on CI