### PR TITLE
Fix NetMHCstabpan mixed-length peptides

### DIFF
--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -87,7 +87,7 @@ def __getattr__(name):
     raise AttributeError(
         "module %r has no attribute %r" % (__name__, name))
 
-__version__ = "3.31.0"
+__version__ = "3.31.1"
 
 __all__ = [
     "Prediction",

--- a/mhctools/netmhcstabpan.py
+++ b/mhctools/netmhcstabpan.py
@@ -36,13 +36,8 @@ class NetMHCstabpan(BaseCommandlinePredictor):
             length_flag="-l",
             allele_flag="-a",
             extra_flags=flags,
-            process_limit=process_limit)
-        
-    def predict_peptides(self, peptides):
-        peptide_lengths = set(len(p) for p in peptides)
-        if len(peptide_lengths) > 1:
-            raise ValueError("All peptides must be the same length")
-        return super().predict_peptides(peptides)
+            process_limit=process_limit,
+            group_peptides_by_length=True)
 
     def _default_pred_kind(self):
         return Kind.pMHC_stability

--- a/tests/test_netmhc_stabpan.py
+++ b/tests/test_netmhc_stabpan.py
@@ -10,8 +10,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 from numpy.testing import assert_allclose
 from mhctools import NetMHCstabpan
+from mhctools.base_commandline_predictor import BaseCommandlinePredictor
+from mhctools.binding_prediction_collection import BindingPredictionCollection
 
 
 DEFAULT_ALLELE = 'HLA-A*02:01'
@@ -58,4 +62,40 @@ def test_netmhc_stabpan_accuracy():
         # This could be the result of different versions of dependencies or the nature of the ANN itself.
         assert_allclose(expected, actual, atol=0.01, err_msg="Peptide %d: expected %f but got %f" % (i, expected, actual))
 
-    
+
+def test_netmhc_stabpan_groups_mixed_length_peptides(monkeypatch):
+    def fake_collect(self, commands, input_filenames, temp_dir_list,
+                     sequence_key_mapping=None):
+        seen_groups = []
+        for path in input_filenames:
+            with open(path) as fd:
+                seen_groups.append([line.strip() for line in fd])
+            os.remove(path)
+        for output_file in commands:
+            output_file.close()
+            os.remove(output_file.name)
+        self.seen_groups = seen_groups
+        return BindingPredictionCollection([])
+
+    monkeypatch.setattr(
+        BaseCommandlinePredictor,
+        "_determine_supported_alleles",
+        staticmethod(lambda command, flag: {"HLA-A02:01"}))
+    monkeypatch.setattr(
+        NetMHCstabpan,
+        "_run_commands_and_collect_predictions",
+        fake_collect)
+    monkeypatch.setattr(
+        NetMHCstabpan,
+        "_check_results",
+        lambda self, binding_predictions, peptides, alleles: None)
+
+    predictor = NetMHCstabpan(alleles=[DEFAULT_ALLELE])
+    predictor.predict_peptides(["SIINFEKL", "SIINFEKLL", "SIINFEKLQY"])
+
+    assert predictor.group_peptides_by_length is True
+    assert sorted(predictor.seen_groups) == sorted([
+        ["SIINFEKL"],
+        ["SIINFEKLL"],
+        ["SIINFEKLQY"],
+    ])


### PR DESCRIPTION
## Summary

Fixes #253.

NetMHCstabpan no longer rejects mixed-length peptide inputs in `predict_peptides`. The wrapper now opts into the existing `BaseCommandlinePredictor` length-grouping path, matching the behavior already used by other command-line predictors that require same-length batches.

## Impact

Callers can pass mixed 8/9/10-mer peptide lists directly to `NetMHCstabpan.predict_peptides` and `predict_peptides_dataframe`; mhctools groups the temporary input files by peptide length before invoking the external predictor.

## Validation

- `pytest tests/test_netmhc_stabpan.py::test_netmhc_stabpan_groups_mixed_length_peptides -q`
- `./lint.sh`
- `./test.sh` (`637 passed, 51 skipped, 2 xfailed`)

## Version

Bumped package version from `3.31.0` to `3.31.1`.