### PR TITLE
Add all predictors to CLI, add --predictors flag

### DIFF
--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -41,7 +41,7 @@ from .netmhcstabpan import NetMHCstabpan
 from .bigmhc import BigMHC
 from .unsupported_allele import UnsupportedAllele
 
-__version__ = "3.3.0"
+__version__ = "3.4.0"
 
 __all__ = [
     "Pred",

--- a/mhctools/cli/__init__.py
+++ b/mhctools/cli/__init__.py
@@ -22,6 +22,7 @@ from .args import (
     make_mhc_arg_parser,
     add_mhc_args,
     mhc_predictors,
+    predictors_from_args,
 )
 
 __all__ = [
@@ -30,4 +31,5 @@ __all__ = [
     "make_mhc_arg_parser",
     "add_mhc_args",
     "mhc_predictors",
+    "predictors_from_args",
 ]

--- a/mhctools/cli/args.py
+++ b/mhctools/cli/args.py
@@ -36,12 +36,22 @@ from .. import (
     NetMHCpan41,
     NetMHCpan41_EL,
     NetMHCpan41_BA,
+    NetMHCpan42,
+    NetMHCpan42_EL,
+    NetMHCpan42_BA,
     NetMHCIIpan,
     NetMHCIIpan3,
     NetMHCIIpan4,
     NetMHCIIpan4_EL,
     NetMHCIIpan4_BA,
+    NetMHCIIpan43,
+    NetMHCIIpan43_EL,
+    NetMHCIIpan43_BA,
     NetMHCcons,
+    NetMHCstabpan,
+    BigMHC,
+    NetChop,
+    Pepsickle,
     RandomBindingPredictor,
     IedbNetMHCpan,
     IedbNetMHCcons,
@@ -66,6 +76,9 @@ mhc_predictors = {
     "netmhcpan41": NetMHCpan41,
     "netmhcpan41-ba": NetMHCpan41_BA,
     "netmhcpan41-el": NetMHCpan41_EL,
+    "netmhcpan42": NetMHCpan42,
+    "netmhcpan42-ba": NetMHCpan42_BA,
+    "netmhcpan42-el": NetMHCpan42_EL,
     "netmhcpan28": NetMHCpan28,
     "netmhcpan3": NetMHCpan3,
     "netmhciipan": NetMHCIIpan,
@@ -73,7 +86,14 @@ mhc_predictors = {
     "netmhciipan4": NetMHCIIpan4,
     "netmhciipan4-ba": NetMHCIIpan4_BA,
     "netmhciipan4-el": NetMHCIIpan4_EL,
+    "netmhciipan43": NetMHCIIpan43,
+    "netmhciipan43-ba": NetMHCIIpan43_BA,
+    "netmhciipan43-el": NetMHCIIpan43_EL,
     "netmhccons": NetMHCcons,
+    "netmhcstabpan": NetMHCstabpan,
+    "bigmhc": BigMHC,
+    "netchop": NetChop,
+    "pepsickle": Pepsickle,
     "random": RandomBindingPredictor,
     # use NetMHCpan via IEDB's web API
     "netmhcpan-iedb": IedbNetMHCpan,
@@ -85,39 +105,63 @@ mhc_predictors = {
     "smm-pmbec-iedb": IedbSMM_PMBEC,
     # Class II MHC binding prediction using NetMHCIIpan via IEDB
     "netmhciipan-iedb": IedbNetMHCIIpan,
-    # TODO implement SMM predictors in mhctools
-    # "smm": None,
-    # "smm-pmbec": None,
     "mhcflurry": MHCflurry,
     "mixmhcpred": MixMHCpred,
 }
 
+# Predictors that don't take alleles (processing/cleavage predictors)
+_no_allele_predictors = {"netchop", "pepsickle"}
+
+def _parse_predictor_list(value):
+    """Parse a comma-separated list of predictor names."""
+    names = [s.strip().lower() for s in value.split(",")]
+    for name in names:
+        if name not in mhc_predictors:
+            from argparse import ArgumentTypeError
+            available = sorted(mhc_predictors.keys())
+            raise ArgumentTypeError(
+                "Unknown predictor %r. Available: %s" % (name, available))
+    return names
+
+
 def add_mhc_args(arg_parser):
     mhc_options_arg_group = arg_parser.add_argument_group(
-        title="MHC Prediction Options",
-        description="MHC Binding Prediction Options")
+        title="Prediction Options",
+        description="Model selection and prediction options")
+
+    mhc_options_arg_group.add_argument(
+        "--predictors",
+        type=_parse_predictor_list,
+        default=None,
+        help=(
+            "Comma-separated list of predictor names to run. "
+            "Can specify one or more: e.g. 'netmhcpan42' or "
+            "'netmhcpan42,bigmhc,pepsickle'. "
+            "Available: %s" % ", ".join(sorted(mhc_predictors.keys()))
+        ))
 
     mhc_options_arg_group.add_argument(
         "--mhc-predictor",
         choices=list(sorted(mhc_predictors.keys())),
         type=lambda s: s.lower().strip(),
-        required=True)
+        default=None,
+        help="Deprecated: use --predictors instead. "
+             "Single prediction method to use.")
 
     mhc_options_arg_group.add_argument(
         "--mhc-predictor-path",
-        help="Path to executable program used for MHC binding predictor",
+        help="Path to executable program used for command-line predictors",
         default=None,
         required=False)
 
     mhc_options_arg_group.add_argument(
         "--mhc-predictor-models-path",
-        help="Path to models to use with predictor. Currently supported only "
-        "by mhcflurry predictor.")
+        help="Path to models to use with predictor (e.g. mhcflurry).")
 
     mhc_options_arg_group.add_argument(
         "--mhc-peptide-lengths",
         type=parse_int_list,
-        help="Lengths of epitopes to consider for MHC binding prediction")
+        help="Lengths of epitopes to consider for binding prediction")
 
     mhc_options_arg_group.add_argument(
         "--mhc-epitope-lengths",
@@ -166,12 +210,86 @@ def mhc_alleles_from_args(args):
             "MHC alleles required (use --mhc-alleles or --mhc-alleles-file)")
     return alleles
 
+def predictors_from_args(args):
+    """Build a list of predictor instances from --predictors (or --mhc-predictor).
+
+    Returns a list of instantiated predictor objects.
+    """
+    predictor_names = getattr(args, "predictors", None)
+    mhc_predictor = getattr(args, "mhc_predictor", None)
+
+    if predictor_names and mhc_predictor:
+        raise ValueError(
+            "--predictors and --mhc-predictor are mutually exclusive. "
+            "Use --predictors (which supports multiple models)."
+        )
+
+    if not predictor_names and not mhc_predictor:
+        raise ValueError(
+            "Either --predictors or --mhc-predictor is required."
+        )
+
+    if mhc_predictor:
+        logger.warning(
+            "--mhc-predictor is deprecated; use --predictors instead"
+        )
+        predictor_names = [mhc_predictor]
+
+    # Determine if any model needs alleles
+    needs_alleles = any(n not in _no_allele_predictors for n in predictor_names)
+    alleles = None
+    if needs_alleles:
+        alleles = mhc_alleles_from_args(args)
+    elif args.mhc_alleles or getattr(args, "mhc_alleles_file", None):
+        logger.info("Alleles ignored — no selected predictor requires them")
+
+    peptide_lengths = getattr(args, "mhc_peptide_lengths", None)
+    if not peptide_lengths:
+        peptide_lengths = getattr(args, "mhc_epitope_lengths", None)
+
+    models = []
+    for name in predictor_names:
+        cls = mhc_predictors[name]
+        kwargs = {}
+        if name not in _no_allele_predictors:
+            kwargs["alleles"] = alleles
+        if peptide_lengths is not None:
+            kwargs["default_peptide_lengths"] = peptide_lengths
+        if getattr(args, "mhc_predictor_models_path", None):
+            kwargs["models_path"] = args.mhc_predictor_models_path
+        if getattr(args, "mhc_predictor_path", None):
+            kwargs["program_name"] = args.mhc_predictor_path
+        if getattr(args, "do_not_raise_on_error", False):
+            if "iedb" in name:
+                kwargs["raise_on_error"] = False
+            else:
+                logger.warning(
+                    "--do-not-raise-on-error ignored for non-IEDB predictor %s",
+                    name,
+                )
+        logger.info("Building predictor %s(%s)", cls.__name__, kwargs)
+        models.append(cls(**kwargs))
+    return models
+
+
 def mhc_binding_predictor_from_args(args):
     mhc_class = mhc_predictors.get(args.mhc_predictor)
     if mhc_class is None:
         raise ValueError(
             "Invalid MHC prediction method: %s" % (args.mhc_predictor,))
-    alleles = mhc_alleles_from_args(args)
+
+    needs_alleles = args.mhc_predictor not in _no_allele_predictors
+
+    if needs_alleles:
+        alleles = mhc_alleles_from_args(args)
+    else:
+        alleles = None
+        # Still allow alleles to be empty for processing predictors
+        if args.mhc_alleles or args.mhc_alleles_file:
+            logger.info(
+                "Alleles ignored for processing predictor %s" %
+                args.mhc_predictor)
+
     peptide_lengths = args.mhc_peptide_lengths
     if not peptide_lengths:
         peptide_lengths = args.mhc_epitope_lengths
@@ -179,10 +297,13 @@ def mhc_binding_predictor_from_args(args):
         ("Building MHC binding prediction %s"
          " for alleles %s"
          " and epitope lengths %s") % (
-            mhc_class.__class__.__name__,
+            mhc_class.__name__,
             alleles,
             peptide_lengths))
-    kwargs = dict(alleles=alleles)
+
+    kwargs = {}
+    if needs_alleles:
+        kwargs["alleles"] = alleles
     if peptide_lengths is not None:
         kwargs["default_peptide_lengths"] = peptide_lengths
 

--- a/tests/test_cli_registry.py
+++ b/tests/test_cli_registry.py
@@ -1,0 +1,46 @@
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from mhctools.cli import mhc_predictors
+from mhctools.cli.args import _no_allele_predictors
+
+
+def test_all_models_in_registry():
+    """Verify all major model classes are available via CLI."""
+    expected = [
+        "netmhcpan42", "netmhcpan42-ba", "netmhcpan42-el",
+        "netmhciipan43", "netmhciipan43-ba", "netmhciipan43-el",
+        "bigmhc", "netmhcstabpan", "netchop", "pepsickle",
+        # legacy entries that should still be present
+        "netmhcpan", "netmhcpan4", "netmhcpan41",
+        "netmhciipan", "netmhciipan4",
+        "mhcflurry", "mixmhcpred", "random",
+    ]
+    for name in expected:
+        assert name in mhc_predictors, f"{name} missing from mhc_predictors registry"
+
+
+def test_no_allele_predictors_in_registry():
+    """Verify processing predictors are marked as not needing alleles."""
+    for name in _no_allele_predictors:
+        assert name in mhc_predictors, (
+            f"{name} in _no_allele_predictors but not in mhc_predictors"
+        )
+
+
+def test_all_registry_values_are_callable():
+    """Every registry value should be callable (class or factory function)."""
+    for name, cls in mhc_predictors.items():
+        assert callable(cls), (
+            f"mhc_predictors[{name!r}] = {cls!r} is not callable"
+        )


### PR DESCRIPTION
## Summary
- Add 10 missing models to CLI registry: `netmhcpan42`, `netmhcpan42-ba`, `netmhcpan42-el`, `netmhciipan43`, `netmhciipan43-ba`, `netmhciipan43-el`, `bigmhc`, `netmhcstabpan`, `netchop`, `pepsickle`
- Add `--predictors` flag supporting comma-separated multi-model selection (e.g. `--predictors netmhcpan42,bigmhc,pepsickle`)
- Deprecate `--mhc-predictor` in favor of `--predictors`
- Handle allele-free processing predictors (netchop, pepsickle)
- Bump version to 3.4.0

## Test plan
- [x] New `test_cli_registry.py` verifies all models in registry
- [x] Existing tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)