### PR TITLE
Add PRIME immunogenicity predictor (#239)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,6 +53,7 @@ jobs:
             tests/test_process_helpers.py \
             tests/test_pred.py \
             tests/test_annotate_table.py \
+            tests/test_prime.py \
             tests/test_processing_predictor.py \
             tests/test_pepsickle.py \
             tests/test_bigmhc.py \

--- a/README.md
+++ b/README.md
@@ -360,9 +360,15 @@ results[0].immunogenicity.score
 > ⚠️ Every current CD8 immunogenicity predictor — `PRIME` and `BigMHC_IM`
 > included — ranks well in the characterized regime but generalizes poorly to
 > truly novel neoepitopes; independent benchmarks put the field near AUC
-> 0.5–0.65, with most of the usable signal coming from expression / agretopicity
-> features rather than the peptide alone. Use these scores to prioritize, not as
-> ground truth.
+> 0.5–0.65 on unseen tumor neoepitopes (ITSNdb ~0.52–0.60, ICERFIRE ~0.56,
+> IMPROVE ~0.60). In the one neutral head-to-head that scored both (NeoaPred,
+> *Bioinformatics* 2024), **`BigMHC_IM` edged `PRIME` on cancer neoepitopes**,
+> while PRIME tends to do better on viral / infectious-disease epitopes — its
+> training positives are mostly viral and cancer-testis antigens, with only
+> ~129 (v1) / ~596 (v2) true immunogenic neoepitopes. PRIME's higher
+> self-reported numbers are partly attributable to documented train/test
+> overlap (IMPROVE flagged ~70% overlap with its evaluation set). Use these
+> scores to prioritize, not as ground truth.
 
 ### TCR specificity
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,8 @@ Examples:
 | `NetCleave_II` | `endolysosomal_cleavage` | `none` | `II` |
 | `NetTCR` | `pMHC_TCR_binding` | `none` | `I` |
 | `Tulip` | `pMHC_TCR_binding` | `single_allele` | `I` |
+| `BigMHC_IM` | `immunogenicity` | `single_allele` | `I` |
+| `PRIME` | `immunogenicity` | `single_allele` | `I` |
 
 ### TCR predictors (`NetTCR`, `Tulip`)
 
@@ -329,6 +331,38 @@ by_protein = predictor.predict_proteins({"TP53": "MEEPQ..."}, peptide_lengths=[1
 > ⚠️ NetCleave's own paper reports class-II C-terminal cleavage is a much
 > weaker signal than class I (AUC ~0.66 vs ~0.91). Treat
 > `endolysosomal_cleavage` scores accordingly.
+
+### Immunogenicity
+
+| Predictor | Kinds produced | Requires |
+|---|---|---|
+| `BigMHC_IM` | immunogenicity | [BigMHC](https://github.com/KarchinLab/bigmhc) clone (set `BIGMHC_DIR`) |
+| `PRIME` | immunogenicity | [PRIME](https://github.com/GfellerLab/PRIME) clone + MixMHCpred |
+
+`PRIME` predicts CD8+ T-cell immunogenicity of class-I peptides by combining
+MHC-I binding (via MixMHCpred, which it calls internally) with a TCR-recognition
+propensity model. It emits one `immunogenicity` prediction per (peptide, allele):
+`score` is the PRIME score (higher = more immunogenic) and `percentile_rank` is
+the PRIME %Rank (lower = better). PRIME is academic / non-commercial licensed, so
+mhctools shells out to a user-provided install rather than vendoring it.
+
+```python
+from mhctools import PRIME
+
+predictor = PRIME(
+    alleles=["HLA-A*02:01", "HLA-B*07:02"],
+    program_name="PRIME",                    # or an absolute path
+    mixmhcpred_path="/path/to/MixMHCpred")    # optional if MixMHCpred is on PATH
+results = predictor.predict(["GILGFVFTL", "NLVPMVATV"])
+results[0].immunogenicity.score
+```
+
+> ⚠️ Every current CD8 immunogenicity predictor — `PRIME` and `BigMHC_IM`
+> included — ranks well in the characterized regime but generalizes poorly to
+> truly novel neoepitopes; independent benchmarks put the field near AUC
+> 0.5–0.65, with most of the usable signal coming from expression / agretopicity
+> features rather than the peptide alone. Use these scores to prioritize, not as
+> ground truth.
 
 ### TCR specificity
 

--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -24,6 +24,7 @@ from .iedb import (
     IedbNetMHCIIpan,
 )
 from .mixmhcpred import MixMHCpred
+from .prime import PRIME
 from .processing_predictor import (
     ProcessingPredictor,
     SCORING_MODES,
@@ -80,7 +81,7 @@ def __getattr__(name):
     raise AttributeError(
         "module %r has no attribute %r" % (__name__, name))
 
-__version__ = "3.22.0"
+__version__ = "3.23.0"
 
 __all__ = [
     "Prediction",
@@ -107,6 +108,7 @@ __all__ = [
     "IedbSMM_PMBEC",
     "IedbNetMHCIIpan",
     "MixMHCpred",
+    "PRIME",
     "MHCflurry",
     "MHCflurry_Affinity",
     "ProcessingPredictor",

--- a/mhctools/cli/args.py
+++ b/mhctools/cli/args.py
@@ -62,6 +62,7 @@ from .. import (
     IedbSMM_PMBEC,
     IedbNetMHCIIpan,
     MixMHCpred,
+    PRIME,
 )
 
 
@@ -165,6 +166,7 @@ mhc_predictors = {
     "mhcflurry": _MHCflurry,
     "mhcflurry-affinity": _MHCflurry_Affinity,
     "mixmhcpred": MixMHCpred,
+    "prime": PRIME,
 }
 
 

--- a/mhctools/prime.py
+++ b/mhctools/prime.py
@@ -1,0 +1,221 @@
+# Copyright (c) 2016. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Wrapper for PRIME — PRedictor of Immunogenic Epitopes (Gfeller lab).
+
+PRIME predicts CD8+ T-cell immunogenicity of class-I peptides by combining
+MHC-I binding (via MixMHCpred) with a TCR-recognition propensity model. This
+wrapper shells out to a user-provided PRIME install (PRIME is academic /
+non-commercial licensed, so mhctools does not vendor it) and emits one
+``Kind.immunogenicity`` prediction per (peptide, allele).
+
+PRIME itself calls MixMHCpred (v3.0+ recommended); point at it with
+``mixmhcpred_path`` if it is not on ``PATH``.
+
+Upstream: https://github.com/GfellerLab/PRIME
+Cite: Gfeller et al., *Cell Systems* 2023 — "Improved predictions of antigen
+presentation and TCR recognition with MixMHCpred2.2 and PRIME2.0".
+
+Note on interpretation: like every current CD8 immunogenicity predictor, PRIME
+is useful for ranking in the well-characterized regime but generalizes poorly
+to truly novel neoepitopes (independent benchmarks put the field near
+AUC 0.5-0.65). Treat scores as a prioritization aid, not ground truth.
+"""
+
+from os import remove
+from os.path import exists, join
+from tempfile import NamedTemporaryFile, mkdtemp
+
+import pandas as pd
+
+from .allele_normalization import normalize_allele_name
+from .base_predictor import BasePredictor, _check_flank_inputs
+from .cleanup_context import CleanupFiles
+from .pred import COLUMNS, Kind, PeptideResult, Prediction
+from .process_helpers import run_command
+
+
+class PRIME(BasePredictor):
+    """Wrapper for the PRIME immunogenicity predictor.
+
+    Parameters
+    ----------
+    alleles : list of str
+        Class-I alleles.
+    default_peptide_lengths : list of int
+    program_name : str
+        PRIME executable (name on ``PATH`` or an absolute path).
+    mixmhcpred_path : str, optional
+        Absolute path to the MixMHCpred executable PRIME should use, forwarded
+        as PRIME's ``-mix`` option. If omitted, PRIME finds MixMHCpred on
+        ``PATH``.
+    """
+
+    def __init__(
+            self,
+            alleles,
+            default_peptide_lengths=[9],
+            program_name="PRIME",
+            mixmhcpred_path=None):
+        BasePredictor.__init__(
+            self,
+            alleles=alleles,
+            default_peptide_lengths=default_peptide_lengths,
+            min_peptide_length=8,
+            max_peptide_length=14,
+            allow_X_in_peptides=False,
+            allow_lowercase_in_peptides=False)
+        self.program_name = program_name
+        self.mixmhcpred_path = mixmhcpred_path
+
+    def predict(self, peptides, n_flanks=None, c_flanks=None):
+        """Predict immunogenicity for a list of peptides.
+
+        Flanks are accepted for a uniform API but ignored (PRIME does not use
+        flanking context).
+
+        Returns
+        -------
+        list of PeptideResult
+            One entry per input peptide; each holds one
+            ``Kind.immunogenicity`` prediction per allele (``score`` = PRIME
+            score, higher = more immunogenic; ``percentile_rank`` = PRIME
+            %Rank, lower = better).
+        """
+        peptide_list, _, _ = _check_flank_inputs(peptides, n_flanks, c_flanks)
+        self._check_peptide_inputs(peptide_list)
+        if not peptide_list:
+            return []
+
+        # PRIME accepts HLA-A*02:01 etc.; normalize for a stable identity that
+        # matches the allele strings we hand back in each Prediction.
+        alleles = [normalize_allele_name(a) for a in self.alleles]
+
+        temp_dir = mkdtemp(prefix="mhctools", suffix="prime")
+        input_file_path = join(temp_dir, "prime_input.txt")
+        output_file_path = join(temp_dir, "prime_output.txt")
+        with open(input_file_path, "w") as f:
+            f.write("\n".join(peptide_list) + "\n")
+
+        args = [
+            self.program_name,
+            "-i", input_file_path,
+            "-o", output_file_path,
+            "-a", ",".join(alleles),
+        ]
+        if self.mixmhcpred_path:
+            args += ["-mix", self.mixmhcpred_path]
+
+        with CleanupFiles(
+                filenames=[input_file_path, output_file_path],
+                directories=[temp_dir]):
+            with NamedTemporaryFile(
+                    prefix="PRIME_stdout", mode="w", delete=False) as stdout_file:
+                stdout_file_name = stdout_file.name
+                run_command(
+                    args,
+                    suppress_stderr=False,
+                    redirect_stdout_file=stdout_file)
+            if exists(output_file_path):
+                preds_by_peptide = parse_prime_results(output_file_path, alleles)
+            else:
+                with open(stdout_file_name) as f:
+                    stdout = f.read().strip()
+                raise ValueError(
+                    "PRIME produced no output for alleles %s; stdout: %s"
+                    % (alleles, stdout))
+            remove(stdout_file_name)
+
+        # Preserve input peptide order; a peptide PRIME dropped becomes empty.
+        return [
+            PeptideResult(preds=tuple(preds_by_peptide.get(peptide, ())))
+            for peptide in peptide_list
+        ]
+
+    def predict_dataframe(self, peptides, sample_name=""):
+        """``predict()`` flattened to a DataFrame."""
+        dfs = [pp.to_dataframe(sample_name) for pp in self.predict(peptides)]
+        if not dfs:
+            return pd.DataFrame(columns=COLUMNS)
+        return pd.concat(dfs, ignore_index=True)
+
+    def _default_pred_kind(self):
+        return Kind.immunogenicity
+
+    def kind_support(self):
+        return {
+            Kind.immunogenicity: {
+                "mhc_dependence": "single_allele",
+                "mhc_class": "I",
+            },
+        }
+
+
+def parse_prime_results(filename, alleles):
+    """Parse a PRIME output file into ``{peptide: [Prediction, ...]}``.
+
+    PRIME's output has a ``#``-comment header block, then columns::
+
+        Peptide  %Rank_bestAllele  Score_bestAllele  %RankBinding_bestAllele
+        BestAllele  %Rank_<A1>  Score_<A1>  %RankBinding_<A1>  %Rank_<A2> ...
+
+    The per-allele column triples (``%Rank`` / ``Score`` / ``%RankBinding``)
+    follow the order the alleles were passed to PRIME. PRIME rewrites allele
+    names into its own short form in the column headers, so we map the triples
+    to ``alleles`` **by position** rather than by header name.
+
+    Parameters
+    ----------
+    filename : str
+    alleles : list of str
+        The (normalized) alleles handed to PRIME, in order. Their identity is
+        carried through to the returned predictions.
+
+    Returns
+    -------
+    dict mapping peptide -> list of Prediction (one per allele)
+    """
+    df = pd.read_csv(filename, comment="#", sep="\t")
+    columns = list(df.columns)
+    if "Peptide" not in columns or "BestAllele" not in columns:
+        raise ValueError(
+            "Unexpected PRIME output columns: %s" % columns)
+
+    # Per-allele columns start right after the fixed best-allele block.
+    base = columns.index("BestAllele") + 1
+    per_allele_columns = columns[base:]
+    if len(per_allele_columns) != 3 * len(alleles):
+        raise ValueError(
+            "PRIME returned %d per-allele columns for %d alleles (%s)"
+            % (len(per_allele_columns), len(alleles), per_allele_columns))
+
+    peptide_idx = columns.index("Peptide")
+    results = {}
+    for row in df.itertuples(index=False):
+        peptide = row[peptide_idx]
+        preds = []
+        for i, allele in enumerate(alleles):
+            rank = float(row[base + 3 * i])       # %Rank_<allele>
+            score = float(row[base + 3 * i + 1])  # Score_<allele>
+            # row[base + 3 * i + 2] is %RankBinding (MixMHCpred %Rank); we
+            # surface only PRIME's own immunogenicity signal here.
+            preds.append(Prediction(
+                kind=Kind.immunogenicity,
+                score=score,
+                peptide=peptide,
+                allele=allele,
+                percentile_rank=rank,
+                predictor_name="prime"))
+        results[peptide] = preds
+    return results

--- a/mhctools/prime.py
+++ b/mhctools/prime.py
@@ -30,7 +30,10 @@ presentation and TCR recognition with MixMHCpred2.2 and PRIME2.0".
 Note on interpretation: like every current CD8 immunogenicity predictor, PRIME
 is useful for ranking in the well-characterized regime but generalizes poorly
 to truly novel neoepitopes (independent benchmarks put the field near
-AUC 0.5-0.65). Treat scores as a prioritization aid, not ground truth.
+AUC 0.5-0.65). PRIME's training positives are dominated by viral / cancer-testis
+antigens, so it does relatively better on infectious-disease epitopes and, in
+the one neutral head-to-head (NeoaPred, Bioinformatics 2024), trails BigMHC_IM
+on cancer neoepitopes. Treat scores as a prioritization aid, not ground truth.
 """
 
 from os import remove

--- a/tests/test_prime.py
+++ b/tests/test_prime.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2016. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the PRIME immunogenicity wrapper.
+
+The parser tests are binary-free (they parse a captured PRIME output file).
+The end-to-end tests near the bottom run only when a PRIME executable is
+available (``PRIME_EXECUTABLE`` env var or ``PRIME`` on ``PATH``); PRIME also
+needs MixMHCpred, whose path may be given via ``MIXMHCPRED_PATH``.
+"""
+
+import os
+import shutil
+from tempfile import NamedTemporaryFile
+
+import pytest
+
+from mhctools import PRIME
+from mhctools.prime import parse_prime_results
+from mhctools.pred import Kind
+
+
+# A captured PRIME (v2.1) output for alleles A0201, B0702 on three peptides.
+_PRIME_OUTPUT = """\
+####################
+# Output from PRIME (v2.1)
+# Alleles: A0201, B0702
+####################
+Peptide\t%Rank_bestAllele\tScore_bestAllele\t%RankBinding_bestAllele\tBestAllele\t%Rank_A0201\tScore_A0201\t%RankBinding_A0201\t%Rank_B0702\tScore_B0702\t%RankBinding_B0702
+SIINFEKL\t40.396\t0.001067\t10.000\tA0201\t40.396\t0.001067\t10.000\t80.982\t0.000332\t52.000
+GILGFVFTL\t0.011\t0.236432\t0.100\tA0201\t0.011\t0.236432\t0.100\t2.556\t0.013242\t16.000
+NLVPMVATV\t0.087\t0.128786\t0.200\tA0201\t0.087\t0.128786\t0.200\t12.663\t0.003802\t32.000
+"""
+
+
+def _write_output():
+    f = NamedTemporaryFile("w", suffix="_prime.txt", delete=False)
+    f.write(_PRIME_OUTPUT)
+    f.close()
+    return f.name
+
+
+# --- parser (binary-free) ---------------------------------------------------
+
+def test_parse_prime_results_shape():
+    alleles = ["HLA-A*02:01", "HLA-B*07:02"]
+    path = _write_output()
+    try:
+        by_peptide = parse_prime_results(path, alleles)
+    finally:
+        os.remove(path)
+
+    assert set(by_peptide) == {"SIINFEKL", "GILGFVFTL", "NLVPMVATV"}
+    for peptide, preds in by_peptide.items():
+        assert len(preds) == 2, "one prediction per allele"
+        assert {p.allele for p in preds} == set(alleles)
+        for p in preds:
+            assert p.kind == Kind.immunogenicity
+            assert p.peptide == peptide
+            assert p.predictor_name == "prime"
+
+
+def test_parse_prime_results_values_and_position_mapping():
+    # Position mapping: first triple -> alleles[0], second -> alleles[1].
+    alleles = ["HLA-A*02:01", "HLA-B*07:02"]
+    path = _write_output()
+    try:
+        by_peptide = parse_prime_results(path, alleles)
+    finally:
+        os.remove(path)
+
+    by_allele = {p.allele: p for p in by_peptide["GILGFVFTL"]}
+    a = by_allele["HLA-A*02:01"]
+    b = by_allele["HLA-B*07:02"]
+    assert a.score == 0.236432 and a.percentile_rank == 0.011
+    assert b.score == 0.013242 and b.percentile_rank == 2.556
+
+
+def test_parse_prime_results_allele_identity_is_caller_supplied():
+    # The returned allele is the normalized string we passed, not PRIME's
+    # short column form (A0201).
+    alleles = ["HLA-A*02:01", "HLA-B*07:02"]
+    path = _write_output()
+    try:
+        by_peptide = parse_prime_results(path, alleles)
+    finally:
+        os.remove(path)
+    alleles_seen = {p.allele for preds in by_peptide.values() for p in preds}
+    assert alleles_seen == {"HLA-A*02:01", "HLA-B*07:02"}
+    assert "A0201" not in alleles_seen
+
+
+def test_parse_prime_results_allele_count_mismatch_raises():
+    # Two alleles' worth of columns but three alleles claimed.
+    path = _write_output()
+    try:
+        with pytest.raises(ValueError, match="per-allele columns"):
+            parse_prime_results(path, ["A", "B", "C"])
+    finally:
+        os.remove(path)
+
+
+def test_prime_default_kind_and_support():
+    predictor = PRIME(alleles=["HLA-A*02:01"], program_name="PRIME")
+    assert predictor._default_pred_kind() == Kind.immunogenicity
+    support = predictor.kind_support()[Kind.immunogenicity]
+    assert support["mhc_dependence"] == "single_allele"
+    assert support["mhc_class"] == "I"
+
+
+# --- end-to-end (requires a PRIME install) ----------------------------------
+
+PRIME_EXECUTABLE = os.environ.get("PRIME_EXECUTABLE") or shutil.which("PRIME")
+MIXMHCPRED_PATH = os.environ.get("MIXMHCPRED_PATH") or shutil.which("MixMHCpred")
+
+# PRIME shells out to MixMHCpred, so both must be present; otherwise skip
+# (rather than fail) so CI without MixMHCpred stays green.
+requires_prime = pytest.mark.skipif(
+    not (PRIME_EXECUTABLE and MIXMHCPRED_PATH),
+    reason="PRIME + MixMHCpred not both installed (set PRIME_EXECUTABLE and "
+           "MIXMHCPRED_PATH, or put PRIME and MixMHCpred on PATH)")
+
+
+@requires_prime
+def test_prime_end_to_end():
+    predictor = PRIME(
+        alleles=["HLA-A*02:01", "HLA-B*07:02"],
+        program_name=PRIME_EXECUTABLE,
+        mixmhcpred_path=MIXMHCPRED_PATH)
+    peptides = ["GILGFVFTL", "NLVPMVATV", "SIINFEKL"]
+    results = predictor.predict(peptides)
+
+    assert len(results) == len(peptides)
+    for result, peptide in zip(results, peptides):
+        assert result.peptide == peptide
+        assert len(result.preds) == 2, "one immunogenicity pred per allele"
+        for pred in result.preds:
+            assert pred.kind == Kind.immunogenicity
+            assert pred.allele in {"HLA-A*02:01", "HLA-B*07:02"}
+            assert pred.score is not None
+            assert pred.percentile_rank is not None
+        # a best-immunogenicity accessor resolves
+        assert result.immunogenicity is not None
+
+
+@requires_prime
+def test_prime_dataframe_end_to_end():
+    predictor = PRIME(
+        alleles=["HLA-A*02:01"],
+        program_name=PRIME_EXECUTABLE,
+        mixmhcpred_path=MIXMHCPRED_PATH)
+    df = predictor.predict_dataframe(["GILGFVFTL", "SIINFEKL"])
+    assert len(df) == 2
+    assert set(df["kind"]) == {Kind.immunogenicity}
+    assert (df["allele"] == "HLA-A*02:01").all()


### PR DESCRIPTION
Closes #239. First of a short series (PRIME → MixMHC2pred → DeepTAP).

Wraps [PRIME](https://github.com/GfellerLab/PRIME) (PRedictor of Immunogenic Epitopes, Gfeller lab) as an mhctools predictor. PRIME predicts CD8+ T-cell immunogenicity of class-I peptides by combining MHC-I binding (via MixMHCpred, which it calls internally) with a TCR-recognition propensity model. It sits alongside `BigMHC_IM` as a second immunogenicity option.

## What it does

`PRIME(alleles=..., program_name="PRIME", mixmhcpred_path=None)` shells out to a user-provided PRIME install and emits **one `Kind.immunogenicity` prediction per (peptide, allele)**:

```python
from mhctools import PRIME

predictor = PRIME(
    alleles=["HLA-A*02:01", "HLA-B*07:02"],
    mixmhcpred_path="/path/to/MixMHCpred")   # optional if MixMHCpred is on PATH
r = predictor.predict(["GILGFVFTL"])[0]
r.immunogenicity.score        # PRIME score, higher = more immunogenic
r.preds[0].percentile_rank    # PRIME %Rank, lower = better
```

- **New data model** (`predict()` / `predict_dataframe()`), like `BigMHC` — so it also composes with `mhctools predict-table` via the existing `immunogenicity` field token: `--predictor prime:prime_im:immunogenicity`.
- PRIME is **academic / non-commercial licensed**, so mhctools shells out to a user-provided install rather than vendoring it (same posture as MixMHCpred / the netMHC tools). `mixmhcpred_path` forwards PRIME's `-mix`.
- **No new kinds or infra** — `Kind.immunogenicity`, its `best_direction`, the `PeptideResult.immunogenicity` accessor, and the annotate `immunogenicity` token all already exist. Just registered `prime` and exported the class.

## How the parsing works

PRIME's output has a `#`-comment header, then per-allele column **triples** (`%Rank`, `Score`, `%RankBinding`) in the order the alleles were passed. PRIME rewrites allele names into its own short form in the headers (`A0201`), so `parse_prime_results` maps triples to alleles **by position** (with a count check) and carries the caller's normalized allele identity through to each prediction. Only PRIME's own immunogenicity signal is surfaced; the embedded MixMHCpred `%RankBinding` column is ignored (use the `MixMHCpred` wrapper for that).

## Tests & CI

- Binary-free parser tests (shape, value/position mapping, allele-identity, count-mismatch, kind_support) — added to the **public CI subset**, run on all Python versions.
- End-to-end tests gated on `PRIME_EXECUTABLE` + MixMHCpred (skip cleanly otherwise, so `integration-netmhc` stays green). **Verified locally against PRIME 2.1** — emitted scores/ranks match PRIME's raw output exactly, and `annotate_table` best-allele selection works.

## On accuracy (README caveat)

Every current CD8 immunogenicity predictor — PRIME and BigMHC_IM included — ranks well in the characterized regime but generalizes poorly to truly novel neoepitopes (independent benchmarks put the field near AUC 0.5–0.65). The README states this so users treat the scores as a prioritization aid, not ground truth.

Version `3.22.0 → 3.23.0`.

https://claude.ai/code/session_01LZahFhBSCiehXTESCYQ7wG
