### PR TITLE
Add MixMHC2pred class-II presentation predictor (#237)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,6 +54,7 @@ jobs:
             tests/test_pred.py \
             tests/test_annotate_table.py \
             tests/test_prime.py \
+            tests/test_mixmhc2pred2.py \
             tests/test_processing_predictor.py \
             tests/test_pepsickle.py \
             tests/test_bigmhc.py \

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Examples:
 | `NetMHCpan41` | `pMHC_affinity` | `single_allele` | `I` |
 | `NetMHCpan41` | `pMHC_presentation` | `single_allele` | `I` |
 | `NetMHCIIpan4_EL` | `pMHC_presentation` | `single_allele` | `II` |
+| `MixMHC2pred` | `pMHC_presentation` | `single_allele` | `II` |
 | `NetMHCstabpan` | `pMHC_stability` | `single_allele` | `I` |
 | `MHCflurry` | `pMHC_affinity` | `single_allele` | `I` |
 | `MHCflurry` haplotype mode | `pMHC_presentation` | `haplotype` | `I` |
@@ -291,9 +292,31 @@ affinity, hours for stability). `percentile_rank` is always optional,
 | `MHCflurry` | affinity + presentation + processing | `pip install mhcflurry` + `mhcflurry-downloads fetch` |
 | `MHCflurry_Affinity` | affinity | `pip install mhcflurry` + `mhcflurry-downloads fetch` |
 | `BigMHC` | presentation or immunogenicity | [BigMHC](https://github.com/KarchinLab/bigmhc) clone (set `BIGMHC_DIR`) |
-| `MixMHCpred` | presentation | [MixMHCpred](https://github.com/GfellerLab/MixMHCpred) |
+| `MixMHCpred` | presentation (class I) | [MixMHCpred](https://github.com/GfellerLab/MixMHCpred) |
+| `MixMHC2pred` | presentation (class II) | [MixMHC2pred](https://github.com/GfellerLab/MixMHC2pred) release (has `PWMdef/`) |
 | `IedbNetMHCpan` / `IedbSMM` / `IedbNetMHCIIpan` | affinity | IEDB web API |
 | `RandomBindingPredictor` | affinity | (built-in) |
+
+`MixMHC2pred` is a pan-allele **class-II** presentation predictor and a strong
+complement to `NetMHCIIpan` (independently co-best in the Frontiers in
+Immunology 2024 class-II benchmark). It emits one `pMHC_presentation`
+prediction per (peptide, allele): `score` is the raw MixMHC2pred score (higher
+= better), `percentile_rank` is its %Rank (lower = better). It's academic /
+non-commercial licensed, so mhctools shells out to a user-provided install
+(download a **release**, not a bare clone — the release ships the `PWMdef/`
+allele definitions). Alleles may be given in the usual spellings
+(`HLA-DRB1*15:01`) or MixMHC2pred's own (`DRB1_15_01`,
+`DQA1_01_02__DQB1_06_02`).
+
+```python
+from mhctools import MixMHC2pred
+
+predictor = MixMHC2pred(
+    alleles=["HLA-DRB1*15:01", "HLA-DQA1*01:02-DQB1*06:02"],
+    program_name="/path/to/MixMHC2pred_unix")   # MixMHC2pred on macOS
+results = predictor.predict(["GELIGTLNAAKVPAD"])   # class-II length peptides
+results[0].presentation.score
+```
 
 ### Antigen processing
 

--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -24,6 +24,7 @@ from .iedb import (
     IedbNetMHCIIpan,
 )
 from .mixmhcpred import MixMHCpred
+from .mixmhc2pred import MixMHC2pred
 from .prime import PRIME
 from .processing_predictor import (
     ProcessingPredictor,
@@ -81,7 +82,7 @@ def __getattr__(name):
     raise AttributeError(
         "module %r has no attribute %r" % (__name__, name))
 
-__version__ = "3.23.1"
+__version__ = "3.24.0"
 
 __all__ = [
     "Prediction",
@@ -108,6 +109,7 @@ __all__ = [
     "IedbSMM_PMBEC",
     "IedbNetMHCIIpan",
     "MixMHCpred",
+    "MixMHC2pred",
     "PRIME",
     "MHCflurry",
     "MHCflurry_Affinity",

--- a/mhctools/cli/args.py
+++ b/mhctools/cli/args.py
@@ -62,6 +62,7 @@ from .. import (
     IedbSMM_PMBEC,
     IedbNetMHCIIpan,
     MixMHCpred,
+    MixMHC2pred,
     PRIME,
 )
 
@@ -166,6 +167,7 @@ mhc_predictors = {
     "mhcflurry": _MHCflurry,
     "mhcflurry-affinity": _MHCflurry_Affinity,
     "mixmhcpred": MixMHCpred,
+    "mixmhc2pred": MixMHC2pred,
     "prime": PRIME,
 }
 

--- a/mhctools/mixmhc2pred.py
+++ b/mhctools/mixmhc2pred.py
@@ -1,0 +1,238 @@
+# Copyright (c) 2016. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Wrapper for MixMHC2pred — pan-allele MHC class-II presentation (Gfeller lab).
+
+MixMHC2pred predicts MHC class-II ligands / eluted-ligand likelihood. This
+wrapper shells out to a user-provided MixMHC2pred install (it is academic /
+non-commercial licensed, so mhctools does not vendor it) and emits one
+``Kind.pMHC_presentation`` prediction per (peptide, allele), with ``score`` =
+MixMHC2pred's raw presentation score (higher = better) and ``percentile_rank``
+= its %Rank (lower = better).
+
+Class-II alleles use MixMHC2pred's own nomenclature (``HLA-`` dropped, ``_``
+separators, paired α/β chains joined by ``__``): e.g. ``DRB1_15_01``,
+``DQA1_01_02__DQB1_06_02``. :func:`to_mixmhc2pred_allele` maps the usual
+spellings (``HLA-DRB1*15:01``, the mhcgnomes-canonical
+``HLA-DRA1*01:01-DRB1*15:01``, or the native ``DRB1_15_01``) onto that form.
+
+Upstream: https://github.com/GfellerLab/MixMHC2pred
+Cite: Racle et al., *Nat. Biotechnol.* 2019; Racle et al., bioRxiv 2022.
+"""
+
+from os import remove
+from os.path import exists, join
+from tempfile import NamedTemporaryFile, mkdtemp
+
+import pandas as pd
+
+from .base_predictor import BasePredictor, _check_flank_inputs
+from .cleanup_context import CleanupFiles
+from .pred import COLUMNS, Kind, PeptideResult, Prediction
+from .process_helpers import run_command
+
+
+def to_mixmhc2pred_allele(allele):
+    """Convert a class-II allele name to MixMHC2pred's nomenclature.
+
+    Handles ``HLA-DRB1*15:01``, the mhcgnomes-canonical
+    ``HLA-DRA1*01:01-DRB1*15:01`` (the explicit DRA1 α-chain is dropped —
+    MixMHC2pred names DR alleles by their DRB chain only), paired DP/DQ chains,
+    and names already in MixMHC2pred form. Examples::
+
+        HLA-DRB1*15:01              -> DRB1_15_01
+        HLA-DRA1*01:01-DRB1*15:01   -> DRB1_15_01
+        HLA-DQA1*01:02-DQB1*06:02   -> DQA1_01_02__DQB1_06_02
+        DRB1_15_01                  -> DRB1_15_01
+    """
+    text = str(allele).strip()
+    if text.upper().startswith("HLA-"):
+        text = text[4:]
+    # mhcgnomes joins paired α/β chains with '-'; users may use '/'.
+    text = text.replace("/", "-")
+    chains = [
+        chain.replace("*", "_").replace(":", "_")
+        for chain in text.split("-") if chain
+    ]
+    # The DRA1 α-chain is implicit in MixMHC2pred's DR naming.
+    chains = [chain for chain in chains if not chain.upper().startswith("DRA")]
+    return "__".join(chains)
+
+
+class MixMHC2pred(BasePredictor):
+    """Wrapper for the MixMHC2pred class-II presentation predictor.
+
+    Parameters
+    ----------
+    alleles : list of str
+        Class-II alleles (any spelling :func:`to_mixmhc2pred_allele` accepts).
+    default_peptide_lengths : list of int
+    program_name : str
+        MixMHC2pred executable (name on ``PATH`` or an absolute path — use
+        ``MixMHC2pred_unix`` on Linux, ``MixMHC2pred`` on macOS). The allele
+        definition folder (``PWMdef``) is resolved relative to the executable.
+    """
+
+    mhc_class = "II"
+
+    def __init__(
+            self,
+            alleles,
+            default_peptide_lengths=[15],
+            program_name="MixMHC2pred"):
+        BasePredictor.__init__(
+            self,
+            alleles=alleles,
+            default_peptide_lengths=default_peptide_lengths,
+            min_peptide_length=9,
+            max_peptide_length=25,
+            allow_X_in_peptides=False,
+            allow_lowercase_in_peptides=False,
+            # Keep MixMHC2pred-native names (DRB1_15_01, ...) verbatim; HLA
+            # spellings are still canonicalized. to_mixmhc2pred_allele maps
+            # either onto the CLI form.
+            keep_unparseable_alleles=True)
+        self.program_name = program_name
+
+    def predict(self, peptides, n_flanks=None, c_flanks=None):
+        """Predict class-II presentation for a list of peptides.
+
+        Flanks are accepted for a uniform API but ignored (this wrapper runs
+        MixMHC2pred in ``--no_context`` mode).
+
+        Returns
+        -------
+        list of PeptideResult
+            One entry per input peptide; each holds one
+            ``Kind.pMHC_presentation`` prediction per allele.
+        """
+        peptide_list, _, _ = _check_flank_inputs(peptides, n_flanks, c_flanks)
+        self._check_peptide_inputs(peptide_list)
+        if not peptide_list:
+            return []
+
+        alleles = list(self.alleles)
+        cli_names = [to_mixmhc2pred_allele(a) for a in alleles]
+
+        temp_dir = mkdtemp(prefix="mhctools", suffix="mixmhc2pred")
+        input_file_path = join(temp_dir, "mixmhc2pred_input.txt")
+        output_file_path = join(temp_dir, "mixmhc2pred_output.txt")
+        with open(input_file_path, "w") as f:
+            f.write("\n".join(peptide_list) + "\n")
+
+        args = [
+            self.program_name,
+            "-i", input_file_path,
+            "-o", output_file_path,
+            "-a", *cli_names,
+            "--no_context",
+            "--extra_out",
+        ]
+
+        with CleanupFiles(
+                filenames=[input_file_path, output_file_path],
+                directories=[temp_dir]):
+            with NamedTemporaryFile(
+                    prefix="MixMHC2pred_stdout", mode="w",
+                    delete=False) as stdout_file:
+                stdout_file_name = stdout_file.name
+                run_command(
+                    args,
+                    suppress_stderr=False,
+                    redirect_stdout_file=stdout_file)
+            if exists(output_file_path):
+                preds_by_peptide = parse_mixmhc2pred_results(
+                    output_file_path, alleles, cli_names)
+            else:
+                with open(stdout_file_name) as f:
+                    stdout = f.read().strip()
+                raise ValueError(
+                    "MixMHC2pred produced no output for alleles %s; stdout: %s"
+                    % (cli_names, stdout))
+            remove(stdout_file_name)
+
+        return [
+            PeptideResult(preds=tuple(preds_by_peptide.get(peptide, ())))
+            for peptide in peptide_list
+        ]
+
+    def predict_dataframe(self, peptides, sample_name=""):
+        """``predict()`` flattened to a DataFrame."""
+        dfs = [pp.to_dataframe(sample_name) for pp in self.predict(peptides)]
+        if not dfs:
+            return pd.DataFrame(columns=COLUMNS)
+        return pd.concat(dfs, ignore_index=True)
+
+    def _default_pred_kind(self):
+        return Kind.pMHC_presentation
+
+    def kind_support(self):
+        return {
+            Kind.pMHC_presentation: {
+                "mhc_dependence": "single_allele",
+                "mhc_class": "II",
+            },
+        }
+
+
+def parse_mixmhc2pred_results(filename, alleles, cli_names):
+    """Parse a MixMHC2pred (``--extra_out``) output into ``{peptide: [preds]}``.
+
+    MixMHC2pred's output has a ``#``-comment header, then columns including,
+    per allele ``M`` (its MixMHC2pred name), ``%Rank_M`` and ``Score_M``. We
+    look those up by name and attach the caller's original allele identity.
+
+    Parameters
+    ----------
+    filename : str
+    alleles : list of str
+        The original allele identities (carried through to the predictions).
+    cli_names : list of str
+        The MixMHC2pred names passed for each allele, in the same order — the
+        column-header suffixes to read.
+
+    Returns
+    -------
+    dict mapping peptide -> list of Prediction (one per allele)
+    """
+    df = pd.read_csv(filename, comment="#", sep="\t")
+    if "Peptide" not in df.columns:
+        raise ValueError("Unexpected MixMHC2pred output columns: %s"
+                         % list(df.columns))
+    for cli_name in cli_names:
+        for prefix in ("%Rank_", "Score_"):
+            column = prefix + cli_name
+            if column not in df.columns:
+                raise ValueError(
+                    "MixMHC2pred output missing column %r (columns: %s)"
+                    % (column, list(df.columns)))
+
+    results = {}
+    for row in df.itertuples(index=False):
+        peptide = getattr(row, "Peptide")
+        preds = []
+        for allele, cli_name in zip(alleles, cli_names):
+            # itertuples mangles '%Rank_...' names, so index by position via
+            # the column list captured from df.columns.
+            rank = float(row[df.columns.get_loc("%Rank_" + cli_name)])
+            score = float(row[df.columns.get_loc("Score_" + cli_name)])
+            preds.append(Prediction(
+                kind=Kind.pMHC_presentation,
+                score=score,
+                peptide=peptide,
+                allele=allele,
+                percentile_rank=rank,
+                predictor_name="mixmhc2pred"))
+        results[peptide] = preds
+    return results

--- a/tests/test_mixmhc2pred2.py
+++ b/tests/test_mixmhc2pred2.py
@@ -1,0 +1,161 @@
+# Copyright (c) 2016. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the MixMHC2pred class-II presentation wrapper.
+
+Parser and allele-mapping tests are binary-free. The end-to-end tests run only
+when a MixMHC2pred executable is available (``MIXMHC2PRED_EXECUTABLE`` env var
+or ``MixMHC2pred`` / ``MixMHC2pred_unix`` on ``PATH``).
+"""
+
+import os
+import shutil
+from tempfile import NamedTemporaryFile
+
+import pytest
+
+from mhctools import MixMHC2pred
+from mhctools.mixmhc2pred import parse_mixmhc2pred_results, to_mixmhc2pred_allele
+from mhctools.pred import Kind
+
+
+# Captured MixMHC2pred (v2.0.2, --extra_out) output for two alleles. Note the
+# columns are NOT grouped per allele: every allele's %Rank/CoreP1/SubSpec come
+# first, then every allele's Score/%RankPWM/ScorePWM — which is why the parser
+# must look columns up by name, not by position.
+_MM2_OUTPUT = (
+    "####################\n"
+    "# Output from MixMHC2pred (v2.0.2)\n"
+    "# Alleles: DRB1_15_01, DQA1_01_02__DQB1_06_02\n"
+    "####################\n"
+    "Peptide\tContext\tBestAllele\t%Rank_best\tCore_best\tCoreP1_best\t"
+    "SubSpec_best\t%Rank_DRB1_15_01\tCoreP1_DRB1_15_01\tSubSpec_DRB1_15_01\t"
+    "%Rank_DQA1_01_02__DQB1_06_02\tCoreP1_DQA1_01_02__DQB1_06_02\t"
+    "SubSpec_DQA1_01_02__DQB1_06_02\tScore_DRB1_15_01\t%RankPWM_DRB1_15_01\t"
+    "ScorePWM_DRB1_15_01\tScore_DQA1_01_02__DQB1_06_02\t"
+    "%RankPWM_DQA1_01_02__DQB1_06_02\tScorePWM_DQA1_01_02__DQB1_06_02\n"
+    "PKYVKQNTLKLAT\t\tDQA1_01_02__DQB1_06_02\t11.3\tVKQNTLKLA\t4\t1\t74.9\t4\t1\t"
+    "11.3\t4\t1\t0.0791\t43.8\t0.00912\t0.218\t6.45\t2.26\n"
+    "GELIGTLNAAKVPAD\t\tDRB1_15_01\t2.52\tIGTLNAAKV\t4\t1\t2.52\t4\t1\t"
+    "18.2\t7\t1\t0.408\t3.07\t3.25\t0.166\t10.6\t0.895\n"
+)
+
+
+def _write_output():
+    f = NamedTemporaryFile("w", suffix="_mm2.txt", delete=False)
+    f.write(_MM2_OUTPUT)
+    f.close()
+    return f.name
+
+
+# --- allele nomenclature mapping --------------------------------------------
+
+@pytest.mark.parametrize("allele,expected", [
+    ("HLA-DRB1*15:01", "DRB1_15_01"),
+    ("HLA-DRA1*01:01-DRB1*15:01", "DRB1_15_01"),   # mhcgnomes-canonical
+    ("DRB1_15_01", "DRB1_15_01"),
+    ("HLA-DQA1*01:02-DQB1*06:02", "DQA1_01_02__DQB1_06_02"),
+    ("DQA1_01_02__DQB1_06_02", "DQA1_01_02__DQB1_06_02"),
+    ("DPA1_02_01__DPB1_01_01", "DPA1_02_01__DPB1_01_01"),
+])
+def test_to_mixmhc2pred_allele(allele, expected):
+    assert to_mixmhc2pred_allele(allele) == expected
+
+
+# --- parser (binary-free) ---------------------------------------------------
+
+def test_parse_mixmhc2pred_shape():
+    alleles = ["HLA-DRA1*01:01-DRB1*15:01", "HLA-DQA1*01:02-DQB1*06:02"]
+    cli_names = ["DRB1_15_01", "DQA1_01_02__DQB1_06_02"]
+    path = _write_output()
+    try:
+        by_peptide = parse_mixmhc2pred_results(path, alleles, cli_names)
+    finally:
+        os.remove(path)
+
+    assert set(by_peptide) == {"PKYVKQNTLKLAT", "GELIGTLNAAKVPAD"}
+    for peptide, preds in by_peptide.items():
+        assert len(preds) == 2
+        assert {p.allele for p in preds} == set(alleles)
+        for p in preds:
+            assert p.kind == Kind.pMHC_presentation
+            assert p.predictor_name == "mixmhc2pred"
+
+
+def test_parse_mixmhc2pred_values_by_name_not_position():
+    # DRB1_15_01 columns come before DQA... for %Rank but the Score_* block is
+    # ordered separately; name-based lookup must still pair them correctly.
+    alleles = ["HLA-DRA1*01:01-DRB1*15:01", "HLA-DQA1*01:02-DQB1*06:02"]
+    cli_names = ["DRB1_15_01", "DQA1_01_02__DQB1_06_02"]
+    path = _write_output()
+    try:
+        by_peptide = parse_mixmhc2pred_results(path, alleles, cli_names)
+    finally:
+        os.remove(path)
+
+    by_allele = {p.allele: p for p in by_peptide["PKYVKQNTLKLAT"]}
+    drb = by_allele["HLA-DRA1*01:01-DRB1*15:01"]
+    dq = by_allele["HLA-DQA1*01:02-DQB1*06:02"]
+    assert drb.score == 0.0791 and drb.percentile_rank == 74.9
+    assert dq.score == 0.218 and dq.percentile_rank == 11.3
+
+
+def test_parse_mixmhc2pred_missing_column_raises():
+    path = _write_output()
+    try:
+        with pytest.raises(ValueError, match="missing column"):
+            parse_mixmhc2pred_results(path, ["A_1"], ["NOT_A_REAL_ALLELE"])
+    finally:
+        os.remove(path)
+
+
+def test_mixmhc2pred_default_kind_and_support():
+    predictor = MixMHC2pred(alleles=["DRB1_15_01"], program_name="MixMHC2pred")
+    assert predictor._default_pred_kind() == Kind.pMHC_presentation
+    assert predictor.mhc_class == "II"
+    support = predictor.kind_support()[Kind.pMHC_presentation]
+    assert support["mhc_dependence"] == "single_allele"
+    assert support["mhc_class"] == "II"
+
+
+# --- end-to-end (requires a MixMHC2pred install) ----------------------------
+
+MIXMHC2PRED = (
+    os.environ.get("MIXMHC2PRED_EXECUTABLE")
+    or shutil.which("MixMHC2pred_unix")
+    or shutil.which("MixMHC2pred"))
+
+requires_mixmhc2pred = pytest.mark.skipif(
+    not MIXMHC2PRED,
+    reason="MixMHC2pred not installed (set MIXMHC2PRED_EXECUTABLE or put "
+           "MixMHC2pred / MixMHC2pred_unix on PATH)")
+
+
+@requires_mixmhc2pred
+def test_mixmhc2pred_end_to_end():
+    predictor = MixMHC2pred(
+        alleles=["DRB1_15_01", "HLA-DQA1*01:02-DQB1*06:02"],
+        program_name=MIXMHC2PRED)
+    peptides = ["PKYVKQNTLKLAT", "GELIGTLNAAKVPAD"]
+    results = predictor.predict(peptides)
+
+    assert len(results) == len(peptides)
+    for result, peptide in zip(results, peptides):
+        assert result.peptide == peptide
+        assert len(result.preds) == 2
+        for pred in result.preds:
+            assert pred.kind == Kind.pMHC_presentation
+            assert pred.score is not None
+            assert pred.percentile_rank is not None
+        assert result.presentation is not None


### PR DESCRIPTION
Closes #237. Second of the series (PRIME ✅ → **MixMHC2pred** → DeepTAP).

Wraps [MixMHC2pred](https://github.com/GfellerLab/MixMHC2pred), a pan-allele **MHC class-II** presentation predictor and a strong complement to `NetMHCIIpan` — independently **co-best with NetMHCIIpan-4.1** in the neutral Frontiers in Immunology 2024 class-II benchmark. Class-II presentation was thin in mhctools (NetMHCIIpan only).

## What it does

`MixMHC2pred(alleles=..., program_name=...)` shells out to a user-provided install and emits **one `Kind.pMHC_presentation` prediction per (peptide, allele)**:

```python
from mhctools import MixMHC2pred

predictor = MixMHC2pred(
    alleles=["HLA-DRB1*15:01", "HLA-DQA1*01:02-DQB1*06:02"],
    program_name="/path/to/MixMHC2pred_unix")
r = predictor.predict(["GELIGTLNAAKVPAD"])[0]
r.presentation.score          # raw MixMHC2pred score, higher = better
r.preds[0].percentile_rank    # %Rank, lower = better
```

- **New data model** (`predict()` / `predict_dataframe()`), so it composes with `mhctools predict-table` via the existing `presentation` token: `--predictor mixmhc2pred:mm2:presentation`.
- Academic / non-commercial license → wrap, don't vendor (like MixMHCpred / PRIME). Download a **release** (ships `PWMdef/` allele definitions), not a bare clone.
- **No new kinds/infra** — `Kind.pMHC_presentation`, its `best_direction`, the `PeptideResult.presentation` accessor, and the annotate token all already exist. Just registered `mixmhc2pred` and exported it.

## The two tricky bits (and how they're handled)

- **Class-II allele nomenclature.** MixMHC2pred uses `DRB1_15_01` / `DQA1_01_02__DQB1_06_02`, while mhcgnomes canonicalizes `HLA-DRB1*15:01` into `HLA-DRA1*01:01-DRB1*15:01` (adds the DRA1 α-chain). `to_mixmhc2pred_allele()` maps all three spellings onto MixMHC2pred's CLI form (dropping the implicit DRA1), and `keep_unparseable_alleles=True` lets native names survive normalization. The caller's original allele identity is carried through to each prediction.
- **Non-contiguous output columns.** With `--extra_out` (needed for the raw `Score`), MixMHC2pred emits *all* alleles' `%Rank_*` columns first, then *all* their `Score_*` columns — so the parser looks columns up **by name** (`%Rank_<M>`, `Score_<M>`), not by position. There's a test that pins exactly this.

## Tests & CI

- Binary-free: allele-mapping (`to_mixmhc2pred_allele`) across all spellings, and a parser test over a **captured `--extra_out` fixture** including the by-name-not-position guard and a missing-column error. Added to the public CI subset.
- End-to-end tests gated on `MIXMHC2PRED_EXECUTABLE` (skip cleanly otherwise). **Verified locally against MixMHC2pred 2.0.2** — scores/ranks match its raw output exactly, and `annotate_table` best-allele selection works.

Version `3.23.1 → 3.24.0`.

https://claude.ai/code/session_01LZahFhBSCiehXTESCYQ7wG