### PR TITLE
Add BigMHC_EL/IM subclasses, unify --mhc-predictor with introspection

### DIFF
--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -38,7 +38,7 @@ from .netmhc_pan42 import NetMHCpan42, NetMHCpan42_BA, NetMHCpan42_EL
 from .netmhcii_pan import NetMHCIIpan, NetMHCIIpan3, NetMHCIIpan4, NetMHCIIpan4_BA, NetMHCIIpan4_EL, NetMHCIIpan43, NetMHCIIpan43_BA, NetMHCIIpan43_EL
 from .random_predictor import RandomBindingPredictor
 from .netmhcstabpan import NetMHCstabpan
-from .bigmhc import BigMHC
+from .bigmhc import BigMHC, BigMHC_EL, BigMHC_IM
 from .unsupported_allele import UnsupportedAllele
 
 __version__ = "3.4.0"
@@ -97,6 +97,8 @@ __all__ = [
     "NetMHCIIpan43_EL",
     "NetMHCstabpan",
     "BigMHC",
+    "BigMHC_EL",
+    "BigMHC_IM",
     "RandomBindingPredictor",
     "UnsupportedAllele",
 ]

--- a/mhctools/bigmhc.py
+++ b/mhctools/bigmhc.py
@@ -277,3 +277,21 @@ class BigMHC:
         if not dfs:
             return pd.DataFrame(columns=COLUMNS)
         return pd.concat(dfs, ignore_index=True)
+
+
+class BigMHC_EL(BigMHC):
+    """BigMHC in presentation (eluted-ligand) mode."""
+    def __init__(self, alleles, bigmhc_path=None, device="cpu",
+                 max_batch_size=4096):
+        BigMHC.__init__(
+            self, alleles, mode="el", bigmhc_path=bigmhc_path,
+            device=device, max_batch_size=max_batch_size)
+
+
+class BigMHC_IM(BigMHC):
+    """BigMHC in immunogenicity mode."""
+    def __init__(self, alleles, bigmhc_path=None, device="cpu",
+                 max_batch_size=4096):
+        BigMHC.__init__(
+            self, alleles, mode="im", bigmhc_path=bigmhc_path,
+            device=device, max_batch_size=max_batch_size)

--- a/mhctools/cli/__init__.py
+++ b/mhctools/cli/__init__.py
@@ -23,6 +23,7 @@ from .args import (
     add_mhc_args,
     mhc_predictors,
     predictors_from_args,
+    _cls_accepts,
 )
 
 __all__ = [
@@ -32,4 +33,5 @@ __all__ = [
     "add_mhc_args",
     "mhc_predictors",
     "predictors_from_args",
+    "_cls_accepts",
 ]

--- a/mhctools/cli/args.py
+++ b/mhctools/cli/args.py
@@ -18,6 +18,7 @@ Commandline options for MHC Binding Prediction
 """
 
 from argparse import ArgumentParser
+import inspect
 import logging
 
 from ..allele_normalization import normalize_allele_name
@@ -50,6 +51,8 @@ from .. import (
     NetMHCcons,
     NetMHCstabpan,
     BigMHC,
+    BigMHC_EL,
+    BigMHC_IM,
     NetChop,
     Pepsickle,
     RandomBindingPredictor,
@@ -92,6 +95,8 @@ mhc_predictors = {
     "netmhccons": NetMHCcons,
     "netmhcstabpan": NetMHCstabpan,
     "bigmhc": BigMHC,
+    "bigmhc-el": BigMHC_EL,
+    "bigmhc-im": BigMHC_IM,
     "netchop": NetChop,
     "pepsickle": Pepsickle,
     "random": RandomBindingPredictor,
@@ -109,18 +114,24 @@ mhc_predictors = {
     "mixmhcpred": MixMHCpred,
 }
 
-# Predictors that don't take alleles (processing/cleavage predictors)
-_no_allele_predictors = {"netchop", "pepsickle"}
 
-def _parse_predictor_list(value):
-    """Parse a comma-separated list of predictor names."""
-    names = [s.strip().lower() for s in value.split(",")]
+def _cls_accepts(cls, param_name):
+    """Check whether a predictor class/factory accepts a given __init__ parameter."""
+    sig = inspect.signature(cls)
+    if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()):
+        return True
+    return param_name in sig.parameters
+
+
+def _parse_predictor_names(value):
+    """Normalize a single CLI token: lowercase, split on commas, validate."""
+    names = [s.strip().lower() for s in value.split(",") if s.strip()]
     for name in names:
         if name not in mhc_predictors:
             from argparse import ArgumentTypeError
-            available = sorted(mhc_predictors.keys())
             raise ArgumentTypeError(
-                "Unknown predictor %r. Available: %s" % (name, available))
+                "Unknown predictor %r. Available: %s"
+                % (name, ", ".join(sorted(mhc_predictors.keys()))))
     return names
 
 
@@ -130,27 +141,21 @@ def add_mhc_args(arg_parser):
         description="Model selection and prediction options")
 
     mhc_options_arg_group.add_argument(
-        "--predictors",
-        type=_parse_predictor_list,
-        default=None,
+        "--mhc-predictor",
+        nargs="+",
+        type=_parse_predictor_names,
+        required=True,
         help=(
-            "Comma-separated list of predictor names to run. "
-            "Can specify one or more: e.g. 'netmhcpan42' or "
-            "'netmhcpan42,bigmhc,pepsickle'. "
+            "One or more predictor names, space or comma separated. "
+            "E.g. '--mhc-predictor netmhcpan42' or "
+            "'--mhc-predictor netmhcpan42 bigmhc-el pepsickle' or "
+            "'--mhc-predictor netmhcpan42,bigmhc-el,pepsickle'. "
             "Available: %s" % ", ".join(sorted(mhc_predictors.keys()))
         ))
 
     mhc_options_arg_group.add_argument(
-        "--mhc-predictor",
-        choices=list(sorted(mhc_predictors.keys())),
-        type=lambda s: s.lower().strip(),
-        default=None,
-        help="Deprecated: use --predictors instead. "
-             "Single prediction method to use.")
-
-    mhc_options_arg_group.add_argument(
         "--mhc-predictor-path",
-        help="Path to executable program used for command-line predictors",
+        help="Path to executable program or model directory",
         default=None,
         required=False)
 
@@ -210,113 +215,64 @@ def mhc_alleles_from_args(args):
             "MHC alleles required (use --mhc-alleles or --mhc-alleles-file)")
     return alleles
 
+def _flatten_predictor_names(args):
+    """Flatten the nested list from nargs="+" + comma-splitting type function."""
+    raw = args.mhc_predictor  # list of lists
+    return [name for group in raw for name in group]
+
+def _build_predictor(cls, name, alleles, peptide_lengths, args):
+    """Build a single predictor instance, passing only kwargs it accepts."""
+    kwargs = {}
+    if alleles is not None and _cls_accepts(cls, "alleles"):
+        kwargs["alleles"] = alleles
+    if peptide_lengths is not None and _cls_accepts(cls, "default_peptide_lengths"):
+        kwargs["default_peptide_lengths"] = peptide_lengths
+    if getattr(args, "mhc_predictor_models_path", None) and _cls_accepts(cls, "models_path"):
+        kwargs["models_path"] = args.mhc_predictor_models_path
+    if getattr(args, "mhc_predictor_path", None):
+        if _cls_accepts(cls, "bigmhc_path"):
+            kwargs["bigmhc_path"] = args.mhc_predictor_path
+        elif _cls_accepts(cls, "program_name"):
+            kwargs["program_name"] = args.mhc_predictor_path
+    if getattr(args, "do_not_raise_on_error", False):
+        if _cls_accepts(cls, "raise_on_error"):
+            kwargs["raise_on_error"] = False
+        else:
+            logger.warning(
+                "--do-not-raise-on-error ignored for predictor %s", name)
+    logger.info("Building predictor %s(%s)",
+                getattr(cls, "__name__", name), kwargs)
+    return cls(**kwargs)
+
+
 def predictors_from_args(args):
-    """Build a list of predictor instances from --predictors (or --mhc-predictor).
+    """Build predictor instances from --mhc-predictor.
 
     Returns a list of instantiated predictor objects.
     """
-    predictor_names = getattr(args, "predictors", None)
-    mhc_predictor = getattr(args, "mhc_predictor", None)
+    names = _flatten_predictor_names(args)
 
-    if predictor_names and mhc_predictor:
-        raise ValueError(
-            "--predictors and --mhc-predictor are mutually exclusive. "
-            "Use --predictors (which supports multiple models)."
-        )
-
-    if not predictor_names and not mhc_predictor:
-        raise ValueError(
-            "Either --predictors or --mhc-predictor is required."
-        )
-
-    if mhc_predictor:
-        logger.warning(
-            "--mhc-predictor is deprecated; use --predictors instead"
-        )
-        predictor_names = [mhc_predictor]
-
-    # Determine if any model needs alleles
-    needs_alleles = any(n not in _no_allele_predictors for n in predictor_names)
+    # Fetch alleles only if at least one predictor needs them
+    needs_alleles = any(_cls_accepts(mhc_predictors[n], "alleles") for n in names)
     alleles = None
     if needs_alleles:
         alleles = mhc_alleles_from_args(args)
-    elif args.mhc_alleles or getattr(args, "mhc_alleles_file", None):
-        logger.info("Alleles ignored — no selected predictor requires them")
 
     peptide_lengths = getattr(args, "mhc_peptide_lengths", None)
     if not peptide_lengths:
         peptide_lengths = getattr(args, "mhc_epitope_lengths", None)
 
-    models = []
-    for name in predictor_names:
-        cls = mhc_predictors[name]
-        kwargs = {}
-        if name not in _no_allele_predictors:
-            kwargs["alleles"] = alleles
-        if peptide_lengths is not None:
-            kwargs["default_peptide_lengths"] = peptide_lengths
-        if getattr(args, "mhc_predictor_models_path", None):
-            kwargs["models_path"] = args.mhc_predictor_models_path
-        if getattr(args, "mhc_predictor_path", None):
-            kwargs["program_name"] = args.mhc_predictor_path
-        if getattr(args, "do_not_raise_on_error", False):
-            if "iedb" in name:
-                kwargs["raise_on_error"] = False
-            else:
-                logger.warning(
-                    "--do-not-raise-on-error ignored for non-IEDB predictor %s",
-                    name,
-                )
-        logger.info("Building predictor %s(%s)", cls.__name__, kwargs)
-        models.append(cls(**kwargs))
-    return models
+    return [
+        _build_predictor(mhc_predictors[name], name, alleles, peptide_lengths, args)
+        for name in names
+    ]
 
 
 def mhc_binding_predictor_from_args(args):
-    mhc_class = mhc_predictors.get(args.mhc_predictor)
-    if mhc_class is None:
+    """Build a single predictor from --mhc-predictor (legacy entry point)."""
+    names = _flatten_predictor_names(args)
+    if len(names) != 1:
         raise ValueError(
-            "Invalid MHC prediction method: %s" % (args.mhc_predictor,))
-
-    needs_alleles = args.mhc_predictor not in _no_allele_predictors
-
-    if needs_alleles:
-        alleles = mhc_alleles_from_args(args)
-    else:
-        alleles = None
-        # Still allow alleles to be empty for processing predictors
-        if args.mhc_alleles or args.mhc_alleles_file:
-            logger.info(
-                "Alleles ignored for processing predictor %s" %
-                args.mhc_predictor)
-
-    peptide_lengths = args.mhc_peptide_lengths
-    if not peptide_lengths:
-        peptide_lengths = args.mhc_epitope_lengths
-    logger.info(
-        ("Building MHC binding prediction %s"
-         " for alleles %s"
-         " and epitope lengths %s") % (
-            mhc_class.__name__,
-            alleles,
-            peptide_lengths))
-
-    kwargs = {}
-    if needs_alleles:
-        kwargs["alleles"] = alleles
-    if peptide_lengths is not None:
-        kwargs["default_peptide_lengths"] = peptide_lengths
-
-    if args.mhc_predictor_models_path:
-        kwargs["models_path"] = args.mhc_predictor_models_path
-
-    if args.mhc_predictor_path:
-        kwargs["program_name"] = args.mhc_predictor_path
-
-    if args.do_not_raise_on_error:
-        if 'iedb' in args.mhc_predictor.lower():
-            kwargs["raise_on_error"] = False
-        else:
-            logger.warning('--do-not-raise-on-error ignored for non-IEDB predictor')
-
-    return mhc_class(**kwargs)
+            "mhc_binding_predictor_from_args expects exactly one predictor, "
+            "got %d. Use predictors_from_args for multiple." % len(names))
+    return predictors_from_args(args)[0]

--- a/tests/test_cli_registry.py
+++ b/tests/test_cli_registry.py
@@ -11,16 +11,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mhctools.cli import mhc_predictors
-from mhctools.cli.args import _no_allele_predictors
+from argparse import ArgumentTypeError, Namespace
 
+import pytest
+
+from mhctools.cli import mhc_predictors, make_mhc_arg_parser, predictors_from_args, _cls_accepts
+from mhctools.cli.args import (
+    _parse_predictor_names,
+    _build_predictor,
+    mhc_binding_predictor_from_args,
+)
+from mhctools.bigmhc import BigMHC, BigMHC_EL, BigMHC_IM
+from mhctools.random_predictor import RandomBindingPredictor
+from mhctools.pepsickle import Pepsickle
+
+
+# ── Registry completeness ──────────────────────────────────────────
 
 def test_all_models_in_registry():
     """Verify all major model classes are available via CLI."""
     expected = [
         "netmhcpan42", "netmhcpan42-ba", "netmhcpan42-el",
         "netmhciipan43", "netmhciipan43-ba", "netmhciipan43-el",
-        "bigmhc", "netmhcstabpan", "netchop", "pepsickle",
+        "bigmhc", "bigmhc-el", "bigmhc-im",
+        "netmhcstabpan", "netchop", "pepsickle",
         # legacy entries that should still be present
         "netmhcpan", "netmhcpan4", "netmhcpan41",
         "netmhciipan", "netmhciipan4",
@@ -30,17 +44,276 @@ def test_all_models_in_registry():
         assert name in mhc_predictors, f"{name} missing from mhc_predictors registry"
 
 
-def test_no_allele_predictors_in_registry():
-    """Verify processing predictors are marked as not needing alleles."""
-    for name in _no_allele_predictors:
-        assert name in mhc_predictors, (
-            f"{name} in _no_allele_predictors but not in mhc_predictors"
-        )
-
-
 def test_all_registry_values_are_callable():
     """Every registry value should be callable (class or factory function)."""
     for name, cls in mhc_predictors.items():
         assert callable(cls), (
             f"mhc_predictors[{name!r}] = {cls!r} is not callable"
         )
+
+
+# ── BigMHC_EL / BigMHC_IM subclass registry entries ───────────────
+
+def test_bigmhc_el_maps_to_subclass():
+    assert mhc_predictors["bigmhc-el"] is BigMHC_EL
+
+
+def test_bigmhc_im_maps_to_subclass():
+    assert mhc_predictors["bigmhc-im"] is BigMHC_IM
+
+
+def test_bigmhc_maps_to_base():
+    assert mhc_predictors["bigmhc"] is BigMHC
+
+
+def test_bigmhc_el_is_subclass():
+    assert issubclass(BigMHC_EL, BigMHC)
+
+
+def test_bigmhc_im_is_subclass():
+    assert issubclass(BigMHC_IM, BigMHC)
+
+
+def test_bigmhc_el_no_mode_arg():
+    """BigMHC_EL should not accept a mode argument — it's fixed to 'el'."""
+    import inspect
+    sig = inspect.signature(BigMHC_EL.__init__)
+    assert "mode" not in sig.parameters
+
+
+def test_bigmhc_im_no_mode_arg():
+    """BigMHC_IM should not accept a mode argument — it's fixed to 'im'."""
+    import inspect
+    sig = inspect.signature(BigMHC_IM.__init__)
+    assert "mode" not in sig.parameters
+
+
+# ── _cls_accepts introspection ─────────────────────────────────────
+
+def test_cls_accepts_bigmhc_path():
+    assert _cls_accepts(BigMHC, "bigmhc_path") is True
+    assert _cls_accepts(BigMHC_EL, "bigmhc_path") is True
+    assert _cls_accepts(BigMHC_IM, "bigmhc_path") is True
+
+
+def test_cls_accepts_bigmhc_rejects_program_name():
+    assert _cls_accepts(BigMHC, "program_name") is False
+
+
+def test_cls_accepts_bigmhc_rejects_default_peptide_lengths():
+    assert _cls_accepts(BigMHC, "default_peptide_lengths") is False
+    assert _cls_accepts(BigMHC_EL, "default_peptide_lengths") is False
+
+
+def test_cls_accepts_random_default_peptide_lengths():
+    assert _cls_accepts(RandomBindingPredictor, "default_peptide_lengths") is True
+
+
+def test_cls_accepts_random_rejects_bigmhc_path():
+    assert _cls_accepts(RandomBindingPredictor, "bigmhc_path") is False
+
+
+def test_cls_accepts_pepsickle_rejects_alleles():
+    assert _cls_accepts(Pepsickle, "alleles") is False
+
+
+def test_cls_accepts_pepsickle_accepts_dpl():
+    assert _cls_accepts(Pepsickle, "default_peptide_lengths") is True
+
+
+# ── _parse_predictor_names ─────────────────────────────────────────
+
+def test_parse_predictor_names_single():
+    assert _parse_predictor_names("random") == ["random"]
+
+
+def test_parse_predictor_names_comma_separated():
+    result = _parse_predictor_names("random,bigmhc,pepsickle")
+    assert result == ["random", "bigmhc", "pepsickle"]
+
+
+def test_parse_predictor_names_strips_whitespace():
+    result = _parse_predictor_names("  random , bigmhc ")
+    assert result == ["random", "bigmhc"]
+
+
+def test_parse_predictor_names_case_insensitive():
+    result = _parse_predictor_names("Random,BIGMHC")
+    assert result == ["random", "bigmhc"]
+
+
+def test_parse_predictor_names_unknown_raises():
+    with pytest.raises(ArgumentTypeError, match="Unknown predictor"):
+        _parse_predictor_names("nonexistent")
+
+
+# ── Argparser construction ─────────────────────────────────────────
+
+def test_parser_single_predictor():
+    parser = make_mhc_arg_parser()
+    args = parser.parse_args(["--mhc-predictor", "random", "--mhc-alleles", "HLA-A*02:01"])
+    # nargs="+" with type that returns list → list of lists
+    assert args.mhc_predictor == [["random"]]
+
+
+def test_parser_multiple_space_separated():
+    parser = make_mhc_arg_parser()
+    args = parser.parse_args([
+        "--mhc-predictor", "random", "bigmhc",
+        "--mhc-alleles", "HLA-A*02:01",
+    ])
+    assert args.mhc_predictor == [["random"], ["bigmhc"]]
+
+
+def test_parser_comma_separated():
+    parser = make_mhc_arg_parser()
+    args = parser.parse_args([
+        "--mhc-predictor", "random,bigmhc",
+        "--mhc-alleles", "HLA-A*02:01",
+    ])
+    assert args.mhc_predictor == [["random", "bigmhc"]]
+
+
+def test_parser_mixed_space_and_comma():
+    parser = make_mhc_arg_parser()
+    args = parser.parse_args([
+        "--mhc-predictor", "random,bigmhc", "pepsickle",
+        "--mhc-alleles", "HLA-A*02:01",
+    ])
+    assert args.mhc_predictor == [["random", "bigmhc"], ["pepsickle"]]
+
+
+# ── _build_predictor kwarg filtering ──────────────────────────────
+
+def _stub_args(**overrides):
+    defaults = dict(
+        mhc_predictor=None,
+        mhc_alleles="HLA-A*02:01",
+        mhc_alleles_file=None,
+        mhc_peptide_lengths=None,
+        mhc_epitope_lengths=None,
+        mhc_predictor_models_path=None,
+        mhc_predictor_path=None,
+        do_not_raise_on_error=False,
+    )
+    defaults.update(overrides)
+    return Namespace(**defaults)
+
+
+def test_build_predictor_skips_dpl_for_bigmhc():
+    """BigMHC doesn't accept default_peptide_lengths; should not receive it."""
+    args = _stub_args()
+    pred = _build_predictor(
+        RandomBindingPredictor, "random",
+        alleles=["HLA-A*02:01"], peptide_lengths=[9, 10], args=args)
+    assert pred.default_peptide_lengths == [9, 10]
+
+    # BigMHC would TypeError if dpl were passed; FileNotFoundError means
+    # it got through kwarg filtering and failed on path lookup
+    with pytest.raises(FileNotFoundError):
+        _build_predictor(
+            BigMHC, "bigmhc",
+            alleles=["HLA-A*02:01"], peptide_lengths=[9, 10], args=args)
+
+
+def test_build_predictor_bigmhc_path_mapping():
+    """--mhc-predictor-path should map to bigmhc_path for BigMHC."""
+    args = _stub_args(mhc_predictor_path="/some/path")
+    with pytest.raises(FileNotFoundError):
+        _build_predictor(
+            BigMHC_EL, "bigmhc-el",
+            alleles=["HLA-A*02:01"], peptide_lengths=None, args=args)
+
+
+def test_build_predictor_skips_alleles_for_pepsickle():
+    """Pepsickle doesn't accept alleles; should not receive them."""
+    args = _stub_args()
+    pred = _build_predictor(
+        Pepsickle, "pepsickle",
+        alleles=["HLA-A*02:01"], peptide_lengths=[9], args=args)
+    assert pred is not None
+
+
+# ── predictors_from_args (full integration) ────────────────────────
+
+def _make_args(predictor_tokens, **overrides):
+    """Build a Namespace matching what argparse produces with nargs='+' type."""
+    names = []
+    for tok in predictor_tokens:
+        names.append(_parse_predictor_names(tok))
+    defaults = dict(
+        mhc_predictor=names,
+        mhc_alleles="HLA-A*02:01",
+        mhc_alleles_file=None,
+        mhc_peptide_lengths=None,
+        mhc_epitope_lengths=None,
+        mhc_predictor_models_path=None,
+        mhc_predictor_path=None,
+        do_not_raise_on_error=False,
+    )
+    defaults.update(overrides)
+    return Namespace(**defaults)
+
+
+def test_predictors_from_args_single():
+    args = _make_args(["random"])
+    result = predictors_from_args(args)
+    assert len(result) == 1
+    assert isinstance(result[0], RandomBindingPredictor)
+
+
+def test_predictors_from_args_multiple():
+    args = _make_args(["random", "random"])
+    result = predictors_from_args(args)
+    assert len(result) == 2
+    assert all(isinstance(r, RandomBindingPredictor) for r in result)
+
+
+def test_predictors_from_args_comma_separated():
+    args = _make_args(["random,random"])
+    result = predictors_from_args(args)
+    assert len(result) == 2
+
+
+def test_predictors_from_args_no_allele_predictor():
+    """Processing predictors should not require alleles."""
+    args = _make_args(["pepsickle"], mhc_alleles="")
+    result = predictors_from_args(args)
+    assert len(result) == 1
+    assert isinstance(result[0], Pepsickle)
+
+
+def test_predictors_from_args_mixed_allele_and_no_allele():
+    """Alleles should be fetched when at least one predictor needs them."""
+    args = _make_args(["random,pepsickle"])
+    result = predictors_from_args(args)
+    assert len(result) == 2
+    assert isinstance(result[0], RandomBindingPredictor)
+    assert isinstance(result[1], Pepsickle)
+
+
+def test_predictors_from_args_peptide_lengths_only_where_accepted():
+    """default_peptide_lengths passed to random, skipped for bigmhc."""
+    args = _make_args(["random"], mhc_peptide_lengths=[8, 9])
+    result = predictors_from_args(args)
+    assert result[0].default_peptide_lengths == [8, 9]
+
+
+def test_predictors_from_args_bigmhc_path():
+    args = _make_args(["bigmhc-el"], mhc_predictor_path="/some/path")
+    with pytest.raises(FileNotFoundError):
+        predictors_from_args(args)
+
+
+# ── mhc_binding_predictor_from_args (legacy compat) ───────────────
+
+def test_legacy_binding_predictor_single():
+    args = _make_args(["random"])
+    result = mhc_binding_predictor_from_args(args)
+    assert isinstance(result, RandomBindingPredictor)
+
+
+def test_legacy_binding_predictor_rejects_multiple():
+    args = _make_args(["random", "random"])
+    with pytest.raises(ValueError, match="exactly one"):
+        mhc_binding_predictor_from_args(args)


### PR DESCRIPTION
## Summary
- Add `BigMHC_EL` and `BigMHC_IM` convenience subclasses (fixed mode, from PR #185)
- Make `--mhc-predictor` accept multiple values (space or comma separated), drop `--predictors`
- Use `inspect.signature` to route kwargs (`alleles`, `default_peptide_lengths`, `program_name`, `bigmhc_path`) only to predictors that accept them — no manual sets to maintain
- Subsumes and closes PR #185

## Test plan
- [x] 37 new unit tests covering registry, introspection, arg parsing, kwarg filtering, and integration
- [x] Full test suite passes (293 passed, 9 skipped, 3 xfailed)