### PR TITLE
Register BigMHC as CLI predictor options

### DIFF
--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -38,7 +38,7 @@ from .netmhc_pan42 import NetMHCpan42, NetMHCpan42_BA, NetMHCpan42_EL
 from .netmhcii_pan import NetMHCIIpan, NetMHCIIpan3, NetMHCIIpan4, NetMHCIIpan4_BA, NetMHCIIpan4_EL, NetMHCIIpan43, NetMHCIIpan43_BA, NetMHCIIpan43_EL
 from .random_predictor import RandomBindingPredictor
 from .netmhcstabpan import NetMHCstabpan
-from .bigmhc import BigMHC
+from .bigmhc import BigMHC, BigMHC_EL, BigMHC_IM
 from .unsupported_allele import UnsupportedAllele
 
 __version__ = "3.3.0"
@@ -97,6 +97,8 @@ __all__ = [
     "NetMHCIIpan43_EL",
     "NetMHCstabpan",
     "BigMHC",
+    "BigMHC_EL",
+    "BigMHC_IM",
     "RandomBindingPredictor",
     "UnsupportedAllele",
 ]

--- a/mhctools/bigmhc.py
+++ b/mhctools/bigmhc.py
@@ -277,3 +277,21 @@ class BigMHC:
         if not dfs:
             return pd.DataFrame(columns=COLUMNS)
         return pd.concat(dfs, ignore_index=True)
+
+
+class BigMHC_EL(BigMHC):
+    """BigMHC in presentation (eluted-ligand) mode."""
+    def __init__(self, alleles, bigmhc_path=None, device="cpu",
+                 max_batch_size=4096):
+        BigMHC.__init__(
+            self, alleles, mode="el", bigmhc_path=bigmhc_path,
+            device=device, max_batch_size=max_batch_size)
+
+
+class BigMHC_IM(BigMHC):
+    """BigMHC in immunogenicity mode."""
+    def __init__(self, alleles, bigmhc_path=None, device="cpu",
+                 max_batch_size=4096):
+        BigMHC.__init__(
+            self, alleles, mode="im", bigmhc_path=bigmhc_path,
+            device=device, max_batch_size=max_batch_size)

--- a/mhctools/cli/args.py
+++ b/mhctools/cli/args.py
@@ -50,6 +50,9 @@ from .. import (
     IedbNetMHCIIpan,
     MHCflurry,
     MixMHCpred,
+    BigMHC,
+    BigMHC_EL,
+    BigMHC_IM,
 )
 
 
@@ -90,6 +93,9 @@ mhc_predictors = {
     # "smm-pmbec": None,
     "mhcflurry": MHCflurry,
     "mixmhcpred": MixMHCpred,
+    "bigmhc": BigMHC,
+    "bigmhc-el": BigMHC_EL,
+    "bigmhc-im": BigMHC_IM,
 }
 
 def add_mhc_args(arg_parser):
@@ -190,7 +196,10 @@ def mhc_binding_predictor_from_args(args):
         kwargs["models_path"] = args.mhc_predictor_models_path
 
     if args.mhc_predictor_path:
-        kwargs["program_name"] = args.mhc_predictor_path
+        if 'bigmhc' in args.mhc_predictor:
+            kwargs["bigmhc_path"] = args.mhc_predictor_path
+        else:
+            kwargs["program_name"] = args.mhc_predictor_path
 
     if args.do_not_raise_on_error:
         if 'iedb' in args.mhc_predictor.lower():


### PR DESCRIPTION
## Summary
- Add `BigMHC_EL` and `BigMHC_IM` subclasses (following the `NetMHCpan4_EL`/`NetMHCpan4_BA` pattern) that fix the mode parameter
- Register `bigmhc`, `bigmhc-el`, and `bigmhc-im` in the CLI predictor registry
- Map `--mhc-predictor-path` to `bigmhc_path` when a BigMHC predictor is selected

## Usage
```
--mhc-predictor bigmhc        # defaults to EL mode
--mhc-predictor bigmhc-el     # presentation (eluted-ligand) mode
--mhc-predictor bigmhc-im     # immunogenicity mode
```

Optionally specify the BigMHC repo path:
```
--mhc-predictor bigmhc-el --mhc-predictor-path /path/to/bigmhc
```

## Test plan
- [ ] Verify CLI arg parsing accepts the three new predictor names
- [ ] Verify `--mhc-predictor-path` maps to `bigmhc_path` for BigMHC predictors
- [ ] Existing predictor CLI options remain unaffected