### PR TITLE
Fix file I/O and O(n^2) validation performance

### DIFF
--- a/mhctools/base_commandline_predictor.py
+++ b/mhctools/base_commandline_predictor.py
@@ -14,6 +14,7 @@
 
 from collections import defaultdict
 import logging
+import os
 from subprocess import check_output
 import tempfile
 
@@ -271,16 +272,16 @@ class BaseCommandlinePredictor(BasePredictor):
                 print_commands=True,
                 process_limit=self.process_limit)
             for output_file, command in commands.items():
-                # closing/opening looks insane
-                # but I was getting empty files otherwise
+                output_file.flush()
+                os.fsync(output_file.fileno())
+                output_file.seek(0)
+                file_contents = output_file.read()
                 output_file.close()
-                with open(output_file.name, 'r') as f:
-                    file_contents = f.read()
-                    binding_predictions.extend(
-                        self.parse_output_fn(
-                            stdout=file_contents,
-                            sequence_key_mapping=sequence_key_mapping,
-                            prediction_method_name=self.program_name))
+                binding_predictions.extend(
+                    self.parse_output_fn(
+                        stdout=file_contents,
+                        sequence_key_mapping=sequence_key_mapping,
+                        prediction_method_name=self.program_name))
 
         if len(binding_predictions) == 0:
             logger.warning("No binding predictions from %s" % self.program_name)
@@ -307,14 +308,16 @@ class BaseCommandlinePredictor(BasePredictor):
                 print_commands=True,
                 process_limit=self.process_limit)
             for output_file, command in commands.items():
+                output_file.flush()
+                os.fsync(output_file.fileno())
+                output_file.seek(0)
+                file_contents = output_file.read()
                 output_file.close()
-                with open(output_file.name, 'r') as f:
-                    file_contents = f.read()
-                    all_preds.extend(
-                        self.parse_to_preds_fn(
-                            stdout=file_contents,
-                            sequence_key_mapping=sequence_key_mapping,
-                            predictor_name=self.program_name))
+                all_preds.extend(
+                    self.parse_to_preds_fn(
+                        stdout=file_contents,
+                        sequence_key_mapping=sequence_key_mapping,
+                        predictor_name=self.program_name))
 
         if len(all_preds) == 0:
             logger.warning("No predictions from %s" % self.program_name)
@@ -355,7 +358,7 @@ class BaseCommandlinePredictor(BasePredictor):
                 else:
                     temp_dirname = None
                 output_file = tempfile.NamedTemporaryFile(
-                    "w",
+                    "w+",
                     prefix="%s_output_length_%d_%d" % (
                         self.program_name, i, j),
                     delete=False)
@@ -396,7 +399,7 @@ class BaseCommandlinePredictor(BasePredictor):
                 else:
                     temp_dirname = None
                 output_file = tempfile.NamedTemporaryFile(
-                    "w",
+                    "w+",
                     prefix="%s_output_length_%d_%d" % (
                         self.program_name, i, j),
                     delete=False)

--- a/mhctools/base_predictor.py
+++ b/mhctools/base_predictor.py
@@ -233,6 +233,17 @@ class BasePredictor(object):
         return peptide_lengths
 
     def _check_results(self, binding_predictions, peptides, alleles):
+        # For large inputs the Cartesian product set is very expensive;
+        # skip the detailed check when the expected size exceeds a threshold.
+        n_expected = len(alleles) * len(peptides)
+        if n_expected > 100_000:
+            if len(binding_predictions) != n_expected:
+                logger.warning(
+                    "Expected %d predictions but got %d (skipping "
+                    "detailed check for large inputs)",
+                    n_expected, len(binding_predictions))
+            return
+
         expected = {(a, p) for a in alleles for p in peptides}
         observed = {(bp.allele, bp.peptide) for bp in binding_predictions}
         if len(expected.intersection(observed)) < len(expected):


### PR DESCRIPTION
## Summary
- **base_commandline_predictor.py**: Replace the close-then-reopen file workaround with `flush()`/`os.fsync()`/`seek(0)`/`read()`. Temp files are now opened in `w+` mode so they can be read back without reopening. Applied to both `_run_commands_and_collect_predictions` and `_run_commands_and_collect_preds`.
- **base_predictor.py**: Add a size guard to `_check_results()` that skips the O(alleles x peptides) Cartesian product set construction when the expected size exceeds 100,000 pairs. For large inputs this avoids unnecessary memory allocation and set operations. A count-based warning is still emitted if the total differs.

## Test plan
- [x] All existing tests pass (`285 passed, 2 skipped` with external predictor tests excluded)
- [ ] Verify with a real commandline predictor (e.g. netMHCpan) that output files are read correctly after flush/fsync/seek
- [ ] Stress test with large allele x peptide inputs (>100k pairs) to confirm the size guard triggers