### PR TITLE
Keep exotic alleles in the CLI; suppress TFLite's XNNPACK log line

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,6 +58,7 @@ jobs:
             tests/test_pepsickle.py \
             tests/test_bigmhc.py \
             tests/test_unparseable_alleles.py \
+            tests/test_nettcr.py \
             tests/test_tulip.py \
             tests/test_random.py
 

--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -81,7 +81,7 @@ def __getattr__(name):
     raise AttributeError(
         "module %r has no attribute %r" % (__name__, name))
 
-__version__ = "3.23.0"
+__version__ = "3.23.1"
 
 __all__ = [
     "Prediction",

--- a/mhctools/cli/args.py
+++ b/mhctools/cli/args.py
@@ -21,7 +21,7 @@ from argparse import ArgumentParser
 import inspect
 import logging
 
-from ..allele_normalization import normalize_allele_name
+from ..allele_normalization import normalize_allele_name_or_raw
 
 from .parsing_helpers import parse_int_list
 # Heavy predictors (BigMHC, MHCflurry) are NOT imported here: pulling them in
@@ -256,8 +256,11 @@ def make_mhc_arg_parser(**kwargs):
     return parser
 
 def mhc_alleles_from_args(args):
+    # normalize_allele_name_or_raw keeps exotic / non-human alleles that
+    # mhcgnomes can't parse (e.g. BoLA-amani.1, H-2-Qa1) instead of raising,
+    # matching the commandline predictors' keep-unparseable behavior (#220).
     alleles = [
-        normalize_allele_name(allele.strip())
+        normalize_allele_name_or_raw(allele.strip())
         for comma_group in args.mhc_alleles.split(",")
         for allele in comma_group.split(" ")
         if allele.strip()
@@ -267,7 +270,7 @@ def mhc_alleles_from_args(args):
             for line in f:
                 line = line.strip()
                 if line:
-                    alleles.append(normalize_allele_name(line))
+                    alleles.append(normalize_allele_name_or_raw(line))
     if len(alleles) == 0:
         raise ValueError(
             "MHC alleles required (use --mhc-alleles or --mhc-alleles-file)")

--- a/mhctools/nettcr.py
+++ b/mhctools/nettcr.py
@@ -55,6 +55,11 @@ def _suppress_native_stderr():
     ``os.devnull`` so that chatter is dropped; Python-level exceptions still
     propagate normally (only native writes to stderr are hidden). Restores the
     original fd afterward, so ordinary stderr keeps working.
+
+    Note: fd 2 is process-global, so for the (brief) duration of the block a
+    concurrent thread's stderr and any non-fatal native warning are also
+    dropped. It wraps only interpreter setup (construction / allocation), never
+    the prediction loop, so the window is small.
     """
     sys.stderr.flush()
     saved_fd = os.dup(2)
@@ -118,25 +123,37 @@ def _load_interpreter(model_path):
 
     Prefers the lightweight LiteRT/tflite runtimes, falling back to the
     ``tensorflow.lite`` interpreter. All expose the same interface.
+
+    Construction is wrapped in :func:`_suppress_native_stderr` as well as
+    ``allocate_tensors`` because different runtimes apply (and log) the XNNPACK
+    delegate at different points — ``tensorflow`` does it in
+    ``allocate_tensors`` (verified), while the LiteRT runtimes may do it at
+    construction. The import itself stays outside the suppression so a genuine
+    ImportError still surfaces normally.
     """
     try:
         from ai_edge_litert.interpreter import Interpreter
-        return Interpreter(model_path=model_path)
     except ImportError:
         pass
+    else:
+        with _suppress_native_stderr():
+            return Interpreter(model_path=model_path)
     try:
         from tflite_runtime.interpreter import Interpreter
-        return Interpreter(model_path=model_path)
     except ImportError:
         pass
+    else:
+        with _suppress_native_stderr():
+            return Interpreter(model_path=model_path)
     try:
         import tensorflow as tf
-        return tf.lite.Interpreter(model_path=model_path)
     except ImportError as e:
         raise ImportError(
             "NetTCR needs a TFLite runtime. Install one of: "
             "`ai-edge-litert` (recommended, lightweight), `tflite-runtime`, "
             "or `tensorflow`.") from e
+    with _suppress_native_stderr():
+        return tf.lite.Interpreter(model_path=model_path)
 
 
 def _find_nettcr_dir(nettcr_path=None):

--- a/mhctools/nettcr.py
+++ b/mhctools/nettcr.py
@@ -33,14 +33,39 @@ pan cross-validation ensemble, matching the published usage.
 
 from __future__ import annotations
 
+import contextlib
 import glob
 import os
+import sys
 
 import numpy as np
 import pandas as pd
 
 from .pred import COLUMNS, Kind, PeptideResult, Prediction
 from .tcr import TCR
+
+
+@contextlib.contextmanager
+def _suppress_native_stderr():
+    """Silence C-level stderr for the duration of the block.
+
+    The TFLite runtimes print ``INFO: Created TensorFlow Lite XNNPACK delegate
+    for CPU.`` from native code straight to file descriptor 2 (during
+    ``allocate_tensors``), bypassing Python's ``logging``. Redirect fd 2 to
+    ``os.devnull`` so that chatter is dropped; Python-level exceptions still
+    propagate normally (only native writes to stderr are hidden). Restores the
+    original fd afterward, so ordinary stderr keeps working.
+    """
+    sys.stderr.flush()
+    saved_fd = os.dup(2)
+    devnull_fd = os.open(os.devnull, os.O_WRONLY)
+    try:
+        os.dup2(devnull_fd, 2)
+        yield
+    finally:
+        os.dup2(saved_fd, 2)
+        os.close(devnull_fd)
+        os.close(saved_fd)
 
 
 # BLOSUM50, restricted to the 20 standard amino acids, in NetTCR's column
@@ -284,7 +309,11 @@ class NetTCR(object):
                         det["index"], [n, det["shape"][1], det["shape"][2]])
                 interpreter.resize_tensor_input(
                     output["index"], [n, output["shape"][1]])
-                interpreter.allocate_tensors()
+                # allocate_tensors() is where the TFLite runtime prints its
+                # one-time "Created ... XNNPACK delegate for CPU." INFO line to
+                # native stderr; keep that out of callers' output.
+                with _suppress_native_stderr():
+                    interpreter.allocate_tensors()
             for det in inputs:
                 # NetTCR names inputs "serving_default_<feature>:0"; match by
                 # the trailing feature token rather than by tensor order.

--- a/tests/test_nettcr.py
+++ b/tests/test_nettcr.py
@@ -16,7 +16,12 @@ import numpy as np
 import pytest
 
 from mhctools import TCR
-from mhctools.nettcr import NetTCR, _BLOSUM50, _encode_feature
+from mhctools.nettcr import (
+    NetTCR,
+    _BLOSUM50,
+    _encode_feature,
+    _suppress_native_stderr,
+)
 from mhctools.pred import COLUMNS, Kind
 
 
@@ -24,6 +29,25 @@ from mhctools.pred import COLUMNS, Kind
 # Encoding unit tests — no NetTCR install or TFLite runtime required.
 # These pin the exact encoding reproduced from NetTCR-2.2 src/predict.py.
 # ---------------------------------------------------------------------------
+
+def test_suppress_native_stderr_hides_fd2_writes_and_restores(capfd):
+    # Emulate a native library writing to fd 2 (like TFLite's XNNPACK line):
+    # writes inside the block are dropped, and stderr works again afterward.
+    with _suppress_native_stderr():
+        os.write(2, b"NATIVE-XNNPACK-NOISE\n")
+    os.write(2, b"real-stderr-after\n")
+    err = capfd.readouterr().err
+    assert "NATIVE-XNNPACK-NOISE" not in err
+    assert "real-stderr-after" in err
+
+
+def test_suppress_native_stderr_restores_on_exception():
+    # fd 2 must be restored even if the body raises.
+    with pytest.raises(ValueError):
+        with _suppress_native_stderr():
+            raise ValueError("boom")
+    os.write(2, b"still-works\n")  # would raise if fd 2 were left closed
+
 
 def test_encode_shape():
     arr = _encode_feature(["SIINFEKL"], "pep")

--- a/tests/test_nettcr.py
+++ b/tests/test_nettcr.py
@@ -41,12 +41,13 @@ def test_suppress_native_stderr_hides_fd2_writes_and_restores(capfd):
     assert "real-stderr-after" in err
 
 
-def test_suppress_native_stderr_restores_on_exception():
+def test_suppress_native_stderr_restores_on_exception(capfd):
     # fd 2 must be restored even if the body raises.
     with pytest.raises(ValueError):
         with _suppress_native_stderr():
             raise ValueError("boom")
     os.write(2, b"still-works\n")  # would raise if fd 2 were left closed
+    assert "still-works" in capfd.readouterr().err
 
 
 def test_encode_shape():

--- a/tests/test_unparseable_alleles.py
+++ b/tests/test_unparseable_alleles.py
@@ -107,6 +107,21 @@ def test_check_hla_alleles_dedupes_star_variants_of_unparseable():
 
 
 # ---------------------------------------------------------------------------
+# CLI --mhc-alleles must keep exotic alleles too, not crash on them (#220).
+# ---------------------------------------------------------------------------
+
+def test_cli_mhc_alleles_keep_exotic():
+    from mhctools.cli.args import make_mhc_arg_parser, mhc_alleles_from_args
+    args = make_mhc_arg_parser().parse_args([
+        "--mhc-predictor", "netmhcpan",
+        "--mhc-alleles", "BoLA-amani.1,HLA-A*02:01 H-2-Qa1"])
+    # Parseable allele is canonicalized; exotic ones are kept verbatim rather
+    # than raising an AlleleParseError at the CLI layer.
+    assert mhc_alleles_from_args(args) == [
+        "BoLA-amani.1", "HLA-A*02:01", "H-2-Qa1"]
+
+
+# ---------------------------------------------------------------------------
 # Output parser falls back to the raw name instead of raising (binary-free).
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Two log-noise / robustness fixes surfaced in use.

## 1. CLI crashed on exotic alleles (real bug)

`cli/args.mhc_alleles_from_args` still used the **raising** `normalize_allele_name`, so `--mhc-alleles BoLA-amani.1` (or `H-2-Qa1`, `Mamu-B12…`) died with an `AlleleParseError` at the CLI layer. The #220 keep-unparseable fix had reached the predictor internals (`keep_unparseable_alleles`) and the parsers, but **not** the CLI allele-collection helper. Switched to `normalize_allele_name_or_raw`, so exotic / non-human alleles are kept verbatim while parseable ones are still canonicalized:

```
--mhc-alleles "BoLA-amani.1,HLA-A*02:01 H-2-Qa1"
→ ['BoLA-amani.1', 'HLA-A*02:01', 'H-2-Qa1']   # was: crash
```

## 2. TFLite XNNPACK INFO line (log noise)

NetTCR's TFLite runtime prints `INFO: Created TensorFlow Lite XNNPACK delegate for CPU.` from **native code straight to fd 2** (bypassing Python's `logging`), during `allocate_tensors()`. Added a `_suppress_native_stderr()` context manager (redirects fd 2 to `/dev/null`, restores afterward, lets exceptions propagate) and wrapped the `allocate_tensors()` call — empirically confirmed to be the emission point (not interpreter construction), reproduced and verified with a minimal `tf.lite` model.

## Tests
- CLI keeps a mix of exotic + normal alleles (`test_unparseable_alleles.py`).
- The suppression helper hides fd-2 writes and restores stderr, including on exception (`test_nettcr.py`). Both files are in the public CI subset.

## Note on the "Skipping allele …: Could not parse …" spam
That per-allele line is a **stale mhctools 3.15.0** sitting in site-packages (its old `logger.info`); current code (3.19.0+) logs a single `logger.debug` aggregate instead. It's an environment issue (a non-editable old copy shadowing the current one), not current-code behavior — reinstalling mhctools clears it. This PR fixes the *separate* real gap (the CLI crash) and the TFLite line.

Version `3.23.0 → 3.23.1`.

https://claude.ai/code/session_01LZahFhBSCiehXTESCYQ7wG