### PR TITLE
Normalize models_path for MHCflurry cache dedupe

### DIFF
--- a/mhctools/mhcflurry.py
+++ b/mhctools/mhcflurry.py
@@ -12,6 +12,7 @@
 
 import logging
 import math
+import os
 
 from numpy import nan
 
@@ -23,8 +24,21 @@ from .unsupported_allele import UnsupportedAllele
 
 logger = logging.getLogger(__name__)
 
-# Module-level cache for loaded models. Keyed by (class_name, models_path).
+# Module-level cache for loaded models. Keyed by (kind, normalized_path).
 _model_cache = {}
+
+
+def _normalize_models_path(models_path):
+    """Normalize a models directory path for cache-key deduplication.
+
+    Different strings pointing at the same directory (relative vs.
+    absolute, with ``~``, via a symlink) should share a single cache
+    entry. ``None`` stays ``None`` — mhcflurry resolves that to the
+    package-default path internally, and we treat it as its own key.
+    """
+    if models_path is None:
+        return None
+    return os.path.realpath(os.path.abspath(os.path.expanduser(models_path)))
 
 
 class MHCflurry(BasePredictor):
@@ -67,7 +81,7 @@ class MHCflurry(BasePredictor):
         if predictor:
             self.predictor = predictor
         else:
-            cache_key = ("presentation", models_path)
+            cache_key = ("presentation", _normalize_models_path(models_path))
             if cache_key not in _model_cache:
                 if models_path:
                     logging.info(
@@ -243,7 +257,7 @@ class MHCflurry_Affinity(BasePredictor):
         if predictor:
             self.predictor = predictor
         else:
-            cache_key = ("affinity", models_path)
+            cache_key = ("affinity", _normalize_models_path(models_path))
             if cache_key not in _model_cache:
                 if models_path:
                     logging.info(

--- a/tests/test_mhcflurry_cache_key.py
+++ b/tests/test_mhcflurry_cache_key.py
@@ -1,0 +1,46 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+"""Tests for mhctools.mhcflurry._normalize_models_path.
+
+Two different strings that point at the same directory should produce
+the same cache key so the models aren't loaded twice into memory.
+"""
+
+import os
+
+from mhctools.mhcflurry import _normalize_models_path
+
+
+def test_none_stays_none():
+    assert _normalize_models_path(None) is None
+
+
+def test_expands_tilde(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert _normalize_models_path("~/models") == str(tmp_path / "models")
+
+
+def test_relative_and_absolute_dedupe(tmp_path, monkeypatch):
+    target = tmp_path / "models"
+    target.mkdir()
+    monkeypatch.chdir(tmp_path)
+    assert _normalize_models_path("models") == _normalize_models_path(str(target))
+
+
+def test_symlink_resolves_to_target(tmp_path):
+    target = tmp_path / "real_models"
+    target.mkdir()
+    link = tmp_path / "link_models"
+    os.symlink(target, link)
+    assert _normalize_models_path(str(link)) == _normalize_models_path(str(target))
+
+
+def test_dotdot_and_redundant_separators_dedupe(tmp_path):
+    target = tmp_path / "models"
+    target.mkdir()
+    messy = "%s/./sub/../models" % tmp_path
+    assert _normalize_models_path(messy) == _normalize_models_path(str(target))


### PR DESCRIPTION
## Summary

Minor follow-up to the correctness audit: `MHCflurry` and `MHCflurry_Affinity` used `models_path` directly as a cache key, so different strings that resolved to the same directory (relative vs. absolute, leading \`~\`, symlinks, \`../\`, \`//\`) each loaded their own copy of the models into memory.

Normalize via \`os.path.realpath(os.path.abspath(os.path.expanduser(models_path)))\` before building the cache key. \`None\` stays \`None\` — mhcflurry resolves that to a package-default path internally, and we treat it as its own entry.

## Test plan

- [x] \`pytest tests/test_mhcflurry_cache_key.py\` — 5 new tests covering None, tilde, relative-vs-absolute, symlink, and \`..\`/redundant-separator normalization
- [x] \`pytest tests/test_mhcflurry.py tests/test_mhcflurry_key_lookup.py\` — existing mhcflurry tests still pass