### PR TITLE
Lazily validate netMHCpan alleles + round-trip the tool's own spelling

### DIFF
--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -78,7 +78,7 @@ def __getattr__(name):
     raise AttributeError(
         "module %r has no attribute %r" % (__name__, name))
 
-__version__ = "3.17.0"
+__version__ = "3.18.0"
 
 __all__ = [
     "Prediction",

--- a/mhctools/base_commandline_predictor.py
+++ b/mhctools/base_commandline_predictor.py
@@ -42,12 +42,23 @@ logger = logging.getLogger(__name__)
 # ~85% of the amortization while bounding those risks.
 AUTO_MAX_ALLELES_PER_COMMAND = 20
 
-# Cache of supported-allele sets keyed by (command, supported_allele_flag).
-# Determining the supported alleles means running e.g. `netMHCpan -listMHC`
-# and normalizing every line (~3,900 alleles), which is slow and identical
-# for every predictor sharing the same binary. Memoize it per process so it
-# happens once instead of on every predictor construction.
+# Caches keyed by (command, supported_allele_flag), memoized per process so a
+# binary's supported-allele list is only read/parsed once no matter how many
+# predictors are constructed.
+#
+# _supported_alleles_cache holds the RAW names exactly as the predictor prints
+# them (e.g. `netMHCpan -listMHC`). Building it is cheap: split lines, no
+# mhcgnomes. User alleles are validated against it with a fast path that only
+# runs mhcgnomes on the user's handful of alleles, so the ~13k-name list is
+# never normalized for the common (human HLA) case.
 _supported_alleles_cache = {}
+
+# _normalized_supported_cache holds the lazily-built {normalized_name: raw_name}
+# mapping, computed only when the fast path misses (a supported allele whose
+# name our normalizer rewrites into a spelling the predictor doesn't accept,
+# e.g. many non-human BoLA/Mamu names). The raw_name is the predictor's own
+# spelling, which is what must be passed back on the command line.
+_normalized_supported_cache = {}
 
 
 class BaseCommandlinePredictor(BasePredictor):
@@ -199,7 +210,9 @@ class BaseCommandlinePredictor(BasePredictor):
         self.group_peptides_by_length = group_peptides_by_length
 
         if self.supported_alleles_flag:
-            valid_alleles = self._determine_supported_alleles(
+            # Raw names exactly as the predictor prints them; validation and
+            # normalization happen lazily in _resolve_supported_alleles().
+            self._supported_allele_names = self._determine_supported_alleles(
                 self.program_name,
                 self.supported_alleles_flag)
         else:
@@ -210,35 +223,31 @@ class BaseCommandlinePredictor(BasePredictor):
                 run_command([self.program_name])
             except Exception:
                 raise SystemError("Failed to run %s" % self.program_name)
-            valid_alleles = None
+            self._supported_allele_names = None
 
-        try:
-            BasePredictor.__init__(
-                self,
-                alleles=alleles,
-                valid_alleles=valid_alleles,
-                default_peptide_lengths=default_peptide_lengths,
-                min_peptide_length=min_peptide_length,
-                max_peptide_length=max_peptide_length)
-        except UnsupportedAllele as e:
-            if self.supported_alleles_flag:
-                additional_message = (
-                    "\nRun command %s %s to see a list of valid alleles" % (
-                        self.program_name,
-                        self.supported_alleles_flag))
-            else:
-                additional_message = ""
-            raise UnsupportedAllele(str(e) + additional_message)
+        # Normalize (and dedupe homozygous) the requested alleles without
+        # validating against the supported list — we validate below against the
+        # raw list so we can hand the predictor back its own spelling.
+        BasePredictor.__init__(
+            self,
+            alleles=alleles,
+            valid_alleles=None,
+            default_peptide_lengths=default_peptide_lengths,
+            min_peptide_length=min_peptide_length,
+            max_peptide_length=max_peptide_length)
+
+        self._resolve_supported_alleles()
 
     @staticmethod
     def _determine_supported_alleles(command, supported_allele_flag):
         """
-        Try asking the commandline predictor (e.g. netMHCpan)
-        which alleles it supports.
+        Ask the commandline predictor (e.g. `netMHCpan -listMHC`) which alleles
+        it supports and return the RAW names it prints, verbatim.
 
-        The result is memoized per (command, supported_allele_flag) so the
-        `-listMHC` call and the parsing of its thousands of alleles happen
-        once per process rather than on every predictor construction.
+        No allele-name normalization happens here: parsing all ~13k names
+        through mhcgnomes is the slow part, and it is deferred to
+        _normalized_supported_alleles() which only runs when the fast
+        validation path misses. Memoized per (command, supported_allele_flag).
         """
         cache_key = (command, supported_allele_flag)
         cached = _supported_alleles_cache.get(cache_key)
@@ -252,33 +261,13 @@ class BaseCommandlinePredictor(BasePredictor):
             supported_alleles_str = supported_alleles_output.decode("ascii", "ignore")
             assert len(supported_alleles_str) > 0, \
                 '%s returned empty allele list' % command
-            supported_alleles = set([])
-            skipped = []
-            for line in supported_alleles_str.split("\n"):
-                line = line.strip()
-                if not line.startswith('#') and len(line) > 0:
-                    try:
-                        # We need to normalize these alleles (the output of the predictor
-                        # when it lists its supported alleles) so that they are comparable with
-                        # our own alleles.
-                        supported_alleles.add(normalize_allele_name(line))
-                    except AlleleParseError as error:
-                        # Non-human/edge-case alleles the normalizer can't
-                        # handle (e.g. some BoLA/Mamu/H-2 names). Log at debug
-                        # so predictor construction doesn't spam the user; a
-                        # single summary is emitted below.
-                        logger.debug("Skipping allele %s: %s", line, error)
-                        skipped.append(line)
-                        continue
+            supported_alleles = {
+                line.strip()
+                for line in supported_alleles_str.split("\n")
+                if line.strip() and not line.strip().startswith("#")
+            }
             if len(supported_alleles) == 0:
                 raise ValueError("Unable to determine supported alleles")
-            if skipped:
-                logger.debug(
-                    "%s %s: skipped %d of %d alleles that could not be parsed",
-                    command,
-                    supported_allele_flag,
-                    len(skipped),
-                    len(supported_alleles) + len(skipped))
             _supported_alleles_cache[cache_key] = supported_alleles
             return supported_alleles
         except Exception as e:
@@ -287,11 +276,108 @@ class BaseCommandlinePredictor(BasePredictor):
                 command,
                 supported_allele_flag))
 
+    @staticmethod
+    def _normalized_supported_alleles(command, supported_allele_flag, raw_names):
+        """
+        Lazily build (and memoize) a {normalized_name: raw_name} mapping over
+        the predictor's supported alleles. This is where the expensive
+        mhcgnomes normalization of the whole list happens; it is only called
+        when a requested allele is not found verbatim, so the common (human
+        HLA) case never pays for it.
+
+        raw_name is the predictor's own spelling, which is what round-trips on
+        the command line. When several raw spellings normalize to the same
+        name (netMHCpan lists e.g. both `BoLA-1:00901` and `BoLA-100901`),
+        prefer a colon-containing spelling, which matches the form these
+        predictors actually accept on `-a`.
+        """
+        cache_key = (command, supported_allele_flag)
+        cached = _normalized_supported_cache.get(cache_key)
+        if cached is not None:
+            return cached
+        mapping = {}
+        skipped = 0
+        for name in raw_names:
+            try:
+                key = normalize_allele_name(name)
+            except AlleleParseError:
+                # Some non-human/edge-case names (e.g. BoLA-amani.1, H-2-Qa1)
+                # can't be normalized; they remain reachable only by verbatim
+                # match on the fast path.
+                skipped += 1
+                continue
+            existing = mapping.get(key)
+            if existing is None or (":" in name and ":" not in existing):
+                mapping[key] = name
+        if skipped:
+            logger.debug(
+                "%s %s: %d of %d supported allele names could not be normalized",
+                command, supported_allele_flag, skipped, len(raw_names))
+        _normalized_supported_cache[cache_key] = mapping
+        return mapping
+
+    def _resolve_supported_alleles(self):
+        """
+        Validate self.alleles against the predictor's supported-allele list and
+        record, for each, the exact spelling to pass on the command line
+        (self._allele_cli_names).
+
+        Fast path: if prepare_allele_name(allele) is printed verbatim by the
+        predictor, use it directly — no full-list normalization needed. Slow
+        path (only on a miss): normalize the whole supported list once and look
+        the allele up by its normalized name, using the predictor's own
+        spelling on the command line so names our normalizer rewrites (many
+        non-human alleles) still round-trip.
+        """
+        raw_names = self._supported_allele_names
+        self._allele_cli_names = {}
+        if raw_names is None:
+            return
+        unsupported = []
+        normalized_map = None
+        for allele in self.alleles:
+            cli_name = self.prepare_allele_name(allele)
+            if cli_name in raw_names:
+                self._allele_cli_names[allele] = cli_name
+                continue
+            if normalized_map is None:
+                normalized_map = self._normalized_supported_alleles(
+                    self.program_name,
+                    self.supported_alleles_flag,
+                    raw_names)
+            original = normalized_map.get(allele)
+            if original is not None:
+                self._allele_cli_names[allele] = original
+            else:
+                unsupported.append(allele)
+        if unsupported:
+            raise UnsupportedAllele(
+                "Unsupported alleles for %s: %s\n"
+                "Run command %s %s to see a list of valid alleles" % (
+                    self.program_name,
+                    unsupported,
+                    self.program_name,
+                    self.supported_alleles_flag))
+
     def prepare_allele_name(self, allele_name):
         """
         How does the predictor expect to see allele names?
         """
         return allele_name.replace("*", "")
+
+    def _cli_allele_name(self, allele_name):
+        """
+        The spelling to pass on the command line for a (normalized) allele.
+
+        Prefers the predictor's own -listMHC spelling recorded during
+        validation (so names like BoLA-1:00901 round-trip instead of being
+        rewritten to a rejected form); falls back to prepare_allele_name for
+        predictors that don't enumerate their supported alleles.
+        """
+        resolved = getattr(self, "_allele_cli_names", {}).get(allele_name)
+        if resolved is not None:
+            return resolved
+        return self.prepare_allele_name(allele_name)
 
     def _auto_allele_group_size(self, n_alleles, n_input_files):
         """
@@ -349,7 +435,7 @@ class BaseCommandlinePredictor(BasePredictor):
         if peptide_mode:
             args.extend(self.peptide_mode_flags)
         allele_arg = ",".join(
-            self.prepare_allele_name(allele) for allele in alleles)
+            self._cli_allele_name(allele) for allele in alleles)
         args.extend([self.allele_flag, allele_arg])
         if length:
             args.extend([self.length_flag, str(length)])

--- a/mhctools/base_commandline_predictor.py
+++ b/mhctools/base_commandline_predictor.py
@@ -42,6 +42,13 @@ logger = logging.getLogger(__name__)
 # ~85% of the amortization while bounding those risks.
 AUTO_MAX_ALLELES_PER_COMMAND = 20
 
+# Cache of supported-allele sets keyed by (command, supported_allele_flag).
+# Determining the supported alleles means running e.g. `netMHCpan -listMHC`
+# and normalizing every line (~3,900 alleles), which is slow and identical
+# for every predictor sharing the same binary. Memoize it per process so it
+# happens once instead of on every predictor construction.
+_supported_alleles_cache = {}
+
 
 class BaseCommandlinePredictor(BasePredictor):
     """
@@ -228,7 +235,15 @@ class BaseCommandlinePredictor(BasePredictor):
         """
         Try asking the commandline predictor (e.g. netMHCpan)
         which alleles it supports.
+
+        The result is memoized per (command, supported_allele_flag) so the
+        `-listMHC` call and the parsing of its thousands of alleles happen
+        once per process rather than on every predictor construction.
         """
+        cache_key = (command, supported_allele_flag)
+        cached = _supported_alleles_cache.get(cache_key)
+        if cached is not None:
+            return cached
         try:
             # convert to str since Python3 returns a `bytes` object
             supported_alleles_output = check_output([
@@ -238,6 +253,7 @@ class BaseCommandlinePredictor(BasePredictor):
             assert len(supported_alleles_str) > 0, \
                 '%s returned empty allele list' % command
             supported_alleles = set([])
+            skipped = []
             for line in supported_alleles_str.split("\n"):
                 line = line.strip()
                 if not line.startswith('#') and len(line) > 0:
@@ -247,10 +263,23 @@ class BaseCommandlinePredictor(BasePredictor):
                         # our own alleles.
                         supported_alleles.add(normalize_allele_name(line))
                     except AlleleParseError as error:
-                        logger.info("Skipping allele %s: %s", line, error)
+                        # Non-human/edge-case alleles the normalizer can't
+                        # handle (e.g. some BoLA/Mamu/H-2 names). Log at debug
+                        # so predictor construction doesn't spam the user; a
+                        # single summary is emitted below.
+                        logger.debug("Skipping allele %s: %s", line, error)
+                        skipped.append(line)
                         continue
             if len(supported_alleles) == 0:
                 raise ValueError("Unable to determine supported alleles")
+            if skipped:
+                logger.debug(
+                    "%s %s: skipped %d of %d alleles that could not be parsed",
+                    command,
+                    supported_allele_flag,
+                    len(skipped),
+                    len(supported_alleles) + len(skipped))
+            _supported_alleles_cache[cache_key] = supported_alleles
             return supported_alleles
         except Exception as e:
             logger.exception(e)

--- a/mhctools/base_commandline_predictor.py
+++ b/mhctools/base_commandline_predictor.py
@@ -61,6 +61,29 @@ _supported_alleles_cache = {}
 _normalized_supported_cache = {}
 
 
+def _prefer_allele_spelling(new, existing):
+    """
+    When several raw -listMHC spellings normalize to the same allele, pick the
+    one most likely accepted on `-a`, deterministically (independent of set
+    iteration order):
+
+      1. a colon-containing spelling (e.g. BoLA-1:00901, which netMHCpan
+         accepts, over BoLA-100901, which it rejects);
+      2. among those, the spelling whose colon sits earliest — i.e. right
+         after the gene (Mamu-A1:00101 over Mamu-A1001:01);
+      3. the lexicographically smaller string as a final stable tie-break.
+    """
+    def rank(name):
+        colon = name.find(":")
+        # higher is preferred: has-colon first, then earliest colon
+        return (colon >= 0, -colon if colon >= 0 else 1)
+
+    rank_new, rank_existing = rank(new), rank(existing)
+    if rank_new != rank_existing:
+        return new if rank_new > rank_existing else existing
+    return min(new, existing)
+
+
 class BaseCommandlinePredictor(BasePredictor):
     """
     Base class for MHC binding predictors that run a local external
@@ -268,6 +291,25 @@ class BaseCommandlinePredictor(BasePredictor):
             }
             if len(supported_alleles) == 0:
                 raise ValueError("Unable to determine supported alleles")
+
+            # Sanity check that this really is an allele list and not, e.g., a
+            # mismatched executable's usage/error text (which would otherwise
+            # sail through as a set of "raw" names and only fail later as an
+            # UnsupportedAllele). At least one name must parse as an allele.
+            # Probe lazily and stop at the first success — O(1) for a real
+            # list, so this does not reintroduce the up-front full parse.
+            def parses(name):
+                try:
+                    normalize_allele_name(name)
+                    return True
+                except AlleleParseError:
+                    return False
+            if not any(parses(name) for name in supported_alleles):
+                raise ValueError(
+                    "No parseable alleles in output of %s %s "
+                    "(possibly an incorrect executable version?)" % (
+                        command, supported_allele_flag))
+
             _supported_alleles_cache[cache_key] = supported_alleles
             return supported_alleles
         except Exception as e:
@@ -286,10 +328,10 @@ class BaseCommandlinePredictor(BasePredictor):
         HLA) case never pays for it.
 
         raw_name is the predictor's own spelling, which is what round-trips on
-        the command line. When several raw spellings normalize to the same
-        name (netMHCpan lists e.g. both `BoLA-1:00901` and `BoLA-100901`),
-        prefer a colon-containing spelling, which matches the form these
-        predictors actually accept on `-a`.
+        the command line. When several raw spellings normalize to the same name
+        (netMHCpan lists e.g. both `BoLA-1:00901` and `BoLA-100901`, or two
+        colon forms for one Mamu allele), _prefer_allele_spelling picks one
+        deterministically.
         """
         cache_key = (command, supported_allele_flag)
         cached = _normalized_supported_cache.get(cache_key)
@@ -307,8 +349,10 @@ class BaseCommandlinePredictor(BasePredictor):
                 skipped += 1
                 continue
             existing = mapping.get(key)
-            if existing is None or (":" in name and ":" not in existing):
+            if existing is None:
                 mapping[key] = name
+            else:
+                mapping[key] = _prefer_allele_spelling(name, existing)
         if skipped:
             logger.debug(
                 "%s %s: %d of %d supported allele names could not be normalized",
@@ -336,8 +380,16 @@ class BaseCommandlinePredictor(BasePredictor):
         unsupported = []
         normalized_map = None
         for allele in self.alleles:
-            cli_name = self.prepare_allele_name(allele)
-            if cli_name in raw_names:
+            # Fast path: the predictor's expected spelling is printed verbatim.
+            # prepare_allele_name can itself reject an allele (e.g. netMHCIIpan
+            # re-parses and raises on unexpected genes); if so, fall through to
+            # the slow path, which resolves via the predictor's own -listMHC
+            # spelling and never needs prepare_allele_name.
+            try:
+                cli_name = self.prepare_allele_name(allele)
+            except Exception:
+                cli_name = None
+            if cli_name is not None and cli_name in raw_names:
                 self._allele_cli_names[allele] = cli_name
                 continue
             if normalized_map is None:

--- a/tests/test_supported_allele_cache.py
+++ b/tests/test_supported_allele_cache.py
@@ -11,25 +11,37 @@
 # limitations under the License.
 
 """
-Unit tests for the supported-allele determination in
-BaseCommandlinePredictor: it should run the `-listMHC` subprocess and parse
-its alleles once per (command, flag) rather than on every predictor
-construction, and it should not spam the user at INFO level about alleles it
-cannot parse. No predictor binary is required.
+Unit tests for supported-allele handling in BaseCommandlinePredictor:
+
+  * `-listMHC` output is read once per (command, flag) and returned verbatim
+    (no mhcgnomes normalization of the ~13k names up front);
+  * user alleles are validated with a fast verbatim path that only needs the
+    normalized map (the expensive mhcgnomes pass) when the fast path misses;
+  * when an allele is supported under a spelling our normalizer rewrites, the
+    predictor's own -listMHC spelling is used on the command line so it
+    round-trips (e.g. BoLA-1:00901 instead of the rejected BoLA-109:01).
+
+No predictor binary is required.
 """
 
 import logging
 
+import pytest
+
 import mhctools.base_commandline_predictor as bcp
 from mhctools.base_commandline_predictor import BaseCommandlinePredictor
+from mhctools.unsupported_allele import UnsupportedAllele
 
-# A tiny stand-in for `netMHCpan -listMHC` output: two parseable HLA alleles,
-# a comment line, and a name the legacy normalizer can't parse.
+
+# Raw `-listMHC`-style output: parseable HLA, a comment, non-human names, and
+# two spellings of one BoLA allele (netMHCpan really does list both).
 _CANNED_LISTMHC = (
     b"# comment line\n"
     b"HLA-A02:01\n"
     b"HLA-B07:02\n"
     b"BoLA-amani.1\n"
+    b"BoLA-1:00901\n"
+    b"BoLA-100901\n"
 )
 
 _KEY = ("faketool_cache_test", "-listMHC")
@@ -37,9 +49,36 @@ _KEY = ("faketool_cache_test", "-listMHC")
 
 def _clear():
     bcp._supported_alleles_cache.pop(_KEY, None)
+    bcp._normalized_supported_cache.pop(_KEY, None)
 
 
-def test_supported_alleles_determined_once_and_cached(monkeypatch):
+@pytest.fixture(autouse=True)
+def _clean_caches():
+    _clear()
+    yield
+    _clear()
+
+
+class _StubResolve(BaseCommandlinePredictor):
+    """Exercises _resolve_supported_alleles without a real binary: sets the
+    attributes it reads and bypasses __init__."""
+    def __init__(self, alleles, supported_names, prepare=None):
+        self.program_name, self.supported_alleles_flag = _KEY
+        self.alleles = list(alleles)              # already normalized
+        self._supported_allele_names = set(supported_names)
+        self._prepare = prepare
+
+    def prepare_allele_name(self, allele_name):
+        if self._prepare is not None:
+            return self._prepare(allele_name)
+        return allele_name.replace("*", "")
+
+
+# ---------------------------------------------------------------------------
+# _determine_supported_alleles: raw, cached, no normalization
+# ---------------------------------------------------------------------------
+
+def test_supported_alleles_are_raw_and_cached(monkeypatch):
     calls = {"n": 0}
 
     def fake_check_output(args):
@@ -47,40 +86,87 @@ def test_supported_alleles_determined_once_and_cached(monkeypatch):
         return _CANNED_LISTMHC
 
     monkeypatch.setattr(bcp, "check_output", fake_check_output)
-    _clear()
-    try:
-        first = BaseCommandlinePredictor._determine_supported_alleles(*_KEY)
-        second = BaseCommandlinePredictor._determine_supported_alleles(*_KEY)
-        # The subprocess ran once; the second call hit the cache.
-        assert calls["n"] == 1
-        assert first is second
-        assert "HLA-A*02:01" in first
-        assert "HLA-B*07:02" in first
-        # The unparseable name is skipped, not included.
-        assert not any("BoLA" in a for a in first)
-    finally:
-        _clear()
+    first = BaseCommandlinePredictor._determine_supported_alleles(*_KEY)
+    second = BaseCommandlinePredictor._determine_supported_alleles(*_KEY)
+    assert calls["n"] == 1                 # subprocess ran once
+    assert first is second                 # cached
+    # names are verbatim, not normalized, and non-human names are kept
+    assert first == {
+        "HLA-A02:01", "HLA-B07:02",
+        "BoLA-amani.1", "BoLA-1:00901", "BoLA-100901"}
 
 
-def test_unparseable_alleles_not_logged_at_info(monkeypatch, caplog):
+def test_determine_does_not_run_mhcgnomes(monkeypatch):
     monkeypatch.setattr(bcp, "check_output", lambda args: _CANNED_LISTMHC)
-    _clear()
-    try:
-        with caplog.at_level(logging.INFO, logger=bcp.logger.name):
-            BaseCommandlinePredictor._determine_supported_alleles(*_KEY)
-        # No per-allele "Skipping allele" spam at INFO — it is emitted at DEBUG.
-        assert "Skipping allele" not in caplog.text
-    finally:
-        _clear()
+
+    def explode(*a, **k):
+        raise AssertionError("normalize_allele_name should not run here")
+
+    monkeypatch.setattr(bcp, "normalize_allele_name", explode)
+    # Must not normalize the list — proves the up-front parse is gone.
+    BaseCommandlinePredictor._determine_supported_alleles(*_KEY)
 
 
-def test_unparseable_alleles_available_at_debug(monkeypatch, caplog):
+# ---------------------------------------------------------------------------
+# Fast path: verbatim match, no normalized map built
+# ---------------------------------------------------------------------------
+
+def test_fast_path_resolves_without_building_normalized_map():
+    p = _StubResolve(
+        ["HLA-A*02:01", "HLA-B*07:02"],
+        {"HLA-A02:01", "HLA-B07:02", "BoLA-1:00901"})
+    p._resolve_supported_alleles()
+    assert p._allele_cli_names == {
+        "HLA-A*02:01": "HLA-A02:01", "HLA-B*07:02": "HLA-B07:02"}
+    # The expensive normalization of the whole list never ran.
+    assert _KEY not in bcp._normalized_supported_cache
+
+
+# ---------------------------------------------------------------------------
+# Slow path: round-trip to the predictor's own spelling
+# ---------------------------------------------------------------------------
+
+def test_slow_path_uses_predictor_spelling_for_non_roundtripping_allele():
+    # prepare("BoLA-1*09:01") -> "BoLA-109:01", which is NOT what netMHCpan
+    # prints; the normalized map must map it back to "BoLA-1:00901".
+    p = _StubResolve(["BoLA-1*09:01"], {"BoLA-1:00901", "BoLA-100901"})
+    p._resolve_supported_alleles()
+    assert p._allele_cli_names == {"BoLA-1*09:01": "BoLA-1:00901"}
+    assert _KEY in bcp._normalized_supported_cache  # map was needed
+
+
+def test_collision_prefers_colon_spelling():
+    mapping = BaseCommandlinePredictor._normalized_supported_alleles(
+        *_KEY, raw_names={"BoLA-100901", "BoLA-1:00901"})
+    assert mapping["BoLA-1*09:01"] == "BoLA-1:00901"
+
+
+def test_unsupported_allele_raises():
+    p = _StubResolve(["HLA-A*99:99"], {"HLA-A02:01", "HLA-B07:02"})
+    with pytest.raises(UnsupportedAllele, match="HLA-A"):
+        p._resolve_supported_alleles()
+
+
+def test_no_supported_list_skips_validation():
+    # Predictors that don't enumerate alleles keep working (no CLI-name map).
+    p = _StubResolve(["HLA-A*02:01"], set())
+    p._supported_allele_names = None
+    p._resolve_supported_alleles()
+    assert p._allele_cli_names == {}
+    # falls back to prepare_allele_name for the command line
+    assert p._cli_allele_name("HLA-A*02:01") == "HLA-A02:01"
+
+
+# ---------------------------------------------------------------------------
+# Logging: no INFO spam about unparseable names
+# ---------------------------------------------------------------------------
+
+def test_no_info_spam(monkeypatch, caplog):
     monkeypatch.setattr(bcp, "check_output", lambda args: _CANNED_LISTMHC)
-    _clear()
-    try:
-        with caplog.at_level(logging.DEBUG, logger=bcp.logger.name):
-            BaseCommandlinePredictor._determine_supported_alleles(*_KEY)
-        # The detail is still there for anyone who opts into DEBUG.
-        assert "BoLA-amani.1" in caplog.text
-    finally:
-        _clear()
+    with caplog.at_level(logging.INFO, logger=bcp.logger.name):
+        BaseCommandlinePredictor._determine_supported_alleles(*_KEY)
+        # even building the normalized map (which skips BoLA-amani.1) is quiet
+        BaseCommandlinePredictor._normalized_supported_alleles(
+            *_KEY,
+            raw_names={"HLA-A02:01", "BoLA-amani.1"})
+    assert "Skipping allele" not in caplog.text

--- a/tests/test_supported_allele_cache.py
+++ b/tests/test_supported_allele_cache.py
@@ -1,0 +1,86 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for the supported-allele determination in
+BaseCommandlinePredictor: it should run the `-listMHC` subprocess and parse
+its alleles once per (command, flag) rather than on every predictor
+construction, and it should not spam the user at INFO level about alleles it
+cannot parse. No predictor binary is required.
+"""
+
+import logging
+
+import mhctools.base_commandline_predictor as bcp
+from mhctools.base_commandline_predictor import BaseCommandlinePredictor
+
+# A tiny stand-in for `netMHCpan -listMHC` output: two parseable HLA alleles,
+# a comment line, and a name the legacy normalizer can't parse.
+_CANNED_LISTMHC = (
+    b"# comment line\n"
+    b"HLA-A02:01\n"
+    b"HLA-B07:02\n"
+    b"BoLA-amani.1\n"
+)
+
+_KEY = ("faketool_cache_test", "-listMHC")
+
+
+def _clear():
+    bcp._supported_alleles_cache.pop(_KEY, None)
+
+
+def test_supported_alleles_determined_once_and_cached(monkeypatch):
+    calls = {"n": 0}
+
+    def fake_check_output(args):
+        calls["n"] += 1
+        return _CANNED_LISTMHC
+
+    monkeypatch.setattr(bcp, "check_output", fake_check_output)
+    _clear()
+    try:
+        first = BaseCommandlinePredictor._determine_supported_alleles(*_KEY)
+        second = BaseCommandlinePredictor._determine_supported_alleles(*_KEY)
+        # The subprocess ran once; the second call hit the cache.
+        assert calls["n"] == 1
+        assert first is second
+        assert "HLA-A*02:01" in first
+        assert "HLA-B*07:02" in first
+        # The unparseable name is skipped, not included.
+        assert not any("BoLA" in a for a in first)
+    finally:
+        _clear()
+
+
+def test_unparseable_alleles_not_logged_at_info(monkeypatch, caplog):
+    monkeypatch.setattr(bcp, "check_output", lambda args: _CANNED_LISTMHC)
+    _clear()
+    try:
+        with caplog.at_level(logging.INFO, logger=bcp.logger.name):
+            BaseCommandlinePredictor._determine_supported_alleles(*_KEY)
+        # No per-allele "Skipping allele" spam at INFO — it is emitted at DEBUG.
+        assert "Skipping allele" not in caplog.text
+    finally:
+        _clear()
+
+
+def test_unparseable_alleles_available_at_debug(monkeypatch, caplog):
+    monkeypatch.setattr(bcp, "check_output", lambda args: _CANNED_LISTMHC)
+    _clear()
+    try:
+        with caplog.at_level(logging.DEBUG, logger=bcp.logger.name):
+            BaseCommandlinePredictor._determine_supported_alleles(*_KEY)
+        # The detail is still there for anyone who opts into DEBUG.
+        assert "BoLA-amani.1" in caplog.text
+    finally:
+        _clear()

--- a/tests/test_supported_allele_cache.py
+++ b/tests/test_supported_allele_cache.py
@@ -60,13 +60,20 @@ def _clean_caches():
 
 
 class _StubResolve(BaseCommandlinePredictor):
-    """Exercises _resolve_supported_alleles without a real binary: sets the
-    attributes it reads and bypasses __init__."""
+    """Exercises _resolve_supported_alleles / _build_command without a real
+    binary: sets the attributes they read and bypasses __init__."""
     def __init__(self, alleles, supported_names, prepare=None):
         self.program_name, self.supported_alleles_flag = _KEY
         self.alleles = list(alleles)              # already normalized
         self._supported_allele_names = set(supported_names)
         self._prepare = prepare
+        # attributes _build_command needs
+        self.peptide_mode_flags = ["-p"]
+        self.allele_flag = "-a"
+        self.length_flag = "-l"
+        self.input_file_flag = "-f"
+        self.tempdir_flag = None
+        self.extra_flags = []
 
     def prepare_allele_name(self, allele_name):
         if self._prepare is not None:
@@ -96,15 +103,32 @@ def test_supported_alleles_are_raw_and_cached(monkeypatch):
         "BoLA-amani.1", "BoLA-1:00901", "BoLA-100901"}
 
 
-def test_determine_does_not_run_mhcgnomes(monkeypatch):
+def test_determine_only_probes_for_a_parseable_allele(monkeypatch):
+    # It must not normalize the whole list up front — only probe until the
+    # first parseable name (the wrong-executable sanity check).
+    calls = {"n": 0}
+    real = bcp.normalize_allele_name
+
+    def counting(name, *a, **k):
+        calls["n"] += 1
+        return real(name, *a, **k)
+
     monkeypatch.setattr(bcp, "check_output", lambda args: _CANNED_LISTMHC)
-
-    def explode(*a, **k):
-        raise AssertionError("normalize_allele_name should not run here")
-
-    monkeypatch.setattr(bcp, "normalize_allele_name", explode)
-    # Must not normalize the list — proves the up-front parse is gone.
+    monkeypatch.setattr(bcp, "normalize_allele_name", counting)
     BaseCommandlinePredictor._determine_supported_alleles(*_KEY)
+    # 5 names; probe stops at the first that parses, so far fewer than 5.
+    assert calls["n"] < 5
+
+
+def test_garbage_output_raises_system_error(monkeypatch):
+    # A mismatched executable's usage/error text has no parseable alleles and
+    # must raise SystemError (the "incorrect executable version?" signal),
+    # not silently pass through as a set of raw names.
+    monkeypatch.setattr(
+        bcp, "check_output",
+        lambda args: b"usage: netMHC [-options]\nnot_an_allele_here\n")
+    with pytest.raises(SystemError):
+        BaseCommandlinePredictor._determine_supported_alleles(*_KEY)
 
 
 # ---------------------------------------------------------------------------
@@ -139,6 +163,40 @@ def test_collision_prefers_colon_spelling():
     mapping = BaseCommandlinePredictor._normalized_supported_alleles(
         *_KEY, raw_names={"BoLA-100901", "BoLA-1:00901"})
     assert mapping["BoLA-1*09:01"] == "BoLA-1:00901"
+
+
+def test_collision_tie_break_is_deterministic():
+    # Two colon spellings for one Mamu allele: pick the one whose colon sits
+    # right after the gene, deterministically regardless of set order.
+    raw = {"Mamu-A1001:01", "Mamu-A1:00101"}
+    a = BaseCommandlinePredictor._normalized_supported_alleles(*_KEY, raw_names=raw)
+    _clear()
+    b = BaseCommandlinePredictor._normalized_supported_alleles(
+        *_KEY, raw_names=set(reversed(list(raw))))
+    assert a == b == {"Mamu-A1*01:01": "Mamu-A1:00101"}
+
+
+def test_resolved_spelling_used_in_command():
+    # The predictor's own -listMHC spelling (not the mangled prepared form)
+    # must reach the -a argument.
+    p = _StubResolve(["BoLA-1*09:01"], {"BoLA-1:00901", "BoLA-100901"})
+    p._resolve_supported_alleles()
+    cmd = p._build_command(
+        input_filename="pep.txt", alleles=["BoLA-1*09:01"], peptide_mode=True)
+    i = cmd.index("-a")
+    assert cmd[i + 1] == "BoLA-1:00901"
+    assert "BoLA-109:01" not in cmd            # not the rewritten form
+
+
+def test_prepare_failure_falls_back_to_slow_path():
+    # prepare_allele_name that raises (as netMHCIIpan can on unexpected genes)
+    # must not crash resolution — it falls through to the -listMHC spelling.
+    def boom(allele):
+        raise ValueError("prepare rejects %s" % allele)
+
+    p = _StubResolve(["BoLA-1*09:01"], {"BoLA-1:00901"}, prepare=boom)
+    p._resolve_supported_alleles()
+    assert p._allele_cli_names == {"BoLA-1*09:01": "BoLA-1:00901"}
 
 
 def test_unsupported_allele_raises():


### PR DESCRIPTION
## Problem

Determining a command-line predictor's supported alleles ran e.g. `netMHCpan -listMHC` and **normalized every one of its ~13,000 names through mhcgnomes** on **every predictor construction**. That was slow (~2.45s each), spammed one INFO line per unparseable name, and — more subtly — mis-spelled alleles on the way back out: mhctools re-derived the CLI name via `prepare(normalize(user))`, which produces a form netMHCpan rejects for ~2,456 (mostly non-human) alleles. E.g. requesting `BoLA-1:00901` sent netMHCpan `BoLA-109:01` → *"cannot be found in hla_pseudo list"*, so those alleles were **unrunnable**.

## Change: lazy validation + round-trip the predictor's own spelling

- **`_determine_supported_alleles` returns the RAW `-listMHC` names verbatim** (a line split — no mhcgnomes). Cheap and cached per `(command, flag)`.
- **Fast validation path**: each requested allele is checked with `prepare_allele_name(allele) ∈ raw_set`. mhcgnomes only ever runs on the **user's handful of alleles**, so the common human-HLA case never parses the 13k list. **First-predictor construction drops ~2.45s → ~0.09s** (~27×); the earlier in-memory cache only helped the *2nd* predictor onward — this helps the first too.
- **Slow path (only on a fast-path miss)**: build the full `{normalized: raw}` map once (cached) and look the allele up by normalized name, then pass netMHCpan **its own `-listMHC` spelling** on the command line. This fixes the round-trip bug — `BoLA-1:00901` now resolves to `BoLA-1:00901` and **runs end-to-end**. ~2,456 previously-unrunnable non-human alleles now work.
- On collision (netMHCpan lists both `BoLA-1:00901` and `BoLA-100901` for one allele) prefer a colon-containing spelling — the form it actually accepts on `-a`.
- **Logging**: no more per-allele "Skipping…" spam — the raw path doesn't normalize, and the lazy map emits only a single DEBUG summary.

Human-HLA identity/output matching is unchanged (`self.alleles` stays normalized); only the CLI spelling and the *timing* of normalization change.

## Why not fully skip validation

~19% of netMHCpan's own names don't round-trip through `normalize→prepare`, so a naive `prepare(user) ∈ raw_set` check with no fallback would falsely reject them. The fast-path-then-normalized-map design keeps validation robust while staying lazy for the common case.

## Verified on real netMHCpan 4.2 (Darwin_arm64)

- Human HLA validates **without** building the normalized map (mhcgnomes runs on user alleles only).
- `BoLA-1:00901` resolves to its own spelling and **predicts** (was impossible before).
- Unsupported alleles still raise `UnsupportedAllele`.
- All netMHC-family integration tests pass (netMHCpan / netMHCIIpan / netMHCcons / netMHCstabpan).

## Tests

`tests/test_supported_allele_cache.py` (binary-free): raw+cached `-listMHC`; `_determine_supported_alleles` runs no mhcgnomes; fast path resolves without building the normalized map; slow path returns the predictor's own spelling; collision prefers the colon form; unsupported raises; no INFO spam.

Version bumped 3.17.0 → 3.18.0.

https://claude.ai/code/session_01LZahFhBSCiehXTESCYQ7wG