### PR TITLE
Rename PeptidePreds → PeptideResult, improve README data model docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,27 @@ For MHCflurry support, also run:
 mhcflurry-downloads fetch
 ```
 
+## Data model
+
+Every predictor returns results as two nested dataclasses:
+
+- **`PeptideResult`** — all predictions for one peptide (across alleles and
+  prediction kinds). This is what you get back per peptide from `predict()`.
+- **`Pred`** — a single prediction: one peptide, one allele, one measurement
+  kind (e.g. affinity, presentation, immunogenicity). Frozen and self-contained.
+
+```
+predict(["SIINFEKL", "GILGFVFTL"])
+  → [PeptideResult, PeptideResult]
+       └── .preds = (Pred(allele=A0201, kind=affinity, ...),
+                     Pred(allele=A0201, kind=presentation, ...),
+                     Pred(allele=B0702, kind=affinity, ...),
+                     ...)
+```
+
+Both convert to DataFrames and have consistent column names for easy downstream
+analysis.
+
 ## Quick start
 
 ```python
@@ -26,12 +47,11 @@ from mhctools import NetMHCpan41
 
 predictor = NetMHCpan41(alleles=["HLA-A*02:01", "HLA-B*07:02"])
 
-# predict for specific peptides
+# predict() returns a list of PeptideResult — one per peptide
 results = predictor.predict(["SIINFEKL", "GILGFVFTL"])
 
-# results is a list of PeptidePreds — one per peptide
-for pp in results:
-    best = pp.best_affinity
+for result in results:
+    best = result.best_affinity
     if best:
         print(f"{best.peptide} -> {best.allele} IC50={best.value:.1f}nM")
 ```
@@ -40,32 +60,29 @@ for pp in results:
 
 ### Predicting peptides
 
-`predict()` takes a list of peptide sequences and returns a `list[PeptidePreds]`.
-Each `PeptidePreds` contains `Pred` objects for every allele and measurement
-kind the predictor supports.
-
 ```python
 from mhctools import NetMHCpan41
 
 predictor = NetMHCpan41(alleles=["HLA-A*02:01", "HLA-B*07:02"])
 results = predictor.predict(["SIINFEKL", "GILGFVFTL"])
 
-pp = results[0]
-pp.best_affinity                # Pred with highest affinity score
-pp.best_affinity.allele         # "HLA-A*02:01"
-pp.best_affinity.value          # IC50 in nM
-pp.best_affinity.score          # higher = better (~0-1)
-pp.best_affinity.percentile_rank  # lower = better (0-100)
+result = results[0]                   # PeptideResult for "SIINFEKL"
+result.preds                          # tuple of Pred objects
+result.best_affinity                  # Pred with highest affinity score
+result.best_affinity.allele           # "HLA-A*02:01"
+result.best_affinity.value            # IC50 in nM
+result.best_affinity.score            # higher = better (~0-1)
+result.best_affinity.percentile_rank  # lower = better (0-100)
 
-pp.best_affinity_by_rank        # Pred with lowest percentile rank
-pp.best_presentation            # best EL/presentation score
-pp.best_presentation_by_rank    # best EL percentile rank
-pp.best_stability               # best pMHC stability (if available)
-pp.best_stability_by_rank
+result.best_affinity_by_rank          # Pred with lowest percentile rank
+result.best_presentation              # best EL/presentation score
+result.best_presentation_by_rank      # best EL percentile rank
+result.best_stability                 # best pMHC stability (if available)
+result.best_stability_by_rank
 
 # filter by kind or allele
-pp.filter(kind=Kind.pMHC_affinity)
-pp.filter(allele="HLA-A*02:01")
+result.filter(kind=Kind.pMHC_affinity)
+result.filter(allele="HLA-A*02:01")
 ```
 
 NetMHCpan 4.1 automatically emits both `pMHC_affinity` and `pMHC_presentation`
@@ -74,7 +91,7 @@ predictions per peptide-allele pair.
 ### Scanning proteins
 
 `predict_proteins()` takes a dictionary of protein sequences and returns
-`{sequence_name: list[PeptidePreds]}`:
+`{sequence_name: list[PeptideResult]}`:
 
 ```python
 proteins = predictor.predict_proteins(
@@ -118,10 +135,10 @@ ms = MultiSample(
     predictor_class=NetMHCpan41,
 )
 
-# {sample_name: list[PeptidePreds]}
+# {sample_name: list[PeptideResult]}
 results = ms.predict(["SIINFEKL", "GILGFVFTL"])
 
-# {sample_name: {seq_name: list[PeptidePreds]}}
+# {sample_name: {seq_name: list[PeptideResult]}}
 protein_results = ms.predict_proteins({"TP53": "MEEPQ..."})
 
 # flat DataFrames with sample_name column
@@ -235,5 +252,5 @@ To convert legacy results to the new types:
 
 ```python
 preds = collection.to_preds()           # list of Pred
-pp_list = collection.to_peptide_preds() # list of PeptidePreds
+pp_list = collection.to_peptide_preds() # list of PeptideResult
 ```

--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -41,7 +41,7 @@ from .netmhcstabpan import NetMHCstabpan
 from .bigmhc import BigMHC
 from .unsupported_allele import UnsupportedAllele
 
-__version__ = "3.2.0"
+__version__ = "3.3.0"
 
 __all__ = [
     "Pred",

--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -1,6 +1,6 @@
 from .binding_prediction import BindingPrediction
 from .binding_prediction_collection import BindingPredictionCollection
-from .pred import Pred, PeptidePreds, Kind, preds_from_rows
+from .pred import Pred, PeptideResult, PeptidePreds, Kind, preds_from_rows
 from .sample import MultiSample
 from .iedb import (
     IedbNetMHCcons,
@@ -45,7 +45,8 @@ __version__ = "3.2.0"
 
 __all__ = [
     "Pred",
-    "PeptidePreds",
+    "PeptideResult",
+    "PeptidePreds",  # backward compat alias
     "Kind",
     "preds_from_rows",
     "MultiSample",

--- a/mhctools/base_commandline_predictor.py
+++ b/mhctools/base_commandline_predictor.py
@@ -27,7 +27,7 @@ from .cleanup_context import CleanupFiles
 from .input_file_formats import create_input_peptides_files
 from .process_helpers import run_multiple_commands_redirect_stdout
 from .binding_prediction_collection import BindingPredictionCollection
-from .pred import PeptidePreds
+from .pred import PeptideResult
 
 logger = logging.getLogger(__name__)
 
@@ -319,18 +319,18 @@ class BaseCommandlinePredictor(BasePredictor):
         if len(all_preds) == 0:
             logger.warning("No predictions from %s" % self.program_name)
 
-        # Group by (peptide, offset, source) into PeptidePreds
+        # Group by (peptide, offset, source) into PeptideResult
         groups = defaultdict(list)
         for pred in all_preds:
             key = (pred.peptide, pred.offset, pred.source_sequence_name)
             groups[key].append(pred)
-        return [PeptidePreds(preds=tuple(preds)) for preds in groups.values()]
+        return [PeptideResult(preds=tuple(preds)) for preds in groups.values()]
 
     def predict(self, peptides):
         """
         Predict for a list of peptide sequences.
 
-        Returns list of PeptidePreds. When a native parse_to_preds_fn is
+        Returns list of PeptideResult. When a native parse_to_preds_fn is
         available, parses directly to Pred objects. Otherwise falls back
         to converting from BindingPrediction.
         """

--- a/mhctools/base_predictor.py
+++ b/mhctools/base_predictor.py
@@ -18,7 +18,7 @@ from .allele_normalization import normalize_allele_name
 
 from .unsupported_allele import UnsupportedAllele
 from .binding_prediction_collection import BindingPredictionCollection
-from .pred import Pred, Kind, PeptidePreds
+from .pred import Pred, Kind, PeptideResult
 
 logger = logging.getLogger(__name__)
 
@@ -95,7 +95,7 @@ class BasePredictor(object):
 
         Returns
         -------
-        list of PeptidePreds
+        list of PeptideResult
         """
         collection = self.predict_peptides(peptides)
         return collection.to_peptide_preds(kind=self._default_pred_kind())
@@ -123,7 +123,7 @@ class BasePredictor(object):
 
         Returns
         -------
-        dict mapping sequence_name -> list of PeptidePreds
+        dict mapping sequence_name -> list of PeptideResult
         """
         if isinstance(sequence_dict, str):
             sequence_dict = {"seq": sequence_dict}
@@ -145,14 +145,14 @@ class BasePredictor(object):
         peptide_list = sorted(peptide_set)
         flat_preds = self.predict(peptide_list)
 
-        # Expand: each PeptidePreds may map to multiple (name, offset) positions
+        # Expand: each PeptideResult may map to multiple (name, offset) positions
         results = defaultdict(list)
         for pp in flat_preds:
             if not pp.preds:
                 continue
             peptide = pp.preds[0].peptide
             for name, offset in peptide_to_name_offset_pairs.get(peptide, []):
-                relocated = PeptidePreds(preds=tuple(
+                relocated = PeptideResult(preds=tuple(
                     Pred(
                         kind=p.kind,
                         score=p.score,

--- a/mhctools/bigmhc.py
+++ b/mhctools/bigmhc.py
@@ -31,7 +31,7 @@ import sys
 import pandas as pd
 import torch
 
-from .pred import Kind, Pred, PeptidePreds, COLUMNS
+from .pred import Kind, Pred, PeptideResult, COLUMNS
 
 
 def _find_bigmhc_dir(bigmhc_path=None):
@@ -236,7 +236,7 @@ class BigMHC:
 
         Returns
         -------
-        list of PeptidePreds
+        list of PeptideResult
             One entry per peptide; each contains one Pred per allele.
         """
         if isinstance(peptides, str):
@@ -268,7 +268,7 @@ class BigMHC:
                     predictor_name=name,
                 ))
                 idx += 1
-            results.append(PeptidePreds(preds=tuple(preds)))
+            results.append(PeptideResult(preds=tuple(preds)))
         return results
 
     def predict_dataframe(self, peptides, sample_name=""):

--- a/mhctools/binding_prediction_collection.py
+++ b/mhctools/binding_prediction_collection.py
@@ -16,7 +16,7 @@ import pandas as pd
 from sercol import Collection
 
 from .binding_prediction import BindingPrediction
-from .pred import Kind, PeptidePreds
+from .pred import Kind, PeptideResult
 
 class BindingPredictionCollection(Collection):
     def to_dataframe(
@@ -32,19 +32,19 @@ class BindingPredictionCollection(Collection):
     def to_preds(self, kind=Kind.pMHC_affinity):
         """Convert all BindingPredictions to Pred objects.
 
-        Returns a list of Pred (not grouped into PeptidePreds, since
+        Returns a list of Pred (not grouped into PeptideResult, since
         BindingPredictionCollection has no peptide-position grouping).
         """
         return [bp.to_pred(kind=kind) for bp in self]
 
     def to_peptide_preds(self, kind=Kind.pMHC_affinity):
-        """Convert to a list of PeptidePreds, grouped by (peptide, offset, source).
+        """Convert to a list of PeptideResult, grouped by (peptide, offset, source).
 
-        Each PeptidePreds contains all alleles for one peptide position.
+        Each PeptideResult contains all alleles for one peptide position.
         """
         from collections import defaultdict
         groups = defaultdict(list)
         for bp in self:
             key = (bp.peptide, bp.offset, bp.source_sequence_name)
             groups[key].append(bp.to_pred(kind=kind))
-        return [PeptidePreds(preds=tuple(preds)) for preds in groups.values()]
+        return [PeptideResult(preds=tuple(preds)) for preds in groups.values()]

--- a/mhctools/pred.py
+++ b/mhctools/pred.py
@@ -85,7 +85,7 @@ class Pred:
 
 
 @dataclass
-class PeptidePreds:
+class PeptideResult:
     """All Preds for one peptide from one predictor."""
     preds: tuple[Pred, ...] = ()
 
@@ -147,7 +147,7 @@ class PeptidePreds:
 
 
 def preds_from_rows(rows, **shared):
-    """Build a PeptidePreds from dicts, with shared fields filled in.
+    """Build a PeptideResult from dicts, with shared fields filled in.
 
     Example::
 
@@ -163,6 +163,10 @@ def preds_from_rows(rows, **shared):
             predictor_version="4.1",
         )
     """
-    return PeptidePreds(preds=tuple(
+    return PeptideResult(preds=tuple(
         Pred(**{**shared, **row}) for row in rows
     ))
+
+
+# Backward compatibility
+PeptidePreds = PeptideResult

--- a/mhctools/pred.py
+++ b/mhctools/pred.py
@@ -12,7 +12,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass, fields
 from enum import Enum
 from typing import Optional
 
@@ -50,7 +50,7 @@ COLUMNS = (
 )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, repr=False)
 class Pred:
     """Single prediction from one model on one peptide. Self-contained."""
     kind: Kind
@@ -65,6 +65,22 @@ class Pred:
     offset: int = 0
     predictor_name: str = ""
     predictor_version: str = ""
+
+    def __repr__(self):
+        parts = [self.peptide or "?", self.kind.value]
+        if self.allele:
+            parts.insert(1, self.allele)
+        parts.append("score=%.4g" % self.score)
+        if self.value is not None:
+            parts.append("value=%.4g" % self.value)
+        if self.percentile_rank is not None:
+            parts.append("rank=%.2f%%" % self.percentile_rank)
+        if self.predictor_name:
+            parts.append(self.predictor_name)
+        return "Pred(%s)" % " | ".join(parts)
+
+    def __str__(self):
+        return repr(self)
 
     def to_row(self, sample_name=""):
         return {
@@ -83,11 +99,40 @@ class Pred:
             "percentile_rank": self.percentile_rank,
         }
 
+    def to_dict(self):
+        """Serialize to a JSON-friendly dict."""
+        d = asdict(self)
+        d["kind"] = self.kind.value
+        return d
 
-@dataclass
+    @classmethod
+    def from_dict(cls, d):
+        """Deserialize from a dict (as produced by :meth:`to_dict`)."""
+        d = dict(d)
+        d["kind"] = Kind(d["kind"])
+        # Only pass fields that Pred knows about
+        valid = {f.name for f in fields(cls)}
+        return cls(**{k: v for k, v in d.items() if k in valid})
+
+
+@dataclass(repr=False)
 class PeptideResult:
-    """All Preds for one peptide from one predictor."""
+    """All predictions for one peptide. Contains a tuple of Pred objects."""
     preds: tuple[Pred, ...] = ()
+
+    def __repr__(self):
+        if not self.preds:
+            return "PeptideResult(empty)"
+        peptide = self.preds[0].peptide or "?"
+        from collections import Counter
+        kinds = Counter(p.kind.value for p in self.preds)
+        kind_str = ", ".join(
+            "%d\u00d7%s" % (n, k) for k, n in kinds.items())
+        return "PeptideResult(%s, %d preds: %s)" % (
+            peptide, len(self.preds), kind_str)
+
+    def __str__(self):
+        return repr(self)
 
     # --- best allele by score (higher = better) ---
 
@@ -124,6 +169,17 @@ class PeptideResult:
         return [p for p in self.preds
                 if (kind is None or p.kind == kind)
                 and (allele is None or p.allele == allele)]
+
+    # --- serialization ---
+
+    def to_dict(self):
+        """Serialize to a JSON-friendly dict."""
+        return {"preds": [p.to_dict() for p in self.preds]}
+
+    @classmethod
+    def from_dict(cls, d):
+        """Deserialize from a dict (as produced by :meth:`to_dict`)."""
+        return cls(preds=tuple(Pred.from_dict(p) for p in d["preds"]))
 
     # --- dataframe ---
 

--- a/mhctools/processing_predictor.py
+++ b/mhctools/processing_predictor.py
@@ -34,7 +34,7 @@ cleavage profile into a single peptide-level score::
 
 from collections import defaultdict
 
-from .pred import Pred, Kind, PeptidePreds
+from .pred import Pred, Kind, PeptideResult
 
 
 # ------------------------------------------------------------------
@@ -271,7 +271,7 @@ class ProcessingPredictor:
 
         Returns
         -------
-        list of PeptidePreds
+        list of PeptideResult
         """
         results = []
         for i, peptide in enumerate(peptides):
@@ -291,7 +291,7 @@ class ProcessingPredictor:
                 c_flank=c_flank,
                 predictor_name=self._predictor_name(),
             )
-            results.append(PeptidePreds(preds=(pred,)))
+            results.append(PeptideResult(preds=(pred,)))
         return results
 
     def predict_dataframe(self, peptides, n_flanks=None, c_flanks=None,
@@ -328,7 +328,7 @@ class ProcessingPredictor:
 
         Returns
         -------
-        dict mapping sequence_name -> list of PeptidePreds
+        dict mapping sequence_name -> list of PeptideResult
         """
         if isinstance(sequence_dict, str):
             sequence_dict = {"seq": sequence_dict}
@@ -360,7 +360,7 @@ class ProcessingPredictor:
                         offset=i,
                         predictor_name=self._predictor_name(),
                     )
-                    results[name].append(PeptidePreds(preds=(pred,)))
+                    results[name].append(PeptideResult(preds=(pred,)))
         return dict(results)
 
     def predict_proteins_dataframe(

--- a/mhctools/sample.py
+++ b/mhctools/sample.py
@@ -48,7 +48,7 @@ class MultiSample:
         """
         Returns
         -------
-        dict mapping sample_name -> list of PeptidePreds
+        dict mapping sample_name -> list of PeptideResult
         """
         results = {}
         for sample_name, alleles in self.samples.items():
@@ -72,7 +72,7 @@ class MultiSample:
         """
         Returns
         -------
-        dict mapping sample_name -> {sequence_name: list of PeptidePreds}
+        dict mapping sample_name -> {sequence_name: list of PeptideResult}
         """
         results = {}
         for sample_name, alleles in self.samples.items():

--- a/tests/test_bigmhc.py
+++ b/tests/test_bigmhc.py
@@ -15,7 +15,7 @@ import os
 import pytest
 
 from mhctools.bigmhc import BigMHC
-from mhctools.pred import Kind, PeptidePreds, COLUMNS
+from mhctools.pred import Kind, PeptideResult, COLUMNS
 
 
 # Skip entire module if BigMHC is not installed
@@ -87,7 +87,7 @@ def test_predict_el_returns_peptide_preds(el_predictor):
     assert isinstance(results, list)
     assert len(results) == len(PEPTIDES)
     for pp in results:
-        assert isinstance(pp, PeptidePreds)
+        assert isinstance(pp, PeptideResult)
         assert len(pp.preds) == len(ALLELES)
 
 

--- a/tests/test_netchop.py
+++ b/tests/test_netchop.py
@@ -14,7 +14,7 @@ import pytest
 from numpy import testing
 from mhctools import NetChop
 from mhctools.proteasome_predictor import ProteasomePredictor
-from mhctools.pred import Kind, PeptidePreds
+from mhctools.pred import Kind, PeptideResult
 from .arch import apple_silicon
 
 # Peptides from http://tools.iedb.org/netchop/example/
@@ -55,7 +55,7 @@ def test_predict_proteins():
     assert "pep0" in result
     pp_list = result["pep0"]
     assert isinstance(pp_list, list)
-    assert all(isinstance(pp, PeptidePreds) for pp in pp_list)
+    assert all(isinstance(pp, PeptideResult) for pp in pp_list)
     for pp in pp_list:
         pred = pp.preds[0]
         assert pred.kind == Kind.proteasome_cleavage

--- a/tests/test_pepsickle.py
+++ b/tests/test_pepsickle.py
@@ -19,7 +19,7 @@ from mhctools.processing_predictor import (
     score_nterm_cterm_anti_max_internal,
 )
 from mhctools.proteasome_predictor import ProteasomePredictor
-from mhctools.pred import Kind, PeptidePreds, COLUMNS
+from mhctools.pred import Kind, PeptideResult, COLUMNS
 
 pepsickle = pytest.importorskip("pepsickle")
 
@@ -91,7 +91,7 @@ def test_predict_returns_peptide_preds(predictor):
     assert isinstance(results, list)
     assert len(results) == len(PEPTIDES)
     for pp in results:
-        assert isinstance(pp, PeptidePreds)
+        assert isinstance(pp, PeptideResult)
         assert len(pp.preds) == 1
         pred = pp.preds[0]
         assert pred.kind == Kind.proteasome_cleavage
@@ -126,7 +126,7 @@ def test_predict_proteins(predictor):
     result = predictor.predict_proteins({"spike": PROTEIN})
     assert "spike" in result
     preds_list = result["spike"]
-    assert all(isinstance(pp, PeptidePreds) for pp in preds_list)
+    assert all(isinstance(pp, PeptideResult) for pp in preds_list)
     expected_count = len(PROTEIN) - 9 + 1
     assert len(preds_list) == expected_count
     for pp in preds_list:

--- a/tests/test_pred.py
+++ b/tests/test_pred.py
@@ -68,6 +68,55 @@ def test_pred_defaults():
     assert p.percentile_rank is None
 
 
+def test_pred_repr():
+    p = Pred(kind=Kind.pMHC_affinity, score=0.85, peptide="SIINFEKL",
+             allele="HLA-A*02:01", value=120.5, percentile_rank=0.8,
+             predictor_name="netMHCpan")
+    r = repr(p)
+    assert "SIINFEKL" in r
+    assert "HLA-A*02:01" in r
+    assert "pMHC_affinity" in r
+    assert "score=0.85" in r
+    assert "value=120.5" in r
+    assert "rank=0.80%" in r
+    assert "netMHCpan" in r
+    assert str(p) == r
+
+
+def test_pred_repr_minimal():
+    p = Pred(kind=Kind.proteasome_cleavage, score=0.5)
+    r = repr(p)
+    assert "score=0.5" in r
+    assert "value" not in r
+    assert "rank" not in r
+
+
+def test_pred_to_dict_round_trip():
+    p = Pred(kind=Kind.pMHC_affinity, score=0.85, peptide="SIINFEKL",
+             allele="HLA-A*02:01", value=120.5, percentile_rank=0.8)
+    d = p.to_dict()
+    assert d["kind"] == "pMHC_affinity"
+    assert d["score"] == 0.85
+    p2 = Pred.from_dict(d)
+    assert p == p2
+
+
+def test_pred_to_dict_json_serializable():
+    import json
+    p = Pred(kind=Kind.pMHC_affinity, score=0.85, peptide="SIINFEKL")
+    s = json.dumps(p.to_dict())
+    p2 = Pred.from_dict(json.loads(s))
+    assert p == p2
+
+
+def test_pred_eq():
+    p1 = Pred(kind=Kind.pMHC_affinity, score=0.85, peptide="SIINFEKL")
+    p2 = Pred(kind=Kind.pMHC_affinity, score=0.85, peptide="SIINFEKL")
+    p3 = Pred(kind=Kind.pMHC_affinity, score=0.50, peptide="SIINFEKL")
+    assert p1 == p2
+    assert p1 != p3
+
+
 # -- PeptideResult --
 
 def _make_pred_set():
@@ -95,6 +144,41 @@ def test_preds_from_rows():
     for p in ps.preds:
         assert p.peptide == "SIINFEKL"
         assert p.predictor_name == "mhcflurry"
+
+
+def test_peptide_result_repr():
+    ps = _make_pred_set()
+    r = repr(ps)
+    assert "SIINFEKL" in r
+    assert "5 preds" in r
+    assert "pMHC_affinity" in r
+    assert str(ps) == r
+
+
+def test_peptide_result_repr_empty():
+    assert "empty" in repr(PeptideResult())
+
+
+def test_peptide_result_to_dict_round_trip():
+    ps = _make_pred_set()
+    d = ps.to_dict()
+    assert len(d["preds"]) == 5
+    ps2 = PeptideResult.from_dict(d)
+    assert ps == ps2
+
+
+def test_peptide_result_to_dict_json_serializable():
+    import json
+    ps = _make_pred_set()
+    s = json.dumps(ps.to_dict())
+    ps2 = PeptideResult.from_dict(json.loads(s))
+    assert ps == ps2
+
+
+def test_peptide_result_eq():
+    ps1 = _make_pred_set()
+    ps2 = _make_pred_set()
+    assert ps1 == ps2
 
 
 def test_best_affinity():

--- a/tests/test_pred.py
+++ b/tests/test_pred.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mhctools.pred import Pred, PeptidePreds, Kind, preds_from_rows, COLUMNS
+from mhctools.pred import Pred, PeptideResult, Kind, preds_from_rows, COLUMNS
 from mhctools.sample import MultiSample
 from mhctools.binding_prediction import BindingPrediction
 from mhctools.binding_prediction_collection import BindingPredictionCollection
@@ -68,7 +68,7 @@ def test_pred_defaults():
     assert p.percentile_rank is None
 
 
-# -- PeptidePreds --
+# -- PeptideResult --
 
 def _make_pred_set():
     return preds_from_rows(
@@ -158,7 +158,7 @@ def test_to_dataframe():
 
 
 def test_empty_pred_set():
-    ps = PeptidePreds()
+    ps = PeptideResult()
     assert ps.best_affinity is None
     df = ps.to_dataframe()
     assert list(df.columns) == list(COLUMNS)
@@ -173,7 +173,7 @@ def test_predict_returns_peptide_preds():
         default_peptide_lengths=[9])
     results = predictor.predict(["SIINFEKLL", "GILGFVFTL"])
     assert isinstance(results, list)
-    assert all(isinstance(pp, PeptidePreds) for pp in results)
+    assert all(isinstance(pp, PeptideResult) for pp in results)
     assert len(results) == 2
     for pp in results:
         assert pp.best_affinity is not None
@@ -195,7 +195,7 @@ def test_predict_proteins():
     result = predictor.predict_proteins({"TP53": "SIINFEKLLAA"})
     assert "TP53" in result
     assert isinstance(result["TP53"], list)
-    assert all(isinstance(pp, PeptidePreds) for pp in result["TP53"])
+    assert all(isinstance(pp, PeptideResult) for pp in result["TP53"])
     for pp in result["TP53"]:
         for pred in pp.preds:
             assert pred.source_sequence_name == "TP53"
@@ -225,7 +225,7 @@ def test_multi_sample_predict():
     results = ms.predict(["SIINFEKLL"])
     assert "pat001" in results
     assert "pat002" in results
-    assert all(isinstance(pp, PeptidePreds) for pp in results["pat001"])
+    assert all(isinstance(pp, PeptideResult) for pp in results["pat001"])
 
 
 def test_multi_sample_predict_dataframe():

--- a/tests/test_processing_predictor.py
+++ b/tests/test_processing_predictor.py
@@ -33,7 +33,7 @@ from mhctools.processing_predictor import (
     _geomean,
 )
 from mhctools.proteasome_predictor import ProteasomePredictor
-from mhctools.pred import Kind, PeptidePreds, COLUMNS
+from mhctools.pred import Kind, PeptideResult, COLUMNS
 
 
 # ======================================================================
@@ -517,7 +517,7 @@ class TestPredict:
         results = stub.predict(["ABCD", "EFGH"])
         assert len(results) == 2
         for pp in results:
-            assert isinstance(pp, PeptidePreds)
+            assert isinstance(pp, PeptideResult)
             assert len(pp.preds) == 1
             assert pp.preds[0].kind == Kind.antigen_processing
             assert pp.preds[0].predictor_name == "stubpredictor"


### PR DESCRIPTION
## Summary
- Rename `PeptidePreds` → `PeptideResult` across 14 files (clearer: "the result for one peptide")
- `PeptidePreds` kept as backward-compat alias in `pred.py` and `__init__.py`
- Add **Data model** section to README that introduces `PeptideResult` and `Pred` upfront, explaining the two-level structure before it appears in code examples
- Use clearer variable names (`result` instead of `pp`) in README examples

## Test plan
- [x] 206 tests pass, lint clean
- [x] Backward compat: `from mhctools import PeptidePreds` still works
- [x] Verified no stale references (only alias + export remain)