### PR TITLE
Skip inter-block header lines in multi-allele NetMHCpan output (fixes #195)

### DIFF
--- a/mhctools/parsing.py
+++ b/mhctools/parsing.py
@@ -68,7 +68,15 @@ def split_stdout_lines(stdout):
         # beginning of headers in NetMHC
         if any(line.startswith(word) for word in NETMHC_TOKENS):
             continue
-        yield line.split()
+        fields = line.split()
+        # Data rows always start with an integer position. Anything else is
+        # a header or summary line interleaved with the result blocks —
+        # e.g. "HLA-A24:02 : Distance to training data ..." in multi-allele
+        # NetMHCpan output, which appears after the first `---` separator
+        # and would otherwise be misparsed.
+        if not fields or not fields[0].lstrip("-").isdigit():
+            continue
+        yield fields
 
 
 def clean_fields(fields, ignored_value_indices, transforms):

--- a/tests/test_mhc_formats.py
+++ b/tests/test_mhc_formats.py
@@ -527,3 +527,49 @@ def test_netmhciipan4_with_bind_level():
     results = parse_netmhciipan4_stdout(output, mode="elution_score")
     assert len(results) == 2
     assert abs(results[1].score - 0.800000) < 0.0001
+
+
+# ---------- Multi-allele runs (openvax/mhctools#195) ----------
+
+def test_multi_allele_netmhcpan41_skips_interblock_headers():
+    """Regression for #195: NetMHCpan 4.1 with multiple alleles in one
+    invocation emits a "Distance to training data" header line between
+    per-allele result blocks (after the first `---` separator). The
+    parser must skip these non-data rows, not crash on them."""
+    output = """
+# NetMHCpan version 4.1b
+
+# Input is in PEPTIDE format
+
+# Make both EL and BA predictions
+
+HLA-A02:01 : Distance to training data  0.000 (using nearest neighbor HLA-A02:01)
+
+# Rank Threshold for Strong binding peptides   0.500
+# Rank Threshold for Weak binding peptides   2.000
+---------------------------------------------------------------------------------------------------------------------------
+ Pos         MHC        Peptide      Core Of Gp Gl Ip Il        Icore        Identity  Score_EL %Rank_EL Score_BA %Rank_BA  Aff(nM) BindLevel
+---------------------------------------------------------------------------------------------------------------------------
+   1 HLA-A*02:01       SIINFEKL SII-NFEKL  0  0  0  3  1     SIINFEKL         PEPLIST 0.0100620    6.723 0.110414   20.171 15140.42
+---------------------------------------------------------------------------------------------------------------------------
+
+Protein PEPLIST. Allele HLA-A*02:01. Number of high binders 0. Number of weak binders 0. Number of peptides 1
+
+HLA-A24:02 : Distance to training data  0.000 (using nearest neighbor HLA-A24:02)
+
+# Rank Threshold for Strong binding peptides   0.500
+# Rank Threshold for Weak binding peptides   2.000
+---------------------------------------------------------------------------------------------------------------------------
+ Pos         MHC        Peptide      Core Of Gp Gl Ip Il        Icore        Identity  Score_EL %Rank_EL Score_BA %Rank_BA  Aff(nM) BindLevel
+---------------------------------------------------------------------------------------------------------------------------
+   1 HLA-A*24:02       SIINFEKL SII-NFEKL  0  0  0  3  1     SIINFEKL         PEPLIST 0.0200000    5.000 0.220000   10.000  8000.00
+---------------------------------------------------------------------------------------------------------------------------
+
+Protein PEPLIST. Allele HLA-A*24:02. Number of high binders 0. Number of weak binders 0. Number of peptides 1
+"""
+    results = parse_netmhcpan_stdout(output, mode="binding_affinity")
+    assert len(results) == 2, (
+        "Expected one row per allele after skipping inter-block header lines"
+    )
+    alleles = {r.allele for r in results}
+    assert alleles == {"HLA-A*02:01", "HLA-A*24:02"}


### PR DESCRIPTION
Fixes #195.

## Summary

When NetMHCpan is run with multiple alleles in one invocation, each per-allele result block is preceded by a line like:

\`\`\`
HLA-A24:02 : Distance to training data  0.000 (using nearest neighbor HLA-A24:02)
\`\`\`

For single-allele runs this line appears *before* the first \`---\` separator and is already skipped. For multi-allele runs the second-and-subsequent ones appear *after* a separator, so they passed through \`split_stdout_lines\` and \`parse_stdout\` crashed converting \`HLA-A24:02\` to an integer Pos.

## Fix

In \`split_stdout_lines\`, after the existing comment/separator/header-token filters, also drop any line whose first token isn't an integer. \`.lstrip(\"-\").isdigit()\` preserves support for NetMHC 4.0's negative positions in peptide-input mode (already explicitly accommodated in that module's comment).

## Test plan

- [x] New regression test \`test_multi_allele_netmhcpan41_skips_interblock_headers\` in \`tests/test_mhc_formats.py\` — parses a two-allele NetMHCpan 4.1 output with the offending inter-block \"Distance to training data\" line, asserts 2 rows come out with both alleles.
- [x] Reproduced exact error from the issue (\`ValueError: invalid literal for int() with base 10: 'HLA-A24:02'\`) before the fix; test passes after.
- [x] Full existing parser-test suite (\`test_mhc_formats.py\`, \`test_class2_allele_formats.py\`) still passes — 33 tests.