### PR TITLE
Add BigMHC integration for presentation and immunogenicity

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,7 @@ jobs:
             tests/test_pred.py \
             tests/test_processing_predictor.py \
             tests/test_pepsickle.py \
+            tests/test_bigmhc.py \
             tests/test_random.py
 
   integration-netmhc:

--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -38,9 +38,10 @@ from .netmhc_pan42 import NetMHCpan42, NetMHCpan42_BA, NetMHCpan42_EL
 from .netmhcii_pan import NetMHCIIpan, NetMHCIIpan3, NetMHCIIpan4, NetMHCIIpan4_BA, NetMHCIIpan4_EL, NetMHCIIpan43, NetMHCIIpan43_BA, NetMHCIIpan43_EL
 from .random_predictor import RandomBindingPredictor
 from .netmhcstabpan import NetMHCstabpan
+from .bigmhc import BigMHC
 from .unsupported_allele import UnsupportedAllele
 
-__version__ = "3.0.2"
+__version__ = "3.1.0"
 
 __all__ = [
     "Pred",
@@ -94,6 +95,7 @@ __all__ = [
     "NetMHCIIpan43_BA",
     "NetMHCIIpan43_EL",
     "NetMHCstabpan",
+    "BigMHC",
     "RandomBindingPredictor",
     "UnsupportedAllele",
 ]

--- a/mhctools/bigmhc.py
+++ b/mhctools/bigmhc.py
@@ -1,0 +1,200 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Wrapper for BigMHC (https://github.com/KarchinLab/bigmhc).
+
+BigMHC offers two models:
+
+* **BigMHC_EL** — pMHC presentation (eluted-ligand trained)
+* **BigMHC_IM** — immunogenicity (transfer-learned on IFN-γ / MANAFEST)
+
+Both are pan-allelic deep neural networks that accept peptides of any
+length and produce a probability score (0–1).
+"""
+
+import csv
+import os
+import subprocess
+import tempfile
+
+from .pred import Kind, Pred, PeptidePreds
+
+
+def _find_bigmhc_dir(bigmhc_path=None):
+    """Resolve the BigMHC installation directory.
+
+    Checks, in order:
+    1. The *bigmhc_path* argument
+    2. The ``BIGMHC_DIR`` environment variable
+    3. ``~/bigmhc``
+    """
+    if bigmhc_path:
+        return bigmhc_path
+    env = os.environ.get("BIGMHC_DIR")
+    if env:
+        return env
+    home = os.path.join(os.path.expanduser("~"), "bigmhc")
+    if os.path.isdir(home):
+        return home
+    raise FileNotFoundError(
+        "BigMHC not found. Set BIGMHC_DIR or pass bigmhc_path= to the constructor. "
+        "Clone from https://github.com/KarchinLab/bigmhc")
+
+
+class BigMHC:
+    """Wrapper for BigMHC presentation and immunogenicity predictions.
+
+    Parameters
+    ----------
+    alleles : list of str
+        HLA alleles (e.g. ``["HLA-A*02:01", "HLA-B*07:02"]``).
+    mode : str
+        ``"el"`` for presentation or ``"im"`` for immunogenicity.
+    bigmhc_path : str, optional
+        Path to the cloned BigMHC repository root.
+    device : str
+        PyTorch device string. Default ``"cpu"``.
+    """
+
+    VALID_MODES = ("el", "im")
+
+    def __init__(self, alleles, mode="el", bigmhc_path=None, device="cpu"):
+        if isinstance(alleles, str):
+            alleles = [alleles]
+        if mode not in self.VALID_MODES:
+            raise ValueError(
+                "mode must be one of %s, got %r" % (self.VALID_MODES, mode))
+        self.alleles = list(alleles)
+        self.mode = mode
+        self.bigmhc_dir = _find_bigmhc_dir(bigmhc_path)
+        self.device = device
+
+        predict_script = os.path.join(self.bigmhc_dir, "src", "predict.py")
+        if not os.path.isfile(predict_script):
+            raise FileNotFoundError(
+                "predict.py not found at %s" % predict_script)
+
+    def __str__(self):
+        return "BigMHC(mode=%s, alleles=%s)" % (self.mode, self.alleles)
+
+    def __repr__(self):
+        return str(self)
+
+    def _pred_kind(self):
+        if self.mode == "im":
+            return Kind.immunogenicity
+        return Kind.pMHC_presentation
+
+    def _predictor_name(self):
+        return "bigmhc_%s" % self.mode
+
+    # ------------------------------------------------------------------
+    # Core prediction
+    # ------------------------------------------------------------------
+
+    def _run_bigmhc(self, peptides, alleles):
+        """Write CSV, run predict.py, return parsed rows."""
+        predict_script = os.path.join(self.bigmhc_dir, "src", "predict.py")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_csv = os.path.join(tmpdir, "input.csv")
+            output_csv = input_csv + ".prd"
+
+            with open(input_csv, "w", newline="") as f:
+                writer = csv.writer(f)
+                writer.writerow(["mhc", "pep"])
+                for pep, allele in zip(peptides, alleles):
+                    writer.writerow([allele, pep])
+
+            result = subprocess.run(
+                ["python", predict_script,
+                 "-i", input_csv,
+                 "-m", self.mode,
+                 "-d", self.device],
+                capture_output=True,
+                cwd=os.path.join(self.bigmhc_dir, "src"),
+                timeout=600,
+            )
+            if result.returncode != 0:
+                raise RuntimeError(
+                    "BigMHC failed (exit %d):\n%s" % (
+                        result.returncode,
+                        result.stderr.decode("utf-8", "replace")))
+
+            rows = []
+            with open(output_csv) as f:
+                reader = csv.DictReader(f)
+                for row in reader:
+                    rows.append(row)
+            return rows
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def predict(self, peptides):
+        """Predict scores for peptides against all alleles.
+
+        Parameters
+        ----------
+        peptides : list of str
+
+        Returns
+        -------
+        list of PeptidePreds
+            One entry per peptide; each contains one Pred per allele.
+        """
+        if isinstance(peptides, str):
+            peptides = [peptides]
+
+        # Build all (peptide, allele) combinations
+        all_peptides = []
+        all_alleles = []
+        for pep in peptides:
+            for allele in self.alleles:
+                all_peptides.append(pep)
+                all_alleles.append(allele)
+
+        rows = self._run_bigmhc(all_peptides, all_alleles)
+
+        # Parse into Pred objects, grouped by peptide
+        score_col = [c for c in rows[0] if c.startswith("BigMHC")][0]
+        kind = self._pred_kind()
+        name = self._predictor_name()
+
+        # Group by peptide in input order
+        idx = 0
+        results = []
+        for pep in peptides:
+            preds = []
+            for allele in self.alleles:
+                score = float(rows[idx][score_col])
+                preds.append(Pred(
+                    kind=kind,
+                    score=score,
+                    peptide=pep,
+                    allele=allele,
+                    predictor_name=name,
+                ))
+                idx += 1
+            results.append(PeptidePreds(preds=tuple(preds)))
+        return results
+
+    def predict_dataframe(self, peptides, sample_name=""):
+        """``predict()`` flattened to a DataFrame."""
+        import pandas as pd
+        from .pred import COLUMNS
+        dfs = [pp.to_dataframe(sample_name) for pp in self.predict(peptides)]
+        if not dfs:
+            return pd.DataFrame(columns=COLUMNS)
+        return pd.concat(dfs, ignore_index=True)

--- a/mhctools/bigmhc.py
+++ b/mhctools/bigmhc.py
@@ -20,14 +20,18 @@ BigMHC offers two models:
 
 Both are pan-allelic deep neural networks that accept peptides of any
 length and produce a probability score (0–1).
+
+Models are loaded lazily on first prediction and kept in memory for
+subsequent calls.
 """
 
-import csv
 import os
-import subprocess
-import tempfile
+import sys
 
-from .pred import Kind, Pred, PeptidePreds
+import pandas as pd
+import torch
+
+from .pred import Kind, Pred, PeptidePreds, COLUMNS
 
 
 def _find_bigmhc_dir(bigmhc_path=None):
@@ -51,8 +55,30 @@ def _find_bigmhc_dir(bigmhc_path=None):
         "Clone from https://github.com/KarchinLab/bigmhc")
 
 
+def _import_bigmhc_modules(bigmhc_dir):
+    """Import BigMHC's internal modules by temporarily adding src/ to sys.path."""
+    src_dir = os.path.join(bigmhc_dir, "src")
+    added = src_dir not in sys.path
+    if added:
+        sys.path.insert(0, src_dir)
+    try:
+        # BigMHC modules use bare imports (e.g. "from bigmhc import BigMHC")
+        import bigmhc as bigmhc_mod
+        import mhcenc as mhcenc_mod
+        import dataset as dataset_mod
+        import mhcuid as mhcuid_mod
+        import encseq as encseq_mod
+        return bigmhc_mod, mhcenc_mod, dataset_mod, mhcuid_mod, encseq_mod
+    finally:
+        if added:
+            sys.path.remove(src_dir)
+
+
 class BigMHC:
     """Wrapper for BigMHC presentation and immunogenicity predictions.
+
+    Models are loaded lazily on the first call to :meth:`predict` and
+    kept in memory for all subsequent calls.
 
     Parameters
     ----------
@@ -64,11 +90,14 @@ class BigMHC:
         Path to the cloned BigMHC repository root.
     device : str
         PyTorch device string. Default ``"cpu"``.
+    max_batch_size : int
+        Maximum peptides per inference batch. Default 4096.
     """
 
     VALID_MODES = ("el", "im")
 
-    def __init__(self, alleles, mode="el", bigmhc_path=None, device="cpu"):
+    def __init__(self, alleles, mode="el", bigmhc_path=None, device="cpu",
+                 max_batch_size=4096):
         if isinstance(alleles, str):
             alleles = [alleles]
         if mode not in self.VALID_MODES:
@@ -78,14 +107,23 @@ class BigMHC:
         self.mode = mode
         self.bigmhc_dir = _find_bigmhc_dir(bigmhc_path)
         self.device = device
+        self.max_batch_size = max_batch_size
 
-        predict_script = os.path.join(self.bigmhc_dir, "src", "predict.py")
-        if not os.path.isfile(predict_script):
+        # Validate installation
+        src_dir = os.path.join(self.bigmhc_dir, "src")
+        if not os.path.isfile(os.path.join(src_dir, "bigmhc.py")):
             raise FileNotFoundError(
-                "predict.py not found at %s" % predict_script)
+                "bigmhc.py not found in %s" % src_dir)
+
+        # Lazy-loaded state
+        self._models = None
+        self._mhcenc = None
+        self._modules = None
 
     def __str__(self):
-        return "BigMHC(mode=%s, alleles=%s)" % (self.mode, self.alleles)
+        loaded = "loaded" if self._models is not None else "not loaded"
+        return "BigMHC(mode=%s, alleles=%s, %s)" % (
+            self.mode, self.alleles, loaded)
 
     def __repr__(self):
         return str(self)
@@ -98,45 +136,92 @@ class BigMHC:
     def _predictor_name(self):
         return "bigmhc_%s" % self.mode
 
+    @property
+    def _model_name(self):
+        return "BigMHC_EL" if self.mode == "el" else "BigMHC_IM"
+
     # ------------------------------------------------------------------
-    # Core prediction
+    # Model loading (lazy, cached)
     # ------------------------------------------------------------------
 
-    def _run_bigmhc(self, peptides, alleles):
-        """Write CSV, run predict.py, return parsed rows."""
-        predict_script = os.path.join(self.bigmhc_dir, "src", "predict.py")
+    def _ensure_loaded(self):
+        """Load models and MHC encoder on first use."""
+        if self._models is not None:
+            return
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            input_csv = os.path.join(tmpdir, "input.csv")
-            output_csv = input_csv + ".prd"
+        self._modules = _import_bigmhc_modules(self.bigmhc_dir)
+        bigmhc_mod, mhcenc_mod, _, _, _ = self._modules
 
-            with open(input_csv, "w", newline="") as f:
-                writer = csv.writer(f)
-                writer.writerow(["mhc", "pep"])
-                for pep, allele in zip(peptides, alleles):
-                    writer.writerow([allele, pep])
+        # Load MHC pseudo-sequence encoder
+        pseudoseqs = os.path.join(self.bigmhc_dir, "data", "pseudoseqs.csv")
+        self._mhcenc = mhcenc_mod.MHCEncoder.read(pseudoseqs)
 
-            result = subprocess.run(
-                ["python", predict_script,
-                 "-i", input_csv,
-                 "-m", self.mode,
-                 "-d", self.device],
-                capture_output=True,
-                cwd=os.path.join(self.bigmhc_dir, "src"),
-                timeout=600,
-            )
-            if result.returncode != 0:
-                raise RuntimeError(
-                    "BigMHC failed (exit %d):\n%s" % (
-                        result.returncode,
-                        result.stderr.decode("utf-8", "replace")))
+        # Resolve model paths (same logic as cli._parseModel)
+        models_dir = os.path.join(self.bigmhc_dir, "models")
+        el_dirs = [
+            os.path.join(models_dir, "bat%d" % (2 ** x))
+            for x in range(9, 16)
+        ]
+        if self.mode == "im":
+            model_dirs = [os.path.join(d, "im") for d in el_dirs]
+        else:
+            model_dirs = el_dirs
 
-            rows = []
-            with open(output_csv) as f:
-                reader = csv.DictReader(f)
-                for row in reader:
-                    rows.append(row)
-            return rows
+        # Load ensemble
+        self._models = []
+        for d in model_dirs:
+            model = bigmhc_mod.BigMHC.load(d)
+            model.eval()
+            model = bigmhc_mod.BigMHC.accelerate(model, devices=[])
+            self._models.append(model)
+
+    # ------------------------------------------------------------------
+    # Core prediction (in-process)
+    # ------------------------------------------------------------------
+
+    def _predict_raw(self, peptides, alleles):
+        """Run BigMHC in-process. Returns list of float scores."""
+        self._ensure_loaded()
+        _, _, dataset_mod, mhcuid_mod, _ = self._modules
+
+        # Build DataFrame in the format BigMHC expects
+        df = pd.DataFrame({"mhc": alleles, "pep": peptides})
+        df["pep"] = df["pep"].str.upper()
+        df["tgt"] = None
+        df["len"] = df["pep"].apply(len)
+        df.insert(
+            0, "uid",
+            df["mhc"].apply(mhcuid_mod.mhcuid) + "_" + df["pep"])
+        df.set_index("uid", drop=True, inplace=True)
+        df = df.astype({
+            "mhc": "string", "pep": "string",
+            "tgt": "float32", "len": "int8"})
+
+        # Create Dataset and batch
+        data = dataset_mod.Dataset(pmhcs=df, mhcenc=self._mhcenc)
+        data.makebats(self.max_batch_size)
+        loader = torch.utils.data.DataLoader(
+            data, batch_size=None, shuffle=False,
+            num_workers=0)
+
+        # Run inference
+        preds_parts = []
+        with torch.no_grad():
+            for idx, bat in enumerate(loader):
+                out_stack = []
+                for model in self._models:
+                    dev = next(model.parameters()).device
+                    out, _ = model(
+                        mhc=bat.mhc.to(dev),
+                        pep=bat.pep.to(dev))
+                    out_stack.append(torch.sigmoid(out))
+                ensemble_out = torch.mean(torch.stack(out_stack), dim=0)
+                rawbat = data.getbat(idx=idx, enc=False)
+                rawbat[self._model_name] = ensemble_out.cpu().numpy()
+                preds_parts.append(rawbat)
+
+        result_df = pd.concat(preds_parts).sort_index()
+        return result_df[self._model_name].tolist()
 
     # ------------------------------------------------------------------
     # Public API
@@ -165,23 +250,19 @@ class BigMHC:
                 all_peptides.append(pep)
                 all_alleles.append(allele)
 
-        rows = self._run_bigmhc(all_peptides, all_alleles)
+        scores = self._predict_raw(all_peptides, all_alleles)
 
-        # Parse into Pred objects, grouped by peptide
-        score_col = [c for c in rows[0] if c.startswith("BigMHC")][0]
         kind = self._pred_kind()
         name = self._predictor_name()
 
-        # Group by peptide in input order
         idx = 0
         results = []
         for pep in peptides:
             preds = []
             for allele in self.alleles:
-                score = float(rows[idx][score_col])
                 preds.append(Pred(
                     kind=kind,
-                    score=score,
+                    score=float(scores[idx]),
                     peptide=pep,
                     allele=allele,
                     predictor_name=name,
@@ -192,8 +273,6 @@ class BigMHC:
 
     def predict_dataframe(self, peptides, sample_name=""):
         """``predict()`` flattened to a DataFrame."""
-        import pandas as pd
-        from .pred import COLUMNS
         dfs = [pp.to_dataframe(sample_name) for pp in self.predict(peptides)]
         if not dfs:
             return pd.DataFrame(columns=COLUMNS)

--- a/mhctools/pred.py
+++ b/mhctools/pred.py
@@ -27,6 +27,7 @@ class Kind(Enum):
     pMHC_stability = "pMHC_stability"
     # Cell-level
     cellular_presentation = "cellular_presentation"
+    immunogenicity = "immunogenicity"
     # Processing pathway
     antigen_processing = "antigen_processing"
     proteasome_cleavage = "proteasome_cleavage"

--- a/tests/test_bigmhc.py
+++ b/tests/test_bigmhc.py
@@ -26,8 +26,8 @@ for candidate in [
     os.path.join(os.path.expanduser("~"), "code", "bigmhc"),
 ]:
     if candidate and os.path.isdir(candidate):
-        predict_py = os.path.join(candidate, "src", "predict.py")
-        if os.path.isfile(predict_py):
+        src_dir = os.path.join(candidate, "src", "bigmhc.py")
+        if os.path.isfile(src_dir):
             BIGMHC_DIR = candidate
             break
 
@@ -45,6 +45,7 @@ def test_init_el():
     p = BigMHC(ALLELES, mode="el", bigmhc_path=BIGMHC_DIR)
     assert p.mode == "el"
     assert p.alleles == ALLELES
+    assert p._models is None  # lazy, not loaded yet
 
 
 def test_init_im():
@@ -52,16 +53,26 @@ def test_init_im():
     assert p.mode == "im"
 
 
+def test_init_string_allele():
+    p = BigMHC("HLA-A*02:01", mode="el", bigmhc_path=BIGMHC_DIR)
+    assert p.alleles == ["HLA-A*02:01"]
+
+
 def test_init_invalid_mode():
     with pytest.raises(ValueError, match="mode"):
         BigMHC(ALLELES, mode="bad", bigmhc_path=BIGMHC_DIR)
 
 
-def test_str():
+def test_init_missing_path():
+    with pytest.raises(FileNotFoundError):
+        BigMHC(ALLELES, bigmhc_path="/nonexistent/path")
+
+
+def test_str_before_load():
     p = BigMHC(ALLELES, mode="el", bigmhc_path=BIGMHC_DIR)
     s = str(p)
     assert "BigMHC" in s
-    assert "el" in s
+    assert "not loaded" in s
 
 
 # -- predict (EL) --
@@ -117,6 +128,21 @@ def test_predict_el_scores_vary(el_predictor):
     assert len(set(round(s, 4) for s in scores)) > 1
 
 
+def test_predict_models_stay_loaded(el_predictor):
+    """After first predict(), models should stay in memory."""
+    el_predictor.predict(["SIINFEKL"])
+    assert el_predictor._models is not None
+    assert "loaded" in str(el_predictor)
+
+
+def test_predict_repeated_calls_consistent(el_predictor):
+    """Multiple predict() calls return identical scores."""
+    r1 = el_predictor.predict(PEPTIDES)
+    r2 = el_predictor.predict(PEPTIDES)
+    for pp1, pp2 in zip(r1, r2):
+        assert abs(pp1.preds[0].score - pp2.preds[0].score) < 1e-6
+
+
 # -- predict (IM) --
 
 @pytest.fixture(scope="module")
@@ -143,6 +169,37 @@ def test_predict_im_scores_are_probabilities(im_predictor):
             assert 0.0 <= pred.score <= 1.0
 
 
+def test_predict_el_im_scores_differ(el_predictor, im_predictor):
+    """EL and IM models should produce different scores."""
+    el = el_predictor.predict(PEPTIDES)
+    im = im_predictor.predict(PEPTIDES)
+    el_scores = [pp.preds[0].score for pp in el]
+    im_scores = [pp.preds[0].score for pp in im]
+    assert el_scores != im_scores
+
+
+# -- ordering --
+
+def test_predict_mixed_lengths_ordering(el_predictor):
+    """Peptides of different lengths are batched separately;
+    verify output order matches input order."""
+    peptides = ["YLQPRTFL", "GILGFVFTL", "YLQPRTFLLK"]  # 8, 9, 10
+    results = el_predictor.predict(peptides)
+    for pep, pp in zip(peptides, results):
+        assert pp.preds[0].peptide == pep
+
+
+def test_predict_duplicate_peptides(el_predictor):
+    """Duplicate peptides should produce duplicate results in order."""
+    peptides = ["SIINFEKL", "GILGFVFTL", "SIINFEKL"]
+    results = el_predictor.predict(peptides)
+    assert len(results) == 3
+    assert results[0].preds[0].peptide == "SIINFEKL"
+    assert results[1].preds[0].peptide == "GILGFVFTL"
+    assert results[2].preds[0].peptide == "SIINFEKL"
+    assert abs(results[0].preds[0].score - results[2].preds[0].score) < 1e-6
+
+
 # -- multiple alleles --
 
 def test_predict_multiple_alleles():
@@ -156,6 +213,36 @@ def test_predict_multiple_alleles():
     assert pp.preds[1].allele == "HLA-B*07:02"
 
 
+def test_predict_multiple_alleles_mixed_lengths():
+    """Multi-allele + mixed-length peptides: ordering stress test."""
+    alleles = ["HLA-A*02:01", "HLA-B*07:02"]
+    peptides = ["YLQPRTFL", "GILGFVFTL", "YLQPRTFLLK"]
+    p = BigMHC(alleles, mode="el", bigmhc_path=BIGMHC_DIR)
+    results = p.predict(peptides)
+    assert len(results) == 3
+    for pep, pp in zip(peptides, results):
+        assert len(pp.preds) == 2
+        assert pp.preds[0].peptide == pep
+        assert pp.preds[1].peptide == pep
+        assert pp.preds[0].allele == "HLA-A*02:01"
+        assert pp.preds[1].allele == "HLA-B*07:02"
+
+
+# -- batch performance --
+
+def test_predict_long_list(el_predictor):
+    """Run on a realistic protein-length input to verify batching works."""
+    protein = "MFVFLVLLPLVSSQCVNLTTRTQLPPAYTNSFTRGVYYPDKVFRSSVLHSTQDLFLPFFSNVTWFHAI"
+    peptides = [protein[i:i + 9] for i in range(len(protein) - 9 + 1)]
+    assert len(peptides) > 50
+    results = el_predictor.predict(peptides)
+    assert len(results) == len(peptides)
+    scores = [pp.preds[0].score for pp in results]
+    assert all(0.0 <= s <= 1.0 for s in scores)
+    # Scores should not all be identical
+    assert len(set(round(s, 4) for s in scores)) > 1
+
+
 # -- dataframe --
 
 def test_predict_dataframe(el_predictor):
@@ -164,6 +251,13 @@ def test_predict_dataframe(el_predictor):
     assert len(df) == len(PEPTIDES) * len(ALLELES)
     assert (df["kind"] == "pMHC_presentation").all()
     assert (df["predictor_name"] == "bigmhc_el").all()
+
+
+def test_predict_dataframe_multiple_alleles():
+    alleles = ["HLA-A*02:01", "HLA-B*07:02"]
+    p = BigMHC(alleles, mode="el", bigmhc_path=BIGMHC_DIR)
+    df = p.predict_dataframe(PEPTIDES)
+    assert len(df) == len(PEPTIDES) * len(alleles)
 
 
 # -- single string input --

--- a/tests/test_bigmhc.py
+++ b/tests/test_bigmhc.py
@@ -1,0 +1,174 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import pytest
+
+from mhctools.bigmhc import BigMHC
+from mhctools.pred import Kind, PeptidePreds, COLUMNS
+
+
+# Skip entire module if BigMHC is not installed
+BIGMHC_DIR = None
+for candidate in [
+    os.environ.get("BIGMHC_DIR", ""),
+    os.path.join(os.path.expanduser("~"), "bigmhc"),
+    os.path.join(os.path.expanduser("~"), "code", "bigmhc"),
+]:
+    if candidate and os.path.isdir(candidate):
+        predict_py = os.path.join(candidate, "src", "predict.py")
+        if os.path.isfile(predict_py):
+            BIGMHC_DIR = candidate
+            break
+
+pytestmark = pytest.mark.skipif(
+    BIGMHC_DIR is None,
+    reason="BigMHC not installed (set BIGMHC_DIR or clone to ~/bigmhc)")
+
+ALLELES = ["HLA-A*02:01"]
+PEPTIDES = ["SIINFEKL", "GILGFVFTL", "NLVPMVATV"]
+
+
+# -- init --
+
+def test_init_el():
+    p = BigMHC(ALLELES, mode="el", bigmhc_path=BIGMHC_DIR)
+    assert p.mode == "el"
+    assert p.alleles == ALLELES
+
+
+def test_init_im():
+    p = BigMHC(ALLELES, mode="im", bigmhc_path=BIGMHC_DIR)
+    assert p.mode == "im"
+
+
+def test_init_invalid_mode():
+    with pytest.raises(ValueError, match="mode"):
+        BigMHC(ALLELES, mode="bad", bigmhc_path=BIGMHC_DIR)
+
+
+def test_str():
+    p = BigMHC(ALLELES, mode="el", bigmhc_path=BIGMHC_DIR)
+    s = str(p)
+    assert "BigMHC" in s
+    assert "el" in s
+
+
+# -- predict (EL) --
+
+@pytest.fixture(scope="module")
+def el_predictor():
+    return BigMHC(ALLELES, mode="el", bigmhc_path=BIGMHC_DIR)
+
+
+def test_predict_el_returns_peptide_preds(el_predictor):
+    results = el_predictor.predict(PEPTIDES)
+    assert isinstance(results, list)
+    assert len(results) == len(PEPTIDES)
+    for pp in results:
+        assert isinstance(pp, PeptidePreds)
+        assert len(pp.preds) == len(ALLELES)
+
+
+def test_predict_el_scores_are_probabilities(el_predictor):
+    results = el_predictor.predict(PEPTIDES)
+    for pp in results:
+        for pred in pp.preds:
+            assert 0.0 <= pred.score <= 1.0
+
+
+def test_predict_el_kind(el_predictor):
+    results = el_predictor.predict(PEPTIDES)
+    for pp in results:
+        for pred in pp.preds:
+            assert pred.kind == Kind.pMHC_presentation
+
+
+def test_predict_el_predictor_name(el_predictor):
+    results = el_predictor.predict(PEPTIDES)
+    assert results[0].preds[0].predictor_name == "bigmhc_el"
+
+
+def test_predict_el_peptides_correct(el_predictor):
+    results = el_predictor.predict(PEPTIDES)
+    for pep, pp in zip(PEPTIDES, results):
+        assert pp.preds[0].peptide == pep
+
+
+def test_predict_el_alleles_correct(el_predictor):
+    results = el_predictor.predict(PEPTIDES)
+    for pp in results:
+        assert pp.preds[0].allele == ALLELES[0]
+
+
+def test_predict_el_scores_vary(el_predictor):
+    results = el_predictor.predict(PEPTIDES)
+    scores = [pp.preds[0].score for pp in results]
+    assert len(set(round(s, 4) for s in scores)) > 1
+
+
+# -- predict (IM) --
+
+@pytest.fixture(scope="module")
+def im_predictor():
+    return BigMHC(ALLELES, mode="im", bigmhc_path=BIGMHC_DIR)
+
+
+def test_predict_im_kind(im_predictor):
+    results = im_predictor.predict(PEPTIDES)
+    for pp in results:
+        for pred in pp.preds:
+            assert pred.kind == Kind.immunogenicity
+
+
+def test_predict_im_predictor_name(im_predictor):
+    results = im_predictor.predict(PEPTIDES)
+    assert results[0].preds[0].predictor_name == "bigmhc_im"
+
+
+def test_predict_im_scores_are_probabilities(im_predictor):
+    results = im_predictor.predict(PEPTIDES)
+    for pp in results:
+        for pred in pp.preds:
+            assert 0.0 <= pred.score <= 1.0
+
+
+# -- multiple alleles --
+
+def test_predict_multiple_alleles():
+    alleles = ["HLA-A*02:01", "HLA-B*07:02"]
+    p = BigMHC(alleles, mode="el", bigmhc_path=BIGMHC_DIR)
+    results = p.predict(["SIINFEKL"])
+    assert len(results) == 1
+    pp = results[0]
+    assert len(pp.preds) == 2
+    assert pp.preds[0].allele == "HLA-A*02:01"
+    assert pp.preds[1].allele == "HLA-B*07:02"
+
+
+# -- dataframe --
+
+def test_predict_dataframe(el_predictor):
+    df = el_predictor.predict_dataframe(PEPTIDES)
+    assert list(df.columns) == list(COLUMNS)
+    assert len(df) == len(PEPTIDES) * len(ALLELES)
+    assert (df["kind"] == "pMHC_presentation").all()
+    assert (df["predictor_name"] == "bigmhc_el").all()
+
+
+# -- single string input --
+
+def test_predict_single_string(el_predictor):
+    results = el_predictor.predict("SIINFEKL")
+    assert len(results) == 1
+    assert results[0].preds[0].peptide == "SIINFEKL"


### PR DESCRIPTION
## Summary
- New `BigMHC` wrapper class for [BigMHC](https://github.com/KarchinLab/bigmhc) (Nature Machine Intelligence 2023)
- Supports **BigMHC_EL** (pMHC presentation, eluted-ligand trained) and **BigMHC_IM** (immunogenicity, transfer-learned)
- Pan-allelic deep neural network, accepts peptides of any length
- Outputs probability scores (0-1) as `Pred` objects with proper `Kind` values
- Add `Kind.immunogenicity` to the prediction type enum
- Requires local BigMHC clone (set `BIGMHC_DIR` env var or clone to `~/bigmhc`)
- Bump version to 3.1.0

## Usage
```python
from mhctools import BigMHC

# Presentation prediction
el = BigMHC(["HLA-A*02:01"], mode="el", bigmhc_path="/path/to/bigmhc")
results = el.predict(["SIINFEKL", "GILGFVFTL"])

# Immunogenicity prediction
im = BigMHC(["HLA-A*02:01"], mode="im", bigmhc_path="/path/to/bigmhc")
results = im.predict(["SIINFEKL"])
```

## Test plan
- [x] 17 tests covering both EL and IM models, multi-allele, DataFrame output
- [x] All 206 existing tests still pass
- [x] BigMHC tests auto-skip in CI (requires local clone with model weights)
- [x] Lint clean