### PR TITLE
Add DeepTAP wrapper — TAP transport prediction (#236)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,6 +55,7 @@ jobs:
             tests/test_annotate_table.py \
             tests/test_prime.py \
             tests/test_mixmhc2pred2.py \
+            tests/test_deeptap.py \
             tests/test_processing_predictor.py \
             tests/test_pepsickle.py \
             tests/test_bigmhc.py \

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ The canonical prediction kind strings are defined in `mhctools.pred.Kind`.
 | `antigen_processing` | Combined processing score |
 | `proteasome_cleavage` | Proteasomal (MHC-I, cytosolic) C-terminal cleavage score |
 | `endolysosomal_cleavage` | Endolysosomal (MHC-II, cathepsin) C-terminal cleavage score |
-| `tap_transport` | TAP transport score (reserved, not yet used) |
+| `tap_transport` | TAP transport / binding score |
 | `erap_trimming` | ERAP trimming score (reserved, not yet used) |
 
 Predictors also expose `kind_support()` so downstream code can tell what MHC
@@ -209,6 +209,7 @@ Examples:
 | `Pepsickle` | `proteasome_cleavage` | `none` | `none` |
 | `NetCleave_I` | `proteasome_cleavage` | `none` | `I` |
 | `NetCleave_II` | `endolysosomal_cleavage` | `none` | `II` |
+| `DeepTAP` | `tap_transport` | `none` | `none` |
 | `NetTCR` | `pMHC_TCR_binding` | `none` | `I` |
 | `Tulip` | `pMHC_TCR_binding` | `single_allele` | `I` |
 | `BigMHC_IM` | `immunogenicity` | `single_allele` | `I` |
@@ -354,6 +355,39 @@ by_protein = predictor.predict_proteins({"TP53": "MEEPQ..."}, peptide_lengths=[1
 > ⚠️ NetCleave's own paper reports class-II C-terminal cleavage is a much
 > weaker signal than class I (AUC ~0.66 vs ~0.91). Treat
 > `endolysosomal_cleavage` scores accordingly.
+
+### TAP transport
+
+| Predictor | Kinds produced | Requires |
+|---|---|---|
+| `DeepTAP` | TAP transport (`tap_transport`) | [DeepTAP](https://github.com/zjupgx/DeepTAP) clone (set `DEEPTAP_HOME`) |
+
+TAP (transporter associated with antigen processing) is the step that shuttles
+cytosolic peptides into the ER for MHC-I loading — a distinct part of the
+processing pathway from proteasomal cleavage, and otherwise a gap in the
+predictor set. `DeepTAP` is a BiGRU that scores each peptide once
+(**allele-independent**, like the cleavage predictors), emitting one
+`tap_transport` prediction per peptide with an empty `allele`. `score` is in
+0-1 (higher = stronger TAP binding); in `task_type="reg"` mode the predicted
+affinity in nM is also surfaced as `value` (lower = stronger).
+
+DeepTAP ships its weights in-repo and is Apache-2.0, but pins an old
+`pytorch-lightning`, so mhctools shells out to DeepTAP's own CLI in a
+user-provided checkout, run by a user-provided interpreter (the checkpoints load
+fine under modern Lightning too). Set `DEEPTAP_HOME` to the clone and, if the
+current interpreter lacks torch, `DEEPTAP_PYTHON` to one that has it.
+
+```python
+from mhctools import DeepTAP
+
+predictor = DeepTAP(task_type="cla")       # resolves DEEPTAP_HOME / ~/DeepTAP
+results = predictor.predict(["SIINFEKL", "AEASAAAAY"])
+results[1].tap_transport.score             # 0-1, higher = stronger TAP binding
+```
+
+> ⚠️ DeepTAP's evaluation is self-reported, and no independent TAP benchmark
+> exists for any tool (true of the whole TAP field). Treat the score as a useful
+> pathway signal for prioritization, not a validated oracle.
 
 ### Immunogenicity
 

--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -26,6 +26,7 @@ from .iedb import (
 from .mixmhcpred import MixMHCpred
 from .mixmhc2pred import MixMHC2pred
 from .prime import PRIME
+from .deeptap import DeepTAP
 from .processing_predictor import (
     ProcessingPredictor,
     SCORING_MODES,
@@ -82,7 +83,7 @@ def __getattr__(name):
     raise AttributeError(
         "module %r has no attribute %r" % (__name__, name))
 
-__version__ = "3.24.0"
+__version__ = "3.25.0"
 
 __all__ = [
     "Prediction",
@@ -111,6 +112,7 @@ __all__ = [
     "MixMHCpred",
     "MixMHC2pred",
     "PRIME",
+    "DeepTAP",
     "MHCflurry",
     "MHCflurry_Affinity",
     "ProcessingPredictor",

--- a/mhctools/annotate.py
+++ b/mhctools/annotate.py
@@ -71,6 +71,7 @@ _OUTPUT_FIELDS = {
     "processing": (Kind.antigen_processing, "score"),
     "stability": (Kind.pMHC_stability, "value"),
     "immunogenicity": (Kind.immunogenicity, "score"),
+    "tap_transport": (Kind.tap_transport, "score"),
 }
 
 

--- a/mhctools/cli/args.py
+++ b/mhctools/cli/args.py
@@ -64,6 +64,7 @@ from .. import (
     MixMHCpred,
     MixMHC2pred,
     PRIME,
+    DeepTAP,
 )
 
 
@@ -169,6 +170,7 @@ mhc_predictors = {
     "mixmhcpred": MixMHCpred,
     "mixmhc2pred": MixMHC2pred,
     "prime": PRIME,
+    "deeptap": DeepTAP,
 }
 
 

--- a/mhctools/deeptap.py
+++ b/mhctools/deeptap.py
@@ -1,0 +1,273 @@
+# Copyright (c) 2016. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Wrapper for DeepTAP — a BiGRU predictor of TAP transport / binding.
+
+TAP (transporter associated with antigen processing) shuttles cytosolic
+peptides into the ER for MHC-I loading, and is a distinct step of the
+processing pathway from proteasomal cleavage (NetChop / NetCleave / Pepsickle).
+mhctools otherwise has no TAP predictor; DeepTAP fills that gap and emits
+``Kind.tap_transport``.
+
+Like the cleavage predictors, DeepTAP is **allele-independent**: it scores each
+peptide once, so ``predict()`` returns one prediction per peptide (with an empty
+``allele``).
+
+DeepTAP ships its pretrained weights in-repo and is Apache-2.0 licensed, but
+pins an old scientific-Python stack (``pytorch-lightning==1.9.2``, torch). To
+keep that stack out of the mhctools environment, this wrapper shells out to
+DeepTAP's own ``deeptap.py`` CLI in a user-provided checkout, run by a
+user-provided interpreter (the Tulip pattern). The checkpoints load fine under
+modern Lightning too, so any interpreter with torch + pytorch-lightning works.
+
+Upstream: https://github.com/zjupgx/DeepTAP
+Cite: Chen et al., *Comput. Biol. Med.* 2023 — "DeepTAP: An RNN-based method of
+TAP-binding peptide prediction in the selection of tumor neoantigens".
+
+Note on interpretation: DeepTAP's evaluation is self-reported, and no
+independent TAP benchmark exists for any tool (true of the whole TAP field).
+Treat the score as a useful pathway signal for prioritization, not a validated
+oracle.
+"""
+
+import os
+import sys
+from os.path import exists, isdir, isfile, join
+from tempfile import mkdtemp
+
+import pandas as pd
+
+from .cleanup_context import CleanupFiles
+from .pred import COLUMNS, Kind, PeptideResult, Prediction
+from .process_helpers import run_command
+
+# DeepTAP one-hot encodes the 20 standard amino acids plus "X" (unknown /
+# padding) and pads every peptide to a fixed width of 17; longer peptides
+# overflow its input tensor, so 17 is a hard model limit.
+DEEPTAP_MAX_PEPTIDE_LENGTH = 17
+_VALID_AMINO_ACIDS = frozenset("ACDEFGHIKLMNPQRSTVWYX")
+
+_TASK_TYPES = ("cla", "reg")
+
+
+def _find_deeptap_home(deeptap_home=None):
+    """Resolve the DeepTAP checkout directory (holds ``deeptap.py`` + ``model/``).
+
+    Checks, in order: the *deeptap_home* argument, ``$DEEPTAP_HOME``, then
+    ``~/DeepTAP``.
+    """
+    candidate = deeptap_home or os.environ.get("DEEPTAP_HOME")
+    if not candidate:
+        home = join(os.path.expanduser("~"), "DeepTAP")
+        if isdir(home):
+            candidate = home
+    if not candidate:
+        raise FileNotFoundError(
+            "DeepTAP not found. Set DEEPTAP_HOME or pass deeptap_home= to the "
+            "constructor. Clone from https://github.com/zjupgx/DeepTAP")
+    if not isfile(join(candidate, "deeptap.py")):
+        raise FileNotFoundError(
+            "deeptap.py not found in %r — is this a DeepTAP checkout?"
+            % candidate)
+    return candidate
+
+
+class DeepTAP:
+    """Wrapper for the DeepTAP TAP-transport predictor.
+
+    Parameters
+    ----------
+    task_type : str
+        ``"cla"`` (classification; ``score`` in 0-1, higher = stronger TAP
+        binding) or ``"reg"`` (regression; also fills ``value`` with the
+        predicted affinity in nM, lower = stronger). Default ``"cla"``.
+    deeptap_home : str, optional
+        Path to a DeepTAP checkout. Resolved from the argument, then
+        ``$DEEPTAP_HOME``, then ``~/DeepTAP``.
+    deeptap_python : str, optional
+        Interpreter that can run DeepTAP (has torch + pytorch-lightning).
+        Resolved from the argument, then ``$DEEPTAP_PYTHON``, then the current
+        interpreter (``sys.executable``).
+    max_peptide_length : int
+        Peptides longer than this are rejected. Capped at DeepTAP's hard limit
+        of 17. Default 17.
+    """
+
+    def __init__(
+            self,
+            task_type="cla",
+            deeptap_home=None,
+            deeptap_python=None,
+            max_peptide_length=DEEPTAP_MAX_PEPTIDE_LENGTH):
+        if task_type not in _TASK_TYPES:
+            raise ValueError(
+                "task_type must be one of %s, got %r"
+                % (_TASK_TYPES, task_type))
+        if max_peptide_length > DEEPTAP_MAX_PEPTIDE_LENGTH:
+            raise ValueError(
+                "DeepTAP pads peptides to %d residues; max_peptide_length "
+                "cannot exceed that (got %d)"
+                % (DEEPTAP_MAX_PEPTIDE_LENGTH, max_peptide_length))
+        self.task_type = task_type
+        self.deeptap_home = _find_deeptap_home(deeptap_home)
+        self.deeptap_python = (
+            deeptap_python
+            or os.environ.get("DEEPTAP_PYTHON")
+            or sys.executable)
+        self.max_peptide_length = max_peptide_length
+
+    def __str__(self):
+        return "DeepTAP(task_type=%r, deeptap_home=%r)" % (
+            self.task_type, self.deeptap_home)
+
+    def __repr__(self):
+        return str(self)
+
+    def _predictor_name(self):
+        return "deeptap_%s" % self.task_type
+
+    def _default_pred_kind(self):
+        return Kind.tap_transport
+
+    def kind_support(self):
+        return {
+            Kind.tap_transport: {
+                "mhc_dependence": "none",
+                "mhc_class": "none",
+            },
+        }
+
+    @property
+    def supported_kinds(self):
+        return tuple(self.kind_support())
+
+    def _check_peptides(self, peptides):
+        for peptide in peptides:
+            if not peptide:
+                raise ValueError("Empty peptide is not allowed")
+            if len(peptide) > self.max_peptide_length:
+                raise ValueError(
+                    "DeepTAP supports peptides up to %d residues; got %r "
+                    "(length %d)"
+                    % (self.max_peptide_length, peptide, len(peptide)))
+            invalid = set(peptide) - _VALID_AMINO_ACIDS
+            if invalid:
+                raise ValueError(
+                    "Peptide %r contains characters DeepTAP cannot encode: %s"
+                    % (peptide, "".join(sorted(invalid))))
+
+    def predict(self, peptides):
+        """Predict TAP transport for a list of peptides.
+
+        Returns
+        -------
+        list of PeptideResult
+            One entry per input peptide, each holding a single
+            ``Kind.tap_transport`` prediction with an empty ``allele``. In
+            ``"reg"`` mode the prediction's ``value`` is the predicted affinity
+            in nM.
+        """
+        if isinstance(peptides, str):
+            peptides = [peptides]
+        peptide_list = [str(p).strip().upper() for p in peptides]
+        self._check_peptides(peptide_list)
+        if not peptide_list:
+            return []
+
+        temp_dir = mkdtemp(prefix="mhctools", suffix="deeptap")
+        # DeepTAP derives the output basename from the input filename up to the
+        # first ".", so keep the stem dot-free.
+        input_file_path = join(temp_dir, "deeptap_input.csv")
+        output_file_path = join(
+            temp_dir, "deeptap_input_DeepTAP_%s_predresult.csv" % self.task_type)
+        rank_file_path = join(
+            temp_dir,
+            "deeptap_input_DeepTAP_%s_predresult_rank.csv" % self.task_type)
+        pd.DataFrame({"peptide": peptide_list}).to_csv(
+            input_file_path, index=False)
+
+        args = [
+            self.deeptap_python,
+            join(self.deeptap_home, "deeptap.py"),
+            "-t", self.task_type,
+            "-f", input_file_path,
+            "-o", temp_dir,
+        ]
+
+        with CleanupFiles(
+                filenames=[input_file_path, output_file_path, rank_file_path],
+                directories=[temp_dir]):
+            run_command(args, suppress_stderr=False)
+            if not exists(output_file_path):
+                raise ValueError(
+                    "DeepTAP produced no output file %r" % output_file_path)
+            preds_by_peptide = parse_deeptap_results(
+                output_file_path, self.task_type)
+
+        return [
+            PeptideResult(preds=tuple(preds_by_peptide.get(peptide, ())))
+            for peptide in peptide_list
+        ]
+
+    def predict_dataframe(self, peptides, sample_name=""):
+        """``predict()`` flattened to a DataFrame."""
+        dfs = [pp.to_dataframe(sample_name) for pp in self.predict(peptides)]
+        if not dfs:
+            return pd.DataFrame(columns=COLUMNS)
+        return pd.concat(dfs, ignore_index=True)
+
+
+def parse_deeptap_results(filename, task_type="cla"):
+    """Parse a DeepTAP prediction CSV into ``{peptide: [Prediction]}``.
+
+    DeepTAP's ``cla`` output has columns ``peptide,pred_score,pred_label`` and
+    its ``reg`` output ``peptide,pred_score,pred_affinity,pred_label``. In both,
+    ``pred_score`` is in 0-1 with higher = stronger TAP binding; in ``reg`` mode
+    the predicted affinity (nM, lower = stronger) is also surfaced as ``value``.
+
+    Parameters
+    ----------
+    filename : str
+    task_type : str
+        ``"cla"`` or ``"reg"`` — selects whether ``pred_affinity`` is expected.
+
+    Returns
+    -------
+    dict mapping peptide -> list with a single Prediction
+    """
+    df = pd.read_csv(filename)
+    columns = list(df.columns)
+    required = ["peptide", "pred_score"]
+    if task_type == "reg":
+        required.append("pred_affinity")
+    missing = [c for c in required if c not in columns]
+    if missing:
+        raise ValueError(
+            "DeepTAP output missing column(s) %s; got %s"
+            % (missing, columns))
+
+    predictor_name = "deeptap_%s" % task_type
+    results = {}
+    for row in df.itertuples(index=False):
+        peptide = str(getattr(row, "peptide")).strip().upper()
+        value = None
+        if task_type == "reg":
+            value = float(getattr(row, "pred_affinity"))
+        results[peptide] = [Prediction(
+            kind=Kind.tap_transport,
+            score=float(getattr(row, "pred_score")),
+            peptide=peptide,
+            value=value,
+            predictor_name=predictor_name)]
+    return results

--- a/mhctools/pred.py
+++ b/mhctools/pred.py
@@ -75,6 +75,7 @@ FIELD_BEST_DIRECTIONS = {
 VALUE_BEST_DIRECTIONS = {
     Kind.pMHC_affinity: "min",   # IC50 nM
     Kind.pMHC_stability: "max",  # half-life
+    Kind.tap_transport: "min",   # predicted TAP-binding affinity, nM
 }
 
 
@@ -286,6 +287,11 @@ class PeptideResult:
     def endolysosomal_cleavage(self) -> Optional[Prediction]:
         """Best endolysosomal (MHC-II) cleavage prediction, or None."""
         return self.best_by_score(Kind.endolysosomal_cleavage)
+
+    @property
+    def tap_transport(self) -> Optional[Prediction]:
+        """Best TAP transport prediction, or None."""
+        return self.best_by_score(Kind.tap_transport)
 
     @property
     def tcr_binding(self) -> Optional[Prediction]:

--- a/tests/test_deeptap.py
+++ b/tests/test_deeptap.py
@@ -1,0 +1,189 @@
+# Copyright (c) 2016. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the DeepTAP TAP-transport wrapper.
+
+Parser and validation tests are binary-free. The end-to-end tests run only when
+a DeepTAP checkout is available (``DEEPTAP_HOME`` pointing at a clone, with
+``DEEPTAP_PYTHON`` optionally naming an interpreter that has torch +
+pytorch-lightning).
+"""
+
+import os
+from os.path import isfile, join
+from tempfile import NamedTemporaryFile
+
+import pytest
+
+from mhctools import DeepTAP, Kind
+from mhctools.deeptap import parse_deeptap_results
+from mhctools.pred import VALUE_BEST_DIRECTIONS, best_direction
+
+
+# Captured DeepTAP (classification) output, matching the committed demo.
+_CLA_OUTPUT = (
+    "peptide,pred_score,pred_label\n"
+    "KADDDKPGA,0.2964,0\n"
+    "AEASAAAAY,0.9795,1\n"
+    "ALAKAGAAV,0.3405,0\n")
+
+# Captured DeepTAP (regression) output — note the extra pred_affinity column.
+_REG_OUTPUT = (
+    "peptide,pred_score,pred_affinity,pred_label\n"
+    "KADDDKPGA,0.2527,101416.8532,1\n"
+    "AEASAAAAY,0.5676,788.6656,1\n"
+    "ALAKAGAAV,0.3499,22637.9888,1\n")
+
+
+def _write(text):
+    f = NamedTemporaryFile("w", suffix="_deeptap.csv", delete=False)
+    f.write(text)
+    f.close()
+    return f.name
+
+
+# --- parser (binary-free) ---------------------------------------------------
+
+def test_parse_deeptap_cla():
+    path = _write(_CLA_OUTPUT)
+    try:
+        by_peptide = parse_deeptap_results(path, "cla")
+    finally:
+        os.remove(path)
+
+    assert set(by_peptide) == {"KADDDKPGA", "AEASAAAAY", "ALAKAGAAV"}
+    pred = by_peptide["AEASAAAAY"][0]
+    assert pred.kind == Kind.tap_transport
+    assert pred.predictor_name == "deeptap_cla"
+    assert pred.peptide == "AEASAAAAY"
+    assert pred.allele == ""
+    assert pred.score == 0.9795
+    assert pred.value is None
+
+
+def test_parse_deeptap_reg_fills_value():
+    path = _write(_REG_OUTPUT)
+    try:
+        by_peptide = parse_deeptap_results(path, "reg")
+    finally:
+        os.remove(path)
+
+    pred = by_peptide["AEASAAAAY"][0]
+    assert pred.kind == Kind.tap_transport
+    assert pred.predictor_name == "deeptap_reg"
+    assert pred.score == 0.5676
+    assert pred.value == 788.6656  # predicted affinity, nM
+
+
+def test_parse_deeptap_reg_requires_affinity_column():
+    # A cla-shaped file has no pred_affinity, so reg parsing must reject it.
+    path = _write(_CLA_OUTPUT)
+    try:
+        with pytest.raises(ValueError, match="pred_affinity"):
+            parse_deeptap_results(path, "reg")
+    finally:
+        os.remove(path)
+
+
+def test_tap_transport_value_direction():
+    # Regression-mode affinity is nM: lower is stronger binding.
+    assert VALUE_BEST_DIRECTIONS[Kind.tap_transport] == "min"
+    assert best_direction(Kind.tap_transport, "value") == "min"
+    assert best_direction(Kind.tap_transport, "score") == "max"
+
+
+# --- construction / validation (no binary needed) ---------------------------
+
+def _stub_home(tmp_path):
+    """A minimal fake DeepTAP checkout (just a deeptap.py marker file)."""
+    (tmp_path / "deeptap.py").write_text("# stub\n")
+    return str(tmp_path)
+
+
+def test_default_kind_and_support(tmp_path):
+    predictor = DeepTAP(deeptap_home=_stub_home(tmp_path))
+    assert predictor._default_pred_kind() == Kind.tap_transport
+    support = predictor.kind_support()[Kind.tap_transport]
+    assert support["mhc_dependence"] == "none"
+    assert support["mhc_class"] == "none"
+    assert predictor.supported_kinds == (Kind.tap_transport,)
+
+
+def test_rejects_bad_task_type(tmp_path):
+    with pytest.raises(ValueError, match="task_type"):
+        DeepTAP(task_type="bogus", deeptap_home=_stub_home(tmp_path))
+
+
+def test_rejects_oversized_max_length(tmp_path):
+    with pytest.raises(ValueError, match="pads peptides"):
+        DeepTAP(deeptap_home=_stub_home(tmp_path), max_peptide_length=25)
+
+
+def test_rejects_missing_home(tmp_path):
+    # An empty directory is not a DeepTAP checkout.
+    with pytest.raises(FileNotFoundError, match="deeptap.py"):
+        DeepTAP(deeptap_home=str(tmp_path))
+
+
+def test_peptide_validation(tmp_path):
+    predictor = DeepTAP(deeptap_home=_stub_home(tmp_path))
+    with pytest.raises(ValueError, match="up to 17"):
+        predictor.predict(["A" * 18])
+    with pytest.raises(ValueError, match="cannot encode"):
+        predictor.predict(["SIINFEKL1"])
+    with pytest.raises(ValueError, match="Empty peptide"):
+        predictor.predict([""])
+
+
+# --- end-to-end (requires a DeepTAP checkout) -------------------------------
+
+DEEPTAP_HOME = os.environ.get("DEEPTAP_HOME")
+_has_deeptap = bool(DEEPTAP_HOME) and isfile(join(DEEPTAP_HOME, "deeptap.py"))
+
+requires_deeptap = pytest.mark.skipif(
+    not _has_deeptap,
+    reason="DeepTAP not installed (set DEEPTAP_HOME to a clone; optionally "
+           "DEEPTAP_PYTHON to an interpreter with torch + pytorch-lightning)")
+
+
+@requires_deeptap
+def test_deeptap_end_to_end_cla():
+    predictor = DeepTAP(task_type="cla", deeptap_home=DEEPTAP_HOME)
+    peptides = ["KADDDKPGA", "AEASAAAAY", "ALAKAGAAV"]
+    results = predictor.predict(peptides)
+
+    assert len(results) == len(peptides)
+    for result, peptide in zip(results, peptides):
+        assert result.peptide == peptide
+        assert len(result.preds) == 1
+        pred = result.preds[0]
+        assert pred.kind == Kind.tap_transport
+        assert pred.allele == ""
+        assert 0.0 <= pred.score <= 1.0
+        assert result.tap_transport is pred
+
+    # DeepTAP is deterministic; these match the committed demo scores.
+    by_peptide = {r.peptide: r.preds[0].score for r in results}
+    assert by_peptide["AEASAAAAY"] == pytest.approx(0.9795, abs=1e-3)
+    assert by_peptide["KADDDKPGA"] == pytest.approx(0.2964, abs=1e-3)
+
+
+@requires_deeptap
+def test_deeptap_end_to_end_reg_sets_value():
+    predictor = DeepTAP(task_type="reg", deeptap_home=DEEPTAP_HOME)
+    results = predictor.predict(["AEASAAAAY"])
+    pred = results[0].preds[0]
+    assert pred.kind == Kind.tap_transport
+    assert pred.value is not None and pred.value > 0  # affinity in nM
+    assert pred.predictor_name == "deeptap_reg"


### PR DESCRIPTION
Closes #236. Third of the series (PRIME ✅ → MixMHC2pred ✅ → **DeepTAP**).

Fills a **total gap**: mhctools predicts proteasomal cleavage (NetChop / NetCleave / Pepsickle) but had nothing for the **TAP transport** step — the transporter that shuttles cytosolic peptides into the ER for MHC-I loading. Wraps [DeepTAP](https://github.com/zjupgx/DeepTAP) (Comput. Biol. Med. 2023), a BiGRU that scores each peptide's TAP binding/transport, emitting **`Kind.tap_transport`**.

## What it does

`DeepTAP` is **allele-independent** (like our cleavage predictors): `predict()` returns one prediction per peptide with an empty `allele`.

```python
from mhctools import DeepTAP

predictor = DeepTAP(task_type="cla")       # resolves DEEPTAP_HOME / ~/DeepTAP
results = predictor.predict(["SIINFEKL", "AEASAAAAY"])
results[1].tap_transport.score             # 0-1, higher = stronger TAP binding
```

- `score` is 0-1 (higher = stronger TAP binding). In `task_type="reg"` mode the predicted **affinity in nM** (lower = stronger) is also surfaced as `value`.
- **New data model** (`predict()` / `predict_dataframe()`), so it composes with `mhctools predict-table` via a new `tap_transport` token: `--predictor deeptap:col:tap_transport`. Verified end-to-end (sidecar correctly reports `higher_is_better=True`).

## Integration choices

- **Subprocess, not in-process.** DeepTAP ships **Apache-2.0** weights in-repo (redistribution-clean), but pins an old `pytorch-lightning`. Rather than drag that stack into the mhctools env, the wrapper shells out to DeepTAP's own `deeptap.py` CLI in a user-provided checkout (`DEEPTAP_HOME`), run by a user-provided interpreter (`DEEPTAP_PYTHON`, default `sys.executable`). No torch import touches mhctools. The checkpoints load fine under modern Lightning (2.x), so any interpreter with torch + pytorch-lightning works.
- **New infra, minimal.** `Kind.tap_transport` already existed (was "reserved"); this adds the `PeptideResult.tap_transport` accessor, a `VALUE_BEST_DIRECTIONS[tap_transport] = "min"` entry (reg-mode nM affinity), the `tap_transport` annotate token, and registers `deeptap`.
- **Parser robustness.** Looks output columns up **by name** (`cla`: `peptide,pred_score,pred_label`; `reg` adds `pred_affinity`), and enforces DeepTAP's hard 17-residue pad limit + encodable-amino-acid validation before shelling out.

## Caveat (documented in the docstring + README)

DeepTAP's evaluation is **self-reported**, and no independent TAP benchmark exists for any tool (true of the whole TAP field). Surfaced as a useful pathway signal for prioritization, not a validated oracle.

## Tests & CI

- Binary-free: parser tests for both `cla`/`reg` shapes (incl. a missing-`pred_affinity` guard), the `tap_transport` value/score directions, and construction/validation (bad task type, oversized max length, non-checkout home, peptide length/charset). Added to the public CI subset.
- End-to-end tests gated on `DEEPTAP_HOME` (skip cleanly otherwise). **Verified locally** against a DeepTAP checkout — reproduces the committed demo scores exactly, and `predict-table` annotation works.

Version `3.24.0 → 3.25.0`.

https://claude.ai/code/session_01LZahFhBSCiehXTESCYQ7wG