### PR TITLE
Add predictor artifact fetch and listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,41 @@ pip install mhctools
 For MHCflurry support, also run:
 
 ```sh
-mhcflurry-downloads fetch
+mhctools fetch mhcflurry
 ```
+
+## Predictor artifacts
+
+mhctools exposes one acquisition command for model weights, reference files,
+and external tool snapshots required by its wrappers. Predictors with their own
+download manager keep using it; mhctools reports the manager and resolved path
+instead of copying the files into a second cache.
+
+```sh
+# Show packaged and optional artifacts, where they live, and who manages them.
+mhctools ls
+
+# Fetch the upstream package's default compatible release.
+mhctools fetch mhcflurry
+
+# Reproducibility runs may request an explicit artifact release.
+mhctools fetch mhcflurry --version 2.2.0
+```
+
+The same operations are available in Python:
+
+```python
+from mhctools import MHCflurry, fetch, list_artifacts
+
+MHCflurry.fetch()
+fetch("mhcflurry-affinity")
+for artifact in list_artifacts():
+    print(artifact.name, artifact.manager, artifact.version, artifact.path)
+```
+
+`fetch()` obtains every safely and legally downloadable artifact needed by the
+named wrapper. It does not install Python packages, execute upstream setup
+scripts, or duplicate caches owned by another package.
 
 ## Quick start
 
@@ -294,8 +327,8 @@ affinity, hours for stability). `percentile_rank` is always optional,
 | `NetMHCIIpan` / `NetMHCIIpan43` | affinity or presentation | [NetMHCIIpan](https://services.healthtech.dtu.dk/services/NetMHCIIpan-4.3/) |
 | `NetMHCcons` | affinity | [NetMHCcons](https://services.healthtech.dtu.dk/services/NetMHCcons-1.1/) |
 | `NetMHCstabpan` | stability | [NetMHCstabpan](https://services.healthtech.dtu.dk/services/NetMHCstabpan-1.0/) |
-| `MHCflurry` | affinity + presentation + processing | `pip install mhcflurry` + `mhcflurry-downloads fetch` |
-| `MHCflurry_Affinity` | affinity | `pip install mhcflurry` + `mhcflurry-downloads fetch` |
+| `MHCflurry` | affinity + presentation + processing | `pip install mhcflurry` + `mhctools fetch mhcflurry` |
+| `MHCflurry_Affinity` | affinity | `pip install mhcflurry` + `mhctools fetch mhcflurry-affinity` |
 | `BigMHC` | presentation or immunogenicity | [BigMHC](https://github.com/KarchinLab/bigmhc) clone (set `BIGMHC_DIR`) |
 | `MixMHCpred` | presentation (class I) | [MixMHCpred](https://github.com/GfellerLab/MixMHCpred) |
 | `MixMHC2pred` | presentation (class II) | [MixMHC2pred](https://github.com/GfellerLab/MixMHC2pred) release (has `PWMdef/`) |

--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -17,6 +17,7 @@ from .pred import (
 from .sample import MultiSample
 from .tcr import TCR
 from .annotate import AnnotationSpec, annotate_table, parse_annotation_spec
+from .artifacts import ArtifactStatus, fetch, list_artifacts
 from .iedb import (
     IedbNetMHCcons,
     IedbNetMHCpan,
@@ -112,6 +113,9 @@ __all__ = [
     "AnnotationSpec",
     "annotate_table",
     "parse_annotation_spec",
+    "ArtifactStatus",
+    "fetch",
+    "list_artifacts",
     "BindingPrediction",
     "BindingPredictionCollection",
     "set_log_level",

--- a/mhctools/artifacts.py
+++ b/mhctools/artifacts.py
@@ -1,0 +1,263 @@
+# Copyright (c) 2026 Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Discover and fetch model artifacts used by mhctools predictors.
+
+Predictors that already manage their own downloads retain ownership of their
+cache.  mhctools provides a common entry point and reports the resolved path;
+it does not copy those artifacts into a second cache.
+"""
+
+from dataclasses import asdict, dataclass
+from importlib import metadata, util
+import os
+from pathlib import Path
+import shutil
+import subprocess
+
+
+@dataclass(frozen=True)
+class ArtifactStatus:
+    """Status of the artifacts required by one predictor wrapper."""
+
+    name: str
+    status: str
+    manager: str
+    version: str
+    path: str
+    fetchable: bool
+    detail: str
+
+    def to_dict(self):
+        """Return a JSON-serializable representation."""
+        return asdict(self)
+
+
+def _mhcflurry_downloads():
+    """Import MHCflurry's lightweight download configuration lazily."""
+    from mhcflurry import downloads
+    return downloads
+
+
+def _mhcflurry_status(name, download_name, relative_path):
+    try:
+        downloads = _mhcflurry_downloads()
+        root = downloads.get_path(download_name, test_exists=False)
+        path = os.path.join(root, relative_path)
+        version = downloads.get_current_release() or "custom"
+        ready = os.path.exists(path)
+        detail = "Managed by MHCflurry"
+    except (ImportError, ModuleNotFoundError):
+        path = ""
+        version = ""
+        ready = False
+        detail = "Install the mhcflurry package before fetching its models"
+    return ArtifactStatus(
+        name=name,
+        status="ready" if ready else "missing",
+        manager="mhcflurry",
+        version=str(version),
+        path=os.path.abspath(path) if path else "",
+        fetchable=True,
+        detail=detail,
+    )
+
+
+def _mhcflurry_presentation_status():
+    return _mhcflurry_status(
+        name="mhcflurry",
+        download_name="models_class1_presentation",
+        relative_path="models",
+    )
+
+
+def _mhcflurry_affinity_status():
+    return _mhcflurry_status(
+        name="mhcflurry-affinity",
+        download_name="models_class1_pan",
+        relative_path="models.combined",
+    )
+
+
+def _calis_status():
+    from . import __version__
+    from . import calis
+    return ArtifactStatus(
+        name="calis",
+        status="ready",
+        manager="mhctools package",
+        version=__version__,
+        path=os.path.abspath(calis.__file__),
+        fetchable=False,
+        detail="Published model parameters are embedded in mhctools",
+    )
+
+
+def _pepsickle_status():
+    spec = util.find_spec("pepsickle")
+    if spec is None or spec.origin is None:
+        return ArtifactStatus(
+            name="pepsickle",
+            status="missing",
+            manager="pepsickle package",
+            version="",
+            path="",
+            fetchable=False,
+            detail="Install mhctools[pepsickle] to obtain the packaged weights",
+        )
+
+    package_dir = Path(spec.origin).resolve().parent
+    required = (
+        package_dir / "model.joblib",
+        package_dir / "trained_model_dict.pickle",
+    )
+    ready = all(path.is_file() for path in required)
+    try:
+        version = metadata.version("pepsickle")
+    except metadata.PackageNotFoundError:
+        version = ""
+    return ArtifactStatus(
+        name="pepsickle",
+        status="ready" if ready else "missing",
+        manager="pepsickle package",
+        version=version,
+        path=str(package_dir),
+        fetchable=False,
+        detail=(
+            "Model weights are installed with the pepsickle package"
+            if ready else
+            "The pepsickle package is present but its model weights are missing"
+        ),
+    )
+
+
+_STATUS_FUNCTIONS = {
+    "calis": _calis_status,
+    "mhcflurry": _mhcflurry_presentation_status,
+    "mhcflurry-affinity": _mhcflurry_affinity_status,
+    "pepsickle": _pepsickle_status,
+}
+
+_ALIASES = {
+    "mhcflurry-presentation": "mhcflurry",
+}
+
+
+def _canonical_name(name):
+    normalized = name.strip().lower()
+    return _ALIASES.get(normalized, normalized)
+
+
+def artifact_status(name):
+    """Return the current status for a named predictor's artifacts."""
+    canonical = _canonical_name(name)
+    try:
+        status_function = _STATUS_FUNCTIONS[canonical]
+    except KeyError:
+        raise ValueError(
+            "Unknown artifact %r. Available: %s" % (
+                name, ", ".join(sorted(_STATUS_FUNCTIONS))))
+    return status_function()
+
+
+def list_artifacts(names=None):
+    """List known packaged, native, and optionally downloadable artifacts."""
+    if names is None:
+        canonical_names = sorted(_STATUS_FUNCTIONS)
+    else:
+        canonical_names = []
+        for name in names:
+            canonical = _canonical_name(name)
+            if canonical not in canonical_names:
+                canonical_names.append(canonical)
+    return [artifact_status(name) for name in canonical_names]
+
+
+def _fetch_mhcflurry(name, download_name, relative_path, version=None):
+    executable = shutil.which("mhcflurry-downloads")
+    if executable is None:
+        raise RuntimeError(
+            "The mhcflurry-downloads command is unavailable. Reinstall the "
+            "mhcflurry package in this Python environment.")
+
+    environment = os.environ.copy()
+    command = [executable, "fetch"]
+    if version is not None:
+        # MHCflurry selects its storage directory at import time using this
+        # environment variable. Passing --release alone can otherwise fetch a
+        # historical release into the current release's directory.
+        environment["MHCFLURRY_DOWNLOADS_CURRENT_RELEASE"] = str(version)
+        command.extend(["--release", str(version)])
+    command.append(download_name)
+    subprocess.run(command, check=True, env=environment)
+
+    path_result = subprocess.run(
+        [executable, "path", download_name],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+    root = path_result.stdout.strip()
+    path = os.path.abspath(os.path.join(root, relative_path))
+    if not os.path.exists(path):
+        raise RuntimeError(
+            "MHCflurry reported a completed download, but the expected path "
+            "does not exist: %s" % path)
+
+    resolved_version = str(version) if version is not None else ""
+    if not resolved_version:
+        resolved_version = str(_mhcflurry_downloads().get_current_release() or "custom")
+    return ArtifactStatus(
+        name=name,
+        status="ready",
+        manager="mhcflurry",
+        version=resolved_version,
+        path=path,
+        fetchable=True,
+        detail="Managed by MHCflurry",
+    )
+
+
+def fetch(name, version=None):
+    """Fetch a predictor's external artifacts and return their status.
+
+    Native download managers retain ownership of their files. Predictors whose
+    parameters are already packaged are treated as successful no-ops.
+    """
+    canonical = _canonical_name(name)
+    if canonical == "mhcflurry":
+        return _fetch_mhcflurry(
+            name="mhcflurry",
+            download_name="models_class1_presentation",
+            relative_path="models",
+            version=version,
+        )
+    if canonical == "mhcflurry-affinity":
+        return _fetch_mhcflurry(
+            name="mhcflurry-affinity",
+            download_name="models_class1_pan",
+            relative_path="models.combined",
+            version=version,
+        )
+
+    status = artifact_status(canonical)
+    if status.status == "ready":
+        if version is not None and version != status.version:
+            raise ValueError(
+                "%s is managed by %s at version %s; mhctools cannot fetch "
+                "version %s" % (
+                    canonical, status.manager, status.version, version))
+        return status
+    raise RuntimeError(status.detail)

--- a/mhctools/cli/artifacts.py
+++ b/mhctools/cli/artifacts.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2026 Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CLI commands for discovering and fetching predictor artifacts."""
+
+from argparse import ArgumentParser
+import json
+
+from ..artifacts import fetch, list_artifacts
+
+
+def _print_table(statuses):
+    headers = ("NAME", "STATUS", "MANAGER", "VERSION", "FETCHABLE", "PATH")
+    rows = [
+        (
+            status.name,
+            status.status,
+            status.manager,
+            status.version or "-",
+            "yes" if status.fetchable else "no",
+            status.path or "-",
+        )
+        for status in statuses
+    ]
+    widths = [
+        max(len(headers[i]), *(len(row[i]) for row in rows))
+        for i in range(len(headers))
+    ]
+    print("  ".join(value.ljust(widths[i]) for i, value in enumerate(headers)))
+    for row in rows:
+        print("  ".join(value.ljust(widths[i]) for i, value in enumerate(row)))
+
+
+def ls_main(args_list=None):
+    """Run ``mhctools ls``."""
+    parser = ArgumentParser(
+        prog="mhctools ls",
+        description="List model weights and other predictor artifacts.",
+    )
+    parser.add_argument("name", nargs="*", help="Optional artifact names")
+    parser.add_argument(
+        "--json", action="store_true", help="Emit machine-readable JSON")
+    args = parser.parse_args(args_list)
+    try:
+        statuses = list_artifacts(args.name or None)
+    except ValueError as error:
+        parser.error(str(error))
+    if args.json:
+        print(json.dumps([status.to_dict() for status in statuses], indent=2))
+    else:
+        _print_table(statuses)
+
+
+def fetch_main(args_list=None):
+    """Run ``mhctools fetch``."""
+    parser = ArgumentParser(
+        prog="mhctools fetch",
+        description="Fetch artifacts required by a predictor wrapper.",
+    )
+    parser.add_argument("name", help="Artifact or predictor name")
+    parser.add_argument(
+        "--version", help="Specific upstream artifact release to fetch")
+    parser.add_argument(
+        "--json", action="store_true", help="Emit machine-readable JSON")
+    args = parser.parse_args(args_list)
+    try:
+        status = fetch(args.name, version=args.version)
+    except (RuntimeError, ValueError) as error:
+        parser.error(str(error))
+    if args.json:
+        print(json.dumps(status.to_dict(), indent=2))
+    else:
+        _print_table([status])

--- a/mhctools/cli/script.py
+++ b/mhctools/cli/script.py
@@ -169,6 +169,12 @@ def main(args_list=None):
     """
     if args_list is None:
         args_list = sys.argv[1:]
+    if args_list and args_list[0] == "ls":
+        from .artifacts import ls_main
+        return ls_main(args_list[1:])
+    if args_list and args_list[0] == "fetch":
+        from .artifacts import fetch_main
+        return fetch_main(args_list[1:])
     if args_list and args_list[0] == "predict-table":
         from .annotate_table import main as annotate_table_main
         return annotate_table_main(args_list[1:])

--- a/mhctools/mhcflurry.py
+++ b/mhctools/mhcflurry.py
@@ -119,6 +119,12 @@ class MHCflurry(BasePredictor):
         "per_allele",
     ))
 
+    @classmethod
+    def fetch(cls, version=None):
+        """Fetch MHCflurry presentation models using its native manager."""
+        from .artifacts import fetch
+        return fetch("mhcflurry", version=version)
+
     def __init__(
             self,
             alleles,
@@ -457,6 +463,12 @@ class MHCflurry_Affinity(BasePredictor):
 
     See https://github.com/openvax/mhcflurry
     """
+
+    @classmethod
+    def fetch(cls, version=None):
+        """Fetch MHCflurry affinity models using its native manager."""
+        from .artifacts import fetch
+        return fetch("mhcflurry-affinity", version=version)
 
     def __init__(
             self,

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -1,0 +1,144 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from mhctools import artifacts
+from mhctools.artifacts import ArtifactStatus, artifact_status, fetch, list_artifacts
+from mhctools.cli import artifacts as artifact_cli
+from mhctools.cli.script import main
+
+
+def test_list_includes_native_and_packaged_artifacts():
+    statuses = {status.name: status for status in list_artifacts()}
+    assert set(statuses) == {
+        "calis", "mhcflurry", "mhcflurry-affinity", "pepsickle"}
+    assert statuses["calis"].manager == "mhctools package"
+    assert statuses["calis"].status == "ready"
+    assert statuses["calis"].fetchable is False
+    assert statuses["pepsickle"].manager == "pepsickle package"
+    assert statuses["mhcflurry"].manager == "mhcflurry"
+    assert statuses["mhcflurry"].fetchable is True
+
+
+def test_alias_resolves_to_presentation_artifact():
+    assert artifact_status("mhcflurry-presentation").name == "mhcflurry"
+
+
+def test_unknown_artifact_error_lists_choices():
+    with pytest.raises(ValueError, match="Available: calis, mhcflurry"):
+        artifact_status("unknown")
+
+
+def test_fetch_packaged_artifact_is_noop():
+    status = fetch("calis")
+    assert status.status == "ready"
+    assert status.manager == "mhctools package"
+    assert Path(status.path).is_file()
+
+
+def test_fetch_packaged_artifact_rejects_other_version():
+    with pytest.raises(ValueError, match="cannot fetch version never"):
+        fetch("calis", version="never")
+
+
+def test_mhcflurry_status_uses_native_manager(monkeypatch, tmp_path):
+    models = tmp_path / "models_class1_presentation" / "models"
+    models.mkdir(parents=True)
+    fake_downloads = SimpleNamespace(
+        get_path=lambda name, test_exists=False: str(tmp_path / name),
+        get_current_release=lambda: "test-release",
+    )
+    monkeypatch.setattr(
+        artifacts, "_mhcflurry_downloads", lambda: fake_downloads)
+
+    status = artifacts._mhcflurry_presentation_status()
+    assert status.status == "ready"
+    assert status.version == "test-release"
+    assert status.path == str(models)
+
+
+def test_fetch_mhcflurry_delegates_and_returns_model_path(monkeypatch, tmp_path):
+    download_root = tmp_path / "models_class1_presentation"
+    model_path = download_root / "models"
+    model_path.mkdir(parents=True)
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        if "path" in command:
+            return SimpleNamespace(stdout=str(download_root) + "\n")
+        return SimpleNamespace(stdout=None)
+
+    monkeypatch.setattr(artifacts.shutil, "which", lambda name: "/bin/mhcflurry-downloads")
+    monkeypatch.setattr(artifacts.subprocess, "run", fake_run)
+
+    status = fetch("mhcflurry", version="2.2.0")
+    assert status.path == str(model_path)
+    assert status.version == "2.2.0"
+    assert calls[0][0] == [
+        "/bin/mhcflurry-downloads", "fetch", "--release", "2.2.0",
+        "models_class1_presentation"]
+    assert calls[0][1]["env"][
+        "MHCFLURRY_DOWNLOADS_CURRENT_RELEASE"] == "2.2.0"
+    assert calls[1][0] == [
+        "/bin/mhcflurry-downloads", "path", "models_class1_presentation"]
+
+
+def test_ls_cli_table(monkeypatch, capsys):
+    status = ArtifactStatus(
+        name="example",
+        status="ready",
+        manager="package",
+        version="1",
+        path="/models/example",
+        fetchable=False,
+        detail="example",
+    )
+    monkeypatch.setattr(artifact_cli, "list_artifacts", lambda names: [status])
+    result = main(["ls"])
+    output = capsys.readouterr().out
+    assert result is None
+    assert "NAME" in output
+    assert "MANAGER" in output
+    assert "/models/example" in output
+
+
+def test_ls_cli_json(monkeypatch, capsys):
+    status = ArtifactStatus(
+        name="example",
+        status="missing",
+        manager="mhctools",
+        version="v1",
+        path="",
+        fetchable=True,
+        detail="example",
+    )
+    monkeypatch.setattr(artifact_cli, "list_artifacts", lambda names: [status])
+    main(["ls", "--json"])
+    output = capsys.readouterr().out
+    assert '"name": "example"' in output
+    assert '"fetchable": true' in output
+
+
+def test_fetch_cli_dispatch(monkeypatch, capsys):
+    status = ArtifactStatus(
+        name="example",
+        status="ready",
+        manager="upstream",
+        version="v1",
+        path="/models/example",
+        fetchable=True,
+        detail="example",
+    )
+    monkeypatch.setattr(
+        artifact_cli, "fetch", lambda name, version=None: status)
+    result = main(["fetch", "example", "--version", "v1"])
+    assert result is None
+    assert "upstream" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- add `mhctools fetch` and Python `fetch()` for predictor artifacts
- delegate MHCflurry presentation and affinity downloads to MHCflurry's native manager
- add `mhctools ls` / JSON inventory with manager, version, path, and fetchability
- inventory Calis parameters and Pepsickle package weights already shipped with installed packages
- expose `MHCflurry.fetch()` and `MHCflurry_Affinity.fetch()` class helpers

## Verification
- `./lint.sh`
- `./test.sh` (692 passed, 53 skipped, 2 xfailed)
- exercised installed console entry points: `mhctools ls`, `mhctools ls --json`, `mhctools fetch calis`, `mhctools fetch mhcflurry`