### PR TITLE
Add Calis (IEDB) class-I immunogenicity predictor

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,6 +56,7 @@ jobs:
             tests/test_prime.py \
             tests/test_mixmhc2pred2.py \
             tests/test_deeptap.py \
+            tests/test_calis.py \
             tests/test_processing_predictor.py \
             tests/test_pepsickle.py \
             tests/test_bigmhc.py \

--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Examples:
 | `Tulip` | `pMHC_TCR_binding` | `single_allele` | `I` |
 | `BigMHC_IM` | `immunogenicity` | `single_allele` | `I` |
 | `PRIME` | `immunogenicity` | `single_allele` | `I` |
+| `Calis` | `immunogenicity` | `none` | `I` |
 
 ### TCR predictors (`NetTCR`, `Tulip`)
 
@@ -393,8 +394,25 @@ results[1].tap_transport.score             # 0-1, higher = stronger TAP binding
 
 | Predictor | Kinds produced | Requires |
 |---|---|---|
+| `Calis` | immunogenicity | nothing — self-contained |
 | `BigMHC_IM` | immunogenicity | [BigMHC](https://github.com/KarchinLab/bigmhc) clone (set `BIGMHC_DIR`) |
 | `PRIME` | immunogenicity | [PRIME](https://github.com/GfellerLab/PRIME) clone + MixMHCpred |
+
+`Calis` is the classic sequence-only IEDB class-I immunogenicity model (Calis et
+al. 2013): a fixed per-amino-acid log-enrichment scale weighted by per-position
+importance, with the anchor positions (P1/P2/C-terminus) masked out. It needs
+**no external install and no downloaded weights** — the ~30 published parameters
+(from the open-access CC-BY paper) are built in — so it is a fast,
+dependency-free, allele-independent baseline. It emits one `immunogenicity`
+prediction per peptide (empty `allele`); `score > 0` leans immunogenic.
+
+```python
+from mhctools import Calis
+
+predictor = Calis()
+results = predictor.predict(["GILGFVFTL", "NLVPMVATV"])
+results[0].immunogenicity.score            # 0.30484 (higher = more immunogenic)
+```
 
 `PRIME` predicts CD8+ T-cell immunogenicity of class-I peptides by combining
 MHC-I binding (via MixMHCpred, which it calls internally) with a TCR-recognition

--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -27,6 +27,7 @@ from .mixmhcpred import MixMHCpred
 from .mixmhc2pred import MixMHC2pred
 from .prime import PRIME
 from .deeptap import DeepTAP
+from .calis import Calis
 from .processing_predictor import (
     ProcessingPredictor,
     SCORING_MODES,
@@ -83,7 +84,7 @@ def __getattr__(name):
     raise AttributeError(
         "module %r has no attribute %r" % (__name__, name))
 
-__version__ = "3.25.0"
+__version__ = "3.26.0"
 
 __all__ = [
     "Prediction",
@@ -113,6 +114,7 @@ __all__ = [
     "MixMHC2pred",
     "PRIME",
     "DeepTAP",
+    "Calis",
     "MHCflurry",
     "MHCflurry_Affinity",
     "ProcessingPredictor",

--- a/mhctools/calis.py
+++ b/mhctools/calis.py
@@ -1,0 +1,205 @@
+# Copyright (c) 2016. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The Calis (IEDB) class-I T-cell immunogenicity model.
+
+Calis et al. 2013 is the classic sequence-only MHC-I immunogenicity predictor:
+a fixed per-amino-acid log-enrichment scale, weighted by per-position
+importance, with the anchor positions (P1, P2, and the C-terminus) masked out
+because their identity is driven by MHC binding rather than TCR recognition.
+
+Unlike every other predictor in mhctools, this needs **no external install and
+no downloaded weights** — the ~30 published parameters are reproduced here
+directly (they come from the open-access CC-BY paper, Calis et al.,
+*PLoS Comput. Biol.* 2013, ``10.1371/journal.pcbi.1003266``). It is a fast,
+dependency-free baseline that sits alongside the learned immunogenicity
+predictors (``BigMHC_IM``, ``PRIME``).
+
+The model is **allele-independent** here: it always masks P1/P2/C-terminus, the
+default the IEDB tool uses when no allele is supplied. (The IEDB tool can swap
+in allele-specific anchor masks for a fixed ~50-allele catalogue, but those
+anchor sets almost all reduce to the P1/P2/C-terminus default anyway.)
+
+Note on interpretation: like every current CD8 immunogenicity predictor, Calis
+is useful for ranking but generalizes weakly — independent benchmarks put the
+whole field near AUC 0.5-0.65 on unseen neoepitopes. Treat scores as a
+prioritization aid, not ground truth. A score > 0 leans immunogenic, < 0 leans
+non-immunogenic.
+"""
+
+import pandas as pd
+
+from .pred import COLUMNS, Kind, PeptideResult, Prediction
+
+# Per-amino-acid log-enrichment score, log(freq(aa | immunogenic) /
+# freq(aa | non-immunogenic)) from the Calis 2013 training set. Higher = more
+# associated with immunogenicity (W most, K/M least).
+IMMUNOSCALE = {
+    "A": 0.127, "C": -0.175, "D": 0.072, "E": 0.325, "F": 0.380,
+    "G": 0.110, "H": 0.105, "I": 0.432, "K": -0.700, "L": -0.036,
+    "M": -0.570, "N": -0.021, "P": -0.036, "Q": -0.376, "R": 0.168,
+    "S": -0.537, "T": 0.126, "V": 0.134, "W": 0.719, "Y": -0.012,
+}
+
+# Per-position importance weights for a 9-mer (KL divergence between the
+# immunogenic and non-immunogenic training peptides at each position). Index 0
+# is P1. The interior positions (P3-P8) carry the signal; P1/P2/P9 are ~0 and
+# are also masked below.
+IMMUNOWEIGHT = [0.00, 0.00, 0.10, 0.31, 0.30, 0.29, 0.26, 0.18, 0.00]
+
+# Amino acids the scale is defined for.
+_VALID_AMINO_ACIDS = frozenset(IMMUNOSCALE)
+
+
+def position_weights(peptide_length):
+    """Per-position importance weights for a peptide of the given length.
+
+    For 9-mers this is :data:`IMMUNOWEIGHT` verbatim. For longer peptides the
+    Calis rule pads the interior (after P5) with ``0.30`` weights, matching the
+    IEDB tool. Shorter peptides use the leading slice of :data:`IMMUNOWEIGHT`.
+    """
+    if peptide_length > 9:
+        return (
+            IMMUNOWEIGHT[:5]
+            + [0.30] * (peptide_length - 9)
+            + IMMUNOWEIGHT[5:])
+    return IMMUNOWEIGHT
+
+
+def immunogenicity_score(peptide):
+    """Calis immunogenicity score for one peptide (default P1/P2/C-term mask).
+
+    Parameters
+    ----------
+    peptide : str
+        Amino-acid sequence (upper-case, standard residues).
+
+    Returns
+    -------
+    float
+        Sum over unmasked positions of ``position_weight * immunoscale``,
+        rounded to 5 decimals (as the IEDB tool does). > 0 leans immunogenic.
+    """
+    peptide = peptide.upper()
+    n = len(peptide)
+    # Default anchor mask (0-indexed): P1, P2, and the C-terminal residue.
+    masked = {0, 1, n - 1}
+    weights = position_weights(n)
+    score = 0.0
+    for i, aa in enumerate(peptide):
+        if i in masked:
+            continue
+        score += weights[i] * IMMUNOSCALE[aa]
+    return round(score, 5)
+
+
+class Calis:
+    """The Calis (IEDB) class-I immunogenicity predictor.
+
+    Self-contained (no external tool, no downloaded weights). Allele-independent:
+    ``predict()`` returns one :class:`~mhctools.pred.Prediction` per peptide with
+    an empty ``allele`` and ``kind == Kind.immunogenicity``.
+
+    Parameters
+    ----------
+    min_peptide_length : int
+        Shortest peptide accepted. Default 8 (class-I minimum).
+    max_peptide_length : int
+        Longest peptide accepted. Default 11 (the class-I range the model was
+        designed for; longer peptides are handled by the interior-padding rule
+        but are outside its intended scope).
+    """
+
+    def __init__(self, min_peptide_length=8, max_peptide_length=11):
+        if min_peptide_length < 3:
+            # With P1/P2/C-term masked, peptides shorter than this have no
+            # scoring positions left.
+            raise ValueError("min_peptide_length must be >= 3")
+        if max_peptide_length < min_peptide_length:
+            raise ValueError(
+                "max_peptide_length (%d) < min_peptide_length (%d)"
+                % (max_peptide_length, min_peptide_length))
+        self.min_peptide_length = min_peptide_length
+        self.max_peptide_length = max_peptide_length
+
+    def __str__(self):
+        return "Calis(min_peptide_length=%d, max_peptide_length=%d)" % (
+            self.min_peptide_length, self.max_peptide_length)
+
+    def __repr__(self):
+        return str(self)
+
+    def _predictor_name(self):
+        return "calis"
+
+    def _default_pred_kind(self):
+        return Kind.immunogenicity
+
+    def kind_support(self):
+        return {
+            Kind.immunogenicity: {
+                "mhc_dependence": "none",
+                "mhc_class": "I",
+            },
+        }
+
+    @property
+    def supported_kinds(self):
+        return tuple(self.kind_support())
+
+    def _check_peptides(self, peptides):
+        for peptide in peptides:
+            n = len(peptide)
+            if n < self.min_peptide_length or n > self.max_peptide_length:
+                raise ValueError(
+                    "Calis supports peptides of length %d-%d; got %r (length %d)"
+                    % (self.min_peptide_length, self.max_peptide_length,
+                       peptide, n))
+            invalid = set(peptide) - _VALID_AMINO_ACIDS
+            if invalid:
+                raise ValueError(
+                    "Peptide %r contains non-standard amino acid(s): %s"
+                    % (peptide, "".join(sorted(invalid))))
+
+    def predict(self, peptides):
+        """Predict immunogenicity for a list of peptides.
+
+        Returns
+        -------
+        list of PeptideResult
+            One entry per input peptide, each holding a single
+            ``Kind.immunogenicity`` prediction (empty ``allele``; ``score`` is
+            the Calis score, higher = more immunogenic).
+        """
+        if isinstance(peptides, str):
+            peptides = [peptides]
+        peptide_list = [str(p).strip().upper() for p in peptides]
+        self._check_peptides(peptide_list)
+
+        results = []
+        for peptide in peptide_list:
+            pred = Prediction(
+                kind=Kind.immunogenicity,
+                score=immunogenicity_score(peptide),
+                peptide=peptide,
+                predictor_name="calis")
+            results.append(PeptideResult(preds=(pred,)))
+        return results
+
+    def predict_dataframe(self, peptides, sample_name=""):
+        """``predict()`` flattened to a DataFrame."""
+        dfs = [pp.to_dataframe(sample_name) for pp in self.predict(peptides)]
+        if not dfs:
+            return pd.DataFrame(columns=COLUMNS)
+        return pd.concat(dfs, ignore_index=True)

--- a/mhctools/cli/args.py
+++ b/mhctools/cli/args.py
@@ -65,6 +65,7 @@ from .. import (
     MixMHC2pred,
     PRIME,
     DeepTAP,
+    Calis,
 )
 
 
@@ -171,6 +172,7 @@ mhc_predictors = {
     "mixmhc2pred": MixMHC2pred,
     "prime": PRIME,
     "deeptap": DeepTAP,
+    "calis": Calis,
 }
 
 

--- a/tests/test_calis.py
+++ b/tests/test_calis.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2016. Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Calis (IEDB) class-I immunogenicity predictor.
+
+Fully binary-free — the model is self-contained. Reference scores below were
+produced by the canonical IEDB ``predict_immunogenicity.py`` algorithm (Calis
+et al. 2013) with the default P1/P2/C-terminus mask.
+"""
+
+import pytest
+
+from mhctools import Calis, Kind
+from mhctools.calis import (
+    IMMUNOSCALE,
+    IMMUNOWEIGHT,
+    immunogenicity_score,
+    position_weights,
+)
+
+
+# peptide -> canonical IEDB score (default anchor mask, rounded to 5 dp).
+_REFERENCE = {
+    "SIINFEKL": 0.06294,     # 8-mer (H-2Kb)
+    "GILGFVFTL": 0.30484,    # 9-mer (influenza M1)
+    "ELAGIGILTV": 0.348,     # 10-mer (MART-1)
+    "NLVPMVATV": -0.0742,    # 9-mer (CMV pp65)
+    "LLFGYPVYV": 0.09074,    # 9-mer (HTLV-1 Tax)
+    "FLRGRAYGL": 0.15481,    # 9-mer (EBV)
+}
+
+
+# --- parameters ------------------------------------------------------------
+
+def test_scale_and_weights_shape():
+    assert len(IMMUNOSCALE) == 20
+    # W most immunogenic, K least — the paper's headline residues.
+    assert max(IMMUNOSCALE, key=IMMUNOSCALE.get) == "W"
+    assert min(IMMUNOSCALE, key=IMMUNOSCALE.get) == "K"
+    assert IMMUNOWEIGHT == [0.00, 0.00, 0.10, 0.31, 0.30, 0.29, 0.26, 0.18, 0.00]
+
+
+def test_position_weights_stretch_for_long_peptides():
+    assert position_weights(9) == IMMUNOWEIGHT
+    # 11-mer: two extra 0.30 interior weights inserted after P5.
+    w11 = position_weights(11)
+    assert len(w11) == 11
+    assert w11 == [0.00, 0.00, 0.10, 0.31, 0.30, 0.30, 0.30, 0.29, 0.26, 0.18, 0.00]
+
+
+# --- scoring against the canonical IEDB output -----------------------------
+
+@pytest.mark.parametrize("peptide,expected", sorted(_REFERENCE.items()))
+def test_immunogenicity_score_matches_iedb(peptide, expected):
+    assert immunogenicity_score(peptide) == pytest.approx(expected, abs=1e-5)
+
+
+def test_case_insensitive():
+    assert immunogenicity_score("gilgfvftl") == immunogenicity_score("GILGFVFTL")
+
+
+# --- predictor API ---------------------------------------------------------
+
+def test_predict_shape_and_kind():
+    predictor = Calis()
+    peptides = ["GILGFVFTL", "NLVPMVATV"]
+    results = predictor.predict(peptides)
+
+    assert len(results) == len(peptides)
+    for result, peptide in zip(results, peptides):
+        assert result.peptide == peptide
+        assert len(result.preds) == 1
+        pred = result.preds[0]
+        assert pred.kind == Kind.immunogenicity
+        assert pred.allele == ""
+        assert pred.predictor_name == "calis"
+        assert pred.score == pytest.approx(_REFERENCE[peptide], abs=1e-5)
+        # convenience accessor resolves to the same prediction
+        assert result.immunogenicity is pred
+
+
+def test_predict_accepts_single_string():
+    (result,) = Calis().predict("GILGFVFTL")
+    assert result.preds[0].score == pytest.approx(0.30484, abs=1e-5)
+
+
+def test_default_kind_and_support():
+    predictor = Calis()
+    assert predictor._default_pred_kind() == Kind.immunogenicity
+    support = predictor.kind_support()[Kind.immunogenicity]
+    assert support["mhc_dependence"] == "none"
+    assert support["mhc_class"] == "I"
+    assert predictor.supported_kinds == (Kind.immunogenicity,)
+
+
+def test_predict_dataframe():
+    df = Calis().predict_dataframe(["GILGFVFTL"], sample_name="s1")
+    assert len(df) == 1
+    row = df.iloc[0]
+    assert row["peptide"] == "GILGFVFTL"
+    assert row["kind"] == Kind.immunogenicity
+    assert row["sample_name"] == "s1"
+    assert row["score"] == pytest.approx(0.30484, abs=1e-5)
+
+
+# --- validation ------------------------------------------------------------
+
+def test_rejects_out_of_range_length():
+    predictor = Calis()  # default 8-11
+    with pytest.raises(ValueError, match="length 8-11"):
+        predictor.predict(["SIINFEK"])       # 7-mer, too short
+    with pytest.raises(ValueError, match="length 8-11"):
+        predictor.predict(["A" * 12])         # 12-mer, too long
+
+
+def test_rejects_non_standard_amino_acids():
+    with pytest.raises(ValueError, match="non-standard amino acid"):
+        Calis().predict(["GILGFVFTX"])
+
+
+def test_custom_length_bounds():
+    # A 10/11-mer window opened up explicitly still scores like IEDB.
+    predictor = Calis(min_peptide_length=10, max_peptide_length=10)
+    (result,) = predictor.predict(["ELAGIGILTV"])
+    assert result.preds[0].score == pytest.approx(0.348, abs=1e-5)
+    with pytest.raises(ValueError):
+        predictor.predict(["GILGFVFTL"])      # 9-mer now out of range


### PR DESCRIPTION
First of two native-reimplementation PRs filling the last survey-flagged gaps (Calis immunogenicity, then ERAMER for the empty `erap_trimming` kind).

Adds the classic sequence-only MHC-I immunogenicity model — Calis et al., *PLoS Comput. Biol.* 2013, the model behind [IEDB's "class I immunogenicity" tool](https://tools.iedb.org/immunogenicity/): a fixed per-amino-acid log-enrichment scale weighted by per-position importance, with the anchor positions (P1/P2/C-terminus) masked out because their identity is MHC-driven, not TCR-driven. Emits **`Kind.immunogenicity`**.

## Why it's worth adding

- **Zero-install, self-contained.** Unlike *every* other predictor in mhctools, Calis needs **no external tool and no downloaded weights** — the ~30 published parameters come from the **open-access CC-BY** paper and are reproduced directly. A fast, dependency-free, allele-independent baseline sitting alongside the learned immunogenicity predictors (`BigMHC_IM`, `PRIME`).
- It's the standard immunogenicity **baseline** in the literature; having it in-tree makes head-to-heads trivial.

```python
from mhctools import Calis

predictor = Calis()
results = predictor.predict(["GILGFVFTL", "NLVPMVATV"])
results[0].immunogenicity.score            # 0.30484 (higher = more immunogenic)
```

## Faithfulness / validation

- Parameters (`IMMUNOSCALE`, `IMMUNOWEIGHT`) and the algorithm (default P1/P2/C-terminus mask, the >9-mer interior-padding rule, 5-dp rounding) match the canonical IEDB `predict_immunogenicity.py` **exactly**. Cross-checked against the UNC-PIRL Apache-2.0 reimplementation (`pirl-unc/ImmFerNo`), which validates to 1e-6 against IEDB's own output.
- `tests/test_calis.py` pins scores to canonical IEDB values (`GILGFVFTL=0.30484`, `ELAGIGILTV=0.348`, `NLVPMVATV=-0.0742`, …). Fully binary-free; added to the public CI subset.

## Integration

- **Allele-independent** (`mhc_dependence: none`, `mhc_class: I`) — one prediction per peptide, empty `allele`, matching the IEDB default (no-allele) masking. New data model, so it composes with `mhctools predict-table` via the existing `immunogenicity` token (`--predictor calis:col:immunogenicity`). Verified end-to-end.
- No new kinds/infra — `Kind.immunogenicity` and its accessors already exist.

## Caveat (documented)

Like every current CD8 immunogenicity predictor, Calis is a ranking aid, not a validated oracle — independent benchmarks put the field near AUC 0.5-0.65 on unseen neoepitopes.

Version `3.25.0 → 3.26.0`.

https://claude.ai/code/session_01LZahFhBSCiehXTESCYQ7wG