### PR TITLE
Upgrade MHCflurry to Class1PresentationPredictor API

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ affinity, hours for stability). `percentile_rank` is always optional,
 | `NetMHCcons` | affinity | [NetMHCcons](https://services.healthtech.dtu.dk/services/NetMHCcons-1.1/) |
 | `NetMHCstabpan` | stability | [NetMHCstabpan](https://services.healthtech.dtu.dk/services/NetMHCstabpan-1.0/) |
 | `MHCflurry` | affinity + presentation | `pip install mhcflurry` + `mhcflurry-downloads fetch` |
+| `MHCflurry_Affinity` | affinity | `pip install mhcflurry` + `mhcflurry-downloads fetch` |
 | `BigMHC` | presentation or immunogenicity | [BigMHC](https://github.com/KarchinLab/bigmhc) clone (set `BIGMHC_DIR`) |
 | `MixMHCpred` | presentation | [MixMHCpred](https://github.com/GfellerLab/MixMHCpred) |
 | `IedbNetMHCpan` / `IedbSMM` / `IedbNetMHCIIpan` | affinity | IEDB web API |

--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -10,7 +10,7 @@ from .iedb import (
     IedbNetMHCIIpan,
 )
 from .mixmhcpred import MixMHCpred
-from .mhcflurry import MHCflurry
+from .mhcflurry import MHCflurry, MHCflurry_Affinity
 from .processing_predictor import (
     ProcessingPredictor,
     SCORING_MODES,
@@ -60,6 +60,7 @@ __all__ = [
     "IedbNetMHCIIpan",
     "MixMHCpred",
     "MHCflurry",
+    "MHCflurry_Affinity",
     "ProcessingPredictor",
     "ProteasomePredictor",
     "SCORING_MODES",

--- a/mhctools/cli/args.py
+++ b/mhctools/cli/args.py
@@ -62,6 +62,7 @@ from .. import (
     IedbSMM_PMBEC,
     IedbNetMHCIIpan,
     MHCflurry,
+    MHCflurry_Affinity,
     MixMHCpred,
 )
 
@@ -111,6 +112,7 @@ mhc_predictors = {
     # Class II MHC binding prediction using NetMHCIIpan via IEDB
     "netmhciipan-iedb": IedbNetMHCIIpan,
     "mhcflurry": MHCflurry,
+    "mhcflurry-affinity": MHCflurry_Affinity,
     "mixmhcpred": MixMHCpred,
 }
 

--- a/mhctools/mhcflurry.py
+++ b/mhctools/mhcflurry.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 import logging
+import math
 
 from numpy import nan
 
@@ -127,9 +128,6 @@ class MHCflurry(BasePredictor):
                 presentation_score = row.presentation_score
                 presentation_pct = row.presentation_percentile
 
-                # Higher score = better binding. Convert IC50 nM to 0-1 score:
-                # score = 1 - log(IC50)/log(50000), clamped to [0,1]
-                import math
                 aff_score = max(0.0, min(1.0,
                     1.0 - math.log(max(affinity_nM, 1e-6)) / math.log(50000)))
 

--- a/mhctools/mhcflurry.py
+++ b/mhctools/mhcflurry.py
@@ -17,6 +17,7 @@ from numpy import nan
 from .base_predictor import BasePredictor
 from .binding_prediction import BindingPrediction
 from .binding_prediction_collection import BindingPredictionCollection
+from .pred import Prediction, Kind
 from .unsupported_allele import UnsupportedAllele
 
 logger = logging.getLogger(__name__)
@@ -24,9 +25,146 @@ logger = logging.getLogger(__name__)
 
 class MHCflurry(BasePredictor):
     """
-    Wrapper around MHCflurry. Users will need to download MHCflurry models
-    first.
-    See https://github.com/hammerlab/mhcflurry
+    MHCflurry predictor using the modern Class1PresentationPredictor API.
+
+    Produces both ``pMHC_affinity`` and ``pMHC_presentation`` predictions
+    per peptide-allele pair. The legacy ``predict_peptides`` method returns
+    BindingPrediction objects based on affinity values for backward compat.
+
+    See https://github.com/openvax/mhcflurry
+    """
+
+    def __init__(
+            self,
+            alleles,
+            default_peptide_lengths=[9],
+            predictor=None,
+            models_path=None):
+        """
+        Parameters
+        -----------
+        alleles : list of str
+
+        default_peptide_lengths : list of int
+
+        predictor : mhcflurry.Class1PresentationPredictor (optional)
+            MHCflurry presentation predictor to use
+
+        models_path : string
+            Models dir to use if predictor argument is None
+        """
+        # Lazy import to avoid importing Keras/TF at module load time
+        from mhcflurry import Class1PresentationPredictor
+        BasePredictor.__init__(
+            self,
+            alleles=alleles,
+            default_peptide_lengths=default_peptide_lengths,
+            min_peptide_length=8,
+            max_peptide_length=15)
+        if predictor:
+            self.predictor = predictor
+        elif models_path:
+            logging.info("Loading MHCflurry models from %s" % models_path)
+            self.predictor = Class1PresentationPredictor.load(models_path)
+        else:
+            self.predictor = Class1PresentationPredictor.load()
+
+        for allele in self.alleles:
+            if allele not in self.predictor.supported_alleles:
+                raise UnsupportedAllele(allele)
+
+    def predict_peptides(self, peptides):
+        """
+        Predict MHC binding affinity and presentation for peptides.
+
+        Returns a BindingPredictionCollection (legacy API) using affinity
+        values for backward compatibility.
+        """
+        binding_predictions = []
+        for allele in self.alleles:
+            df = self.predictor.predict(
+                peptides=list(peptides),
+                alleles=[allele],
+                include_affinity_percentile=True,
+                verbose=0,
+            )
+            for row in df.itertuples(index=False):
+                binding_predictions.append(BindingPrediction(
+                    allele=allele,
+                    peptide=row.peptide,
+                    affinity=row.affinity,
+                    percentile_rank=(
+                        row.affinity_percentile
+                        if hasattr(row, 'affinity_percentile') else nan),
+                    prediction_method_name="mhcflurry",
+                ))
+        return BindingPredictionCollection(binding_predictions)
+
+    def predict(self, peptides):
+        """
+        Predict for a list of peptide sequences.
+
+        Returns a list of PeptideResult, each containing both
+        pMHC_affinity and pMHC_presentation Prediction objects per allele.
+        """
+        from collections import defaultdict
+        from .pred import PeptideResult
+
+        groups = defaultdict(list)
+        for allele in self.alleles:
+            df = self.predictor.predict(
+                peptides=list(peptides),
+                alleles=[allele],
+                include_affinity_percentile=True,
+                verbose=0,
+            )
+            for row in df.itertuples(index=False):
+                pep = row.peptide
+                affinity_nM = row.affinity
+                affinity_pct = (
+                    row.affinity_percentile
+                    if hasattr(row, 'affinity_percentile') else None)
+                presentation_score = row.presentation_score
+                presentation_pct = row.presentation_percentile
+
+                # Higher score = better binding. Convert IC50 nM to 0-1 score:
+                # score = 1 - log(IC50)/log(50000), clamped to [0,1]
+                import math
+                aff_score = max(0.0, min(1.0,
+                    1.0 - math.log(max(affinity_nM, 1e-6)) / math.log(50000)))
+
+                groups[pep].append(Prediction(
+                    kind=Kind.pMHC_affinity,
+                    score=aff_score,
+                    peptide=pep,
+                    allele=allele,
+                    value=affinity_nM,
+                    percentile_rank=affinity_pct,
+                    predictor_name="mhcflurry",
+                ))
+                groups[pep].append(Prediction(
+                    kind=Kind.pMHC_presentation,
+                    score=presentation_score,
+                    peptide=pep,
+                    allele=allele,
+                    percentile_rank=presentation_pct,
+                    predictor_name="mhcflurry",
+                ))
+
+        return [PeptideResult(preds=tuple(preds)) for preds in groups.values()]
+
+    def _default_pred_kind(self):
+        return Kind.pMHC_affinity
+
+
+class MHCflurry_Affinity(BasePredictor):
+    """
+    MHCflurry predictor using the older Class1AffinityPredictor API.
+
+    Only produces ``pMHC_affinity`` predictions. Use this if you only need
+    affinity scores and don't want the presentation model overhead.
+
+    See https://github.com/openvax/mhcflurry
     """
 
     def __init__(
@@ -43,15 +181,11 @@ class MHCflurry(BasePredictor):
         default_peptide_lengths : list of int
 
         predictor : mhcflurry.Class1AffinityPredictor (optional)
-            MHCflurry predictor to use
+            MHCflurry affinity predictor to use
 
         models_path : string
             Models dir to use if predictor argument is None
-
         """
-        # moving import here since the mhcflurry package imports
-        # Keras and its backend (either Theano or TF) which end up
-        # slowing down responsive for any CLI application using MHCtools
         from mhcflurry import Class1AffinityPredictor
         BasePredictor.__init__(
             self,
@@ -67,8 +201,6 @@ class MHCflurry(BasePredictor):
         else:
             self.predictor = Class1AffinityPredictor.load()
 
-        # relying on BasePredictor and MHCflurry to both normalize
-        # allele names to the same canonical representation
         for allele in self.alleles:
             if allele not in self.predictor.supported_alleles:
                 raise UnsupportedAllele(allele)
@@ -77,9 +209,6 @@ class MHCflurry(BasePredictor):
         """
         Predict MHC affinity for peptides.
         """
-
-        # importing locally to avoid slowing down CLI applications which
-        # don't use MHCflurry
         from mhcflurry.encodable_sequences import EncodableSequences
 
         binding_predictions = []
@@ -87,14 +216,14 @@ class MHCflurry(BasePredictor):
         for allele in self.alleles:
             predictions_df = self.predictor.predict_to_dataframe(
                 encodable_sequences, allele=allele)
-            for (_, row) in predictions_df.iterrows():
-                binding_prediction = BindingPrediction(
+            for row in predictions_df.itertuples(index=False):
+                binding_predictions.append(BindingPrediction(
                     allele=allele,
                     peptide=row.peptide,
                     affinity=row.prediction,
                     percentile_rank=(
                         row.prediction_percentile
-                        if 'prediction_percentile' in row else nan),
-                    prediction_method_name="mhcflurry")
-                binding_predictions.append(binding_prediction)
+                        if hasattr(row, 'prediction_percentile') else nan),
+                    prediction_method_name="mhcflurry",
+                ))
         return BindingPredictionCollection(binding_predictions)

--- a/tests/test_mhcflurry.py
+++ b/tests/test_mhcflurry.py
@@ -12,11 +12,12 @@
 
 
 
-from .common  import eq_
+from .common import eq_
 from numpy import testing
 
 from mhcflurry import Class1AffinityPredictor
-from mhctools import MHCflurry
+from mhctools import MHCflurry, MHCflurry_Affinity
+from mhctools.pred import Kind
 
 DEFAULT_ALLELE = "HLA-A*02:01"
 
@@ -26,8 +27,77 @@ protein_sequence_dict = {
 }
 
 
-def test_mhcflurry():
+def test_mhcflurry_presentation_predict_subsequences():
+    """Legacy predict_subsequences still works with the presentation-based MHCflurry."""
     predictor = MHCflurry(alleles=[DEFAULT_ALLELE])
+    binding_predictions = predictor.predict_subsequences(
+        protein_sequence_dict,
+        peptide_lengths=[9])
+    eq_(4, len(binding_predictions),
+        "Expected 4 binding predictions from %s" % (binding_predictions,))
+
+    # Verify affinity values are reasonable (positive nM values)
+    for bp in binding_predictions:
+        assert bp.affinity > 0, "Affinity should be positive, got %s" % bp.affinity
+        assert bp.allele == DEFAULT_ALLELE
+
+
+def test_mhcflurry_presentation_predict():
+    """New predict() API returns PeptideResults with both affinity and presentation."""
+    predictor = MHCflurry(alleles=[DEFAULT_ALLELE])
+    peptides = ["SIINFEKL", "ASILLLVFY"]
+    results = predictor.predict(peptides)
+
+    eq_(len(peptides), len(results),
+        "Expected one PeptideResult per peptide")
+
+    for r in results:
+        assert r.peptide in peptides
+        assert r.affinity is not None, "Should have affinity prediction"
+        assert r.presentation is not None, "Should have presentation prediction"
+
+        # Check affinity prediction
+        assert r.affinity.kind == Kind.pMHC_affinity
+        assert r.affinity.value > 0, "Affinity value should be positive nM"
+        assert r.affinity.score >= 0
+        assert r.affinity.allele == DEFAULT_ALLELE
+        assert r.affinity.predictor_name == "mhcflurry"
+
+        # Check presentation prediction
+        assert r.presentation.kind == Kind.pMHC_presentation
+        assert r.presentation.score >= 0
+        assert r.presentation.allele == DEFAULT_ALLELE
+        assert r.presentation.predictor_name == "mhcflurry"
+
+        # Check that percentile ranks are present
+        assert r.affinity.percentile_rank is not None
+        assert r.presentation.percentile_rank is not None
+
+    # Verify kinds
+    for r in results:
+        assert Kind.pMHC_affinity in r.kinds
+        assert Kind.pMHC_presentation in r.kinds
+
+
+def test_mhcflurry_presentation_affinity_matches_old_api():
+    """Affinity values from the presentation predictor should be close to the
+    old Class1AffinityPredictor values."""
+    predictor = MHCflurry(alleles=[DEFAULT_ALLELE])
+    binding_predictions = predictor.predict_peptides(["SIINFEKL"])
+
+    old_predictor = Class1AffinityPredictor.load()
+    old_prediction = old_predictor.predict(["SIINFEKL"], allele=DEFAULT_ALLELE)
+
+    assert len(binding_predictions) == 1
+    # Approximate check -- presentation predictor uses the same affinity model
+    # but values can differ slightly
+    testing.assert_almost_equal(
+        binding_predictions[0].affinity, old_prediction[0], decimal=0)
+
+
+def test_mhcflurry_affinity_only():
+    """MHCflurry_Affinity subclass only produces affinity predictions."""
+    predictor = MHCflurry_Affinity(alleles=[DEFAULT_ALLELE])
     binding_predictions = predictor.predict_subsequences(
         protein_sequence_dict,
         peptide_lengths=[9])
@@ -38,10 +108,28 @@ def test_mhcflurry():
         (x.peptide, x.allele): x.affinity for x in binding_predictions
     }
 
-    predictor = Class1AffinityPredictor.load()
+    old_predictor = Class1AffinityPredictor.load()
     # test one prediction at a time to make sure there's no peptide/allele mixup
     for (peptide, allele), affinity in prediction_scores.items():
-        prediction = predictor.predict([peptide], allele=allele)
+        prediction = old_predictor.predict([peptide], allele=allele)
         assert len(prediction) == 1
-        # we've seen results differ a bit so doing an approximate check, not an error condition
         testing.assert_almost_equal(prediction[0], affinity, decimal=0)
+
+
+def test_mhcflurry_multiple_alleles():
+    """MHCflurry with multiple alleles produces predictions for each allele."""
+    alleles = ["HLA-A*02:01", "HLA-B*07:02"]
+    predictor = MHCflurry(alleles=alleles)
+    results = predictor.predict(["SIINFEKL"])
+
+    eq_(1, len(results), "Expected one PeptideResult")
+    r = results[0]
+
+    # Should have 2 alleles x 2 kinds = 4 predictions total
+    eq_(4, len(r.preds), "Expected 4 predictions (2 alleles x 2 kinds)")
+
+    # Both alleles should be present
+    assert r.alleles == set(alleles)
+
+    # Both kinds should be present
+    assert r.kinds == {Kind.pMHC_affinity, Kind.pMHC_presentation}


### PR DESCRIPTION
## Summary
- **MHCflurry** default class now uses `Class1PresentationPredictor` (MHCflurry 2.0+), emitting both `pMHC_affinity` and `pMHC_presentation` Prediction objects per peptide-allele pair
- New **MHCflurry_Affinity** subclass preserves the old `Class1AffinityPredictor` behavior for users who only need affinity scores
- CLI registry: `--mhc-predictor mhcflurry` uses presentation (default), `--mhc-predictor mhcflurry-affinity` for affinity-only
- Replaced `iterrows()` with `itertuples()` for faster DataFrame iteration
- Legacy `predict_peptides()` returns `BindingPredictionCollection` with affinity values for backward compat

## Test plan
- [x] `test_mhcflurry_presentation_predict_subsequences` -- legacy predict_subsequences works with new predictor
- [x] `test_mhcflurry_presentation_predict` -- new predict() returns both affinity + presentation
- [x] `test_mhcflurry_presentation_affinity_matches_old_api` -- affinity values match Class1AffinityPredictor
- [x] `test_mhcflurry_affinity_only` -- MHCflurry_Affinity subclass works correctly
- [x] `test_mhcflurry_multiple_alleles` -- multi-allele predictions produce correct (allele x kind) combinations
- [x] All 85 tests in test_mhcflurry, test_pred, test_cli_registry pass