### PR TITLE
Fetch pinned predictor tools and weights

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,26 @@ mhctools fetch mhcflurry
 
 # Reproducibility runs may request an explicit artifact release.
 mhctools fetch mhcflurry --version 2.2.0
+
+# Fetch a pinned open-source snapshot (code plus the wrapper's model files).
+mhctools fetch eramer
+
+# Academic licenses must be reviewed and accepted explicitly.
+mhctools fetch nettcr --accept-license
+
+# Machine-readable inventory, optionally rooted somewhere else.
+mhctools ls --json
+mhctools ls --data-dir /shared/models
 ```
 
 The same operations are available in Python:
 
 ```python
-from mhctools import MHCflurry, fetch, list_artifacts
+from mhctools import ERAMER, MHCflurry, fetch, list_artifacts
 
 MHCflurry.fetch()
 fetch("mhcflurry-affinity")
+ERAMER.fetch()
 for artifact in list_artifacts():
     print(artifact.name, artifact.manager, artifact.version, artifact.path)
 ```
@@ -51,6 +62,23 @@ for artifact in list_artifacts():
 `fetch()` obtains every safely and legally downloadable artifact needed by the
 named wrapper. It does not install Python packages, execute upstream setup
 scripts, or duplicate caches owned by another package.
+
+mhctools-managed snapshots default to the platform's user data directory
+(`~/Library/Application Support/mhctools` on macOS,
+`~/.local/share/mhctools` on Linux). Set `MHCTOOLS_DATA_DIR`, pass
+`--data-dir`, or use the Python `data_dir=` argument to put them on shared or
+scratch storage. Every snapshot lives under
+`artifacts/<tool>/<git-commit>/` and includes `.mhctools-artifact.json` with
+its source repository, exact commit, sparse paths, and license provenance.
+
+The `MANAGER` column distinguishes four ownership models:
+
+- `mhctools package` / `<package> package`: weights shipped in an installed
+  Python package;
+- `mhcflurry`: MHCflurry's own native download cache;
+- `mhctools`: a pinned snapshot fetched into the directory above;
+- `user` / `manual`: an existing checkout or licensed executable owned by the
+  user. Manual artifacts are listed but `fetch` will not redistribute them.
 
 ## Quick start
 
@@ -263,17 +291,19 @@ MHC allele.
 from mhctools import Tulip, TCR
 
 tcr = TCR(cdr3a="CAGASGNTGKLIF", cdr3b="CASSIRASYEQYF", name="clone1")
-predictor = Tulip()                       # needs TULIP_HOME + TULIP_PYTHON
+Tulip.fetch()                             # pinned code, tokenizers, and weights
+predictor = Tulip()                       # also needs a TULIP-capable Python
 results = predictor.predict(["GILGFVFTL"], [tcr], mhc="HLA-A*02:01")
 results[0].preds[0].score                 # higher = more likely binding
 ```
 
 [TULIP-TCR](https://github.com/barthelemymp/TULIP-TCR) is **GPLv3** and pinned to
 `transformers==4.32.1`; mhctools is Apache-2.0 and depends on neither torch nor
-transformers. The `Tulip` wrapper therefore vendors none of TULIP — it runs a
-user-provided checkout out-of-process, in an isolated interpreter, via TULIP's
-own `predict.py`. Set two things up first (see `scripts/setup_tulip_env.sh`,
-which does both):
+transformers. The `Tulip` wrapper therefore vendors none of TULIP — it runs an
+upstream checkout out-of-process, in an isolated interpreter, via TULIP's own
+`predict.py`. `mhctools fetch tulip` obtains the tested code, tokenizers, and
+weights; `scripts/setup_tulip_env.sh` can build the separate runtime. You may
+instead provide your own checkout and interpreter:
 
 - `TULIP_HOME` — a clone of TULIP-TCR (provides `predict.py`, `src/`, tokenizers,
   and the released `model_weights/`);
@@ -329,7 +359,7 @@ affinity, hours for stability). `percentile_rank` is always optional,
 | `NetMHCstabpan` | stability | [NetMHCstabpan](https://services.healthtech.dtu.dk/services/NetMHCstabpan-1.0/) |
 | `MHCflurry` | affinity + presentation + processing | `pip install mhcflurry` + `mhctools fetch mhcflurry` |
 | `MHCflurry_Affinity` | affinity | `pip install mhcflurry` + `mhctools fetch mhcflurry-affinity` |
-| `BigMHC` | presentation or immunogenicity | [BigMHC](https://github.com/KarchinLab/bigmhc) clone (set `BIGMHC_DIR`) |
+| `BigMHC` | presentation or immunogenicity | `mhctools fetch bigmhc --accept-license` + PyTorch, or set `BIGMHC_DIR` |
 | `MixMHCpred` | presentation (class I) | [MixMHCpred](https://github.com/GfellerLab/MixMHCpred) |
 | `MixMHC2pred` | presentation (class II) | [MixMHC2pred](https://github.com/GfellerLab/MixMHC2pred) release (has `PWMdef/`) |
 | `IedbNetMHCpan` / `IedbSMM` / `IedbNetMHCIIpan` | affinity | IEDB web API |
@@ -464,7 +494,7 @@ by_protein = predictor.predict_proteins({"TP53": "MEEPQ..."}, peptide_lengths=[1
 
 | Predictor | Kinds produced | Requires |
 |---|---|---|
-| `DeepTAP` | TAP transport (`tap_transport`) | [DeepTAP](https://github.com/zjupgx/DeepTAP) clone (set `DEEPTAP_HOME`) |
+| `DeepTAP` | TAP transport (`tap_transport`) | `mhctools fetch deeptap` + a DeepTAP-capable Python |
 
 TAP (transporter associated with antigen processing) is the step that shuttles
 cytosolic peptides into the ER for MHC-I loading — a distinct part of the
@@ -477,13 +507,15 @@ affinity in nM is also surfaced as `value` (lower = stronger).
 
 DeepTAP ships its weights in-repo and is Apache-2.0, but pins an old
 `pytorch-lightning`, so mhctools shells out to DeepTAP's own CLI in a
-user-provided checkout, run by a user-provided interpreter (the checkpoints load
-fine under modern Lightning too). Set `DEEPTAP_HOME` to the clone and, if the
-current interpreter lacks torch, `DEEPTAP_PYTHON` to one that has it.
+separate interpreter (the checkpoints load fine under modern Lightning too).
+Run `mhctools fetch deeptap`; if the current interpreter lacks torch, set
+`DEEPTAP_PYTHON` to one that has it. `DEEPTAP_HOME` can still select a manual
+checkout.
 
 ```python
 from mhctools import DeepTAP
 
+DeepTAP.fetch()
 predictor = DeepTAP(task_type="cla")       # resolves DEEPTAP_HOME / ~/DeepTAP
 results = predictor.predict(["SIINFEKL", "AEASAAAAY"])
 results[1].tap_transport.score             # 0-1, higher = stronger TAP binding
@@ -497,7 +529,7 @@ results[1].tap_transport.score             # 0-1, higher = stronger TAP binding
 
 | Predictor | Kinds produced | Requires |
 |---|---|---|
-| `ERAMER` | ERAP1 trimming (`erap_trimming`) | [ERAMER](https://github.com/aalokaily/ERAMER) clone with `PWM.xlsx` (set `ERAMER_HOME`) + `openpyxl` |
+| `ERAMER` | ERAP1 trimming (`erap_trimming`) | `mhctools fetch eramer` + `openpyxl` |
 
 ERAP1 trims the N-termini of 9–16mer precursor peptides in the ER down to the
 8–10mers MHC-I presents — the step between TAP transport and MHC loading, and
@@ -510,11 +542,13 @@ likely trimmed).
 ERAMER is **GPLv3** and its PWM ships in a GPL-licensed `PWM.xlsx`, so mhctools
 vendors neither: this is a clean-room Python-3 reimplementation of the
 (Python-2.7) tool's trimming-cascade average that loads the PWM from a
-user-provided ERAMER checkout at runtime. Point at the clone with `ERAMER_HOME`.
+upstream ERAMER checkout at runtime. Run `mhctools fetch eramer`, or point at a
+manual clone with `ERAMER_HOME`.
 
 ```python
 from mhctools import ERAMER
 
+ERAMER.fetch()
 predictor = ERAMER(epitope_length=8)       # resolves ERAMER_HOME / ~/ERAMER
 results = predictor.predict(["GGGGGVVVVVVAAAEE"])   # a 9-16mer precursor
 results[0].erap_trimming.score
@@ -528,9 +562,9 @@ results[0].erap_trimming.score
 | Predictor | Kinds produced | Requires |
 |---|---|---|
 | `Calis` | immunogenicity | nothing — self-contained |
-| `BigMHC_IM` | immunogenicity | [BigMHC](https://github.com/KarchinLab/bigmhc) clone (set `BIGMHC_DIR`) |
+| `BigMHC_IM` | immunogenicity | `mhctools fetch bigmhc --accept-license` + PyTorch, or set `BIGMHC_DIR` |
 | `PRIME` | immunogenicity | [PRIME](https://github.com/GfellerLab/PRIME) clone + MixMHCpred |
-| `DeepImmuno` | immunogenicity | [DeepImmuno](https://github.com/frankligy/DeepImmuno) clone (set `DEEPIMMUNO_HOME`) |
+| `DeepImmuno` | immunogenicity | `mhctools fetch deepimmuno` + a TensorFlow/Keras-2-capable Python |
 | `TLimmuno2` | immunogenicity (class II) | [TLimmuno2](https://github.com/XSLiuLab/TLimmuno2) clone (set `TLIMMUNO2_HOME`) |
 
 `Calis` is the classic sequence-only IEDB class-I immunogenicity model (Calis et
@@ -574,7 +608,8 @@ nearest it knows. It emits one `immunogenicity` prediction per (peptide,
 allele); `score` is in 0–1 (higher = more immunogenic). DeepImmuno ships its
 weights in-repo and is MIT-licensed, but its script loads them with an old
 Keras 2 / TensorFlow stack, so mhctools shells out to DeepImmuno's own CLI in a
-user-provided checkout. Point at the clone with `DEEPIMMUNO_HOME`, and set
+separate checkout. Run `mhctools fetch deepimmuno`, or point at a manual clone
+with `DEEPIMMUNO_HOME`, and set
 `DEEPIMMUNO_PYTHON` to an interpreter that has TensorFlow (with Keras 2, or
 newer TensorFlow plus the `tf-keras` shim — the wrapper sets
 `TF_USE_LEGACY_KERAS=1` for the subprocess).
@@ -582,6 +617,7 @@ newer TensorFlow plus the `tf-keras` shim — the wrapper sets
 ```python
 from mhctools import DeepImmuno
 
+DeepImmuno.fetch()
 predictor = DeepImmuno(alleles=["HLA-A*02:01"])   # resolves DEEPIMMUNO_HOME / ~/DeepImmuno
 results = predictor.predict(["NLVPMVATV", "GILGFVFTL"])
 results[0].immunogenicity.score                   # 0.9568 (higher = more immunogenic)
@@ -631,7 +667,7 @@ results[0].immunogenicity.score                    # 0.9874 (higher = more immun
 
 | Predictor | Kinds produced | Requires |
 |---|---|---|
-| `NetTCR` | pMHC:TCR binding | [NetTCR-2.2](https://github.com/mnielLab/NetTCR-2.2) clone (set `NETTCR_DIR`) + a TFLite runtime (`pip install mhctools[nettcr]`) |
+| `NetTCR` | pMHC:TCR binding | `mhctools fetch nettcr --accept-license` + a TFLite runtime (`pip install mhctools[nettcr]`) |
 
 `NetTCR` predicts whether a paired αβ T-cell receptor recognises a
 (class-I) peptide. Unlike the MHC-ligand predictors, its input is a peptide
@@ -643,6 +679,7 @@ ensemble in-process and does not need NetTCR's conda environment.
 ```python
 from mhctools import NetTCR, TCR
 
+NetTCR.fetch(accept_license=True)  # downloads only the ~8 MB pan ensemble
 predictor = NetTCR()   # resolves NETTCR_DIR / ~/NetTCR-2.2
 tcr = TCR(
     cdr1a="NSASQS", cdr2a="VYSSG", cdr3a="VVEGDKVI",

--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -17,7 +17,14 @@ from .pred import (
 from .sample import MultiSample
 from .tcr import TCR
 from .annotate import AnnotationSpec, annotate_table, parse_annotation_spec
-from .artifacts import ArtifactStatus, fetch, list_artifacts
+from .artifacts import (
+    ArtifactStatus,
+    artifact_status,
+    data_path,
+    fetch,
+    list_artifacts,
+    managed_path,
+)
 from .iedb import (
     IedbNetMHCcons,
     IedbNetMHCpan,
@@ -114,8 +121,11 @@ __all__ = [
     "annotate_table",
     "parse_annotation_spec",
     "ArtifactStatus",
+    "artifact_status",
+    "data_path",
     "fetch",
     "list_artifacts",
+    "managed_path",
     "BindingPrediction",
     "BindingPredictionCollection",
     "set_log_level",

--- a/mhctools/artifacts.py
+++ b/mhctools/artifacts.py
@@ -15,16 +15,23 @@
 """Discover and fetch model artifacts used by mhctools predictors.
 
 Predictors that already manage their own downloads retain ownership of their
-cache.  mhctools provides a common entry point and reports the resolved path;
-it does not copy those artifacts into a second cache.
+cache. For upstream repositories that have no download manager, mhctools can
+install a pinned, minimal git snapshot in its data directory. Other tools are
+inventory-only because their licenses or distribution mechanisms require a
+manual installation.
 """
 
 from dataclasses import asdict, dataclass
 from importlib import metadata, util
+import json
 import os
 from pathlib import Path
 import shutil
 import subprocess
+import sys
+import tempfile
+
+from platformdirs import user_data_path
 
 
 @dataclass(frozen=True)
@@ -42,6 +49,200 @@ class ArtifactStatus:
     def to_dict(self):
         """Return a JSON-serializable representation."""
         return asdict(self)
+
+
+@dataclass(frozen=True)
+class _Snapshot:
+    """A tested upstream git snapshot that mhctools can acquire."""
+
+    repository: str
+    revision: str
+    required_paths: tuple
+    sparse_paths: tuple = ()
+    sparse_cone: bool = True
+    required_globs: tuple = ()
+    license_name: str = ""
+    license_url: str = ""
+    acceptance_required: bool = False
+    environment_variable: str = ""
+    legacy_paths: tuple = ()
+
+
+# Revisions are deliberately immutable. Updating one is a reviewed mhctools
+# change, which gives wrappers a stable upstream layout and reproducible model
+# identity instead of silently following a moving default branch.
+_SNAPSHOTS = {
+    "bigmhc": _Snapshot(
+        repository="https://github.com/KarchinLab/bigmhc.git",
+        revision="c7e37a249317704bf96a1e3881a7ece3c3c977a6",
+        sparse_paths=("data", "models", "src"),
+        required_paths=("src/bigmhc.py", "data/pseudoseqs.csv", "models"),
+        license_name="BigMHC Academic License",
+        license_url=(
+            "https://github.com/KarchinLab/bigmhc/blob/"
+            "c7e37a249317704bf96a1e3881a7ece3c3c977a6/LICENSE"),
+        acceptance_required=True,
+        environment_variable="BIGMHC_DIR",
+        legacy_paths=("~/bigmhc",),
+    ),
+    "deepimmuno": _Snapshot(
+        repository="https://github.com/frankligy/DeepImmuno.git",
+        revision="df42ac5b6bddfe531268335e2dcb496559cd488b",
+        sparse_paths=("data", "models"),
+        required_paths=("deepimmuno-cnn.py", "data", "models"),
+        license_name="MIT",
+        license_url=(
+            "https://github.com/frankligy/DeepImmuno/blob/"
+            "df42ac5b6bddfe531268335e2dcb496559cd488b/LICENSE"),
+        environment_variable="DEEPIMMUNO_HOME",
+        legacy_paths=("~/DeepImmuno",),
+    ),
+    "deeptap": _Snapshot(
+        repository="https://github.com/zjupgx/DeepTAP.git",
+        revision="d2dad5bdea146ecc245304f509e97ae8137f94fd",
+        sparse_paths=("data", "model"),
+        required_paths=("deeptap.py", "data", "model"),
+        license_name="Apache-2.0",
+        license_url=(
+            "https://github.com/zjupgx/DeepTAP/blob/"
+            "d2dad5bdea146ecc245304f509e97ae8137f94fd/LICENSE"),
+        environment_variable="DEEPTAP_HOME",
+        legacy_paths=("~/DeepTAP",),
+    ),
+    "eramer": _Snapshot(
+        repository="https://github.com/aalokaily/ERAMER.git",
+        revision="7745d5cf72d99bcda1c73f26ca746d025b46b7f3",
+        required_paths=("PWM.xlsx",),
+        license_name="GPL-3.0",
+        license_url=(
+            "https://github.com/aalokaily/ERAMER/blob/"
+            "7745d5cf72d99bcda1c73f26ca746d025b46b7f3/LICENSE"),
+        environment_variable="ERAMER_HOME",
+        legacy_paths=("~/ERAMER",),
+    ),
+    "nettcr": _Snapshot(
+        repository="https://github.com/mnielLab/NetTCR-2.2.git",
+        revision="7cead3fe6dcb539ff8e2d9121586dafca1e059c2",
+        sparse_paths=(
+            "/README.md",
+            "/academic_software_license_agreement.pdf",
+            "/models/nettcr_2_2_pan/checkpoint/*.tflite",
+        ),
+        sparse_cone=False,
+        required_paths=("models/nettcr_2_2_pan/checkpoint",),
+        required_globs=("models/nettcr_2_2_pan/checkpoint/*.tflite",),
+        license_name="NetTCR Academic Software License Agreement",
+        license_url=(
+            "https://github.com/mnielLab/NetTCR-2.2/blob/"
+            "7cead3fe6dcb539ff8e2d9121586dafca1e059c2/"
+            "academic_software_license_agreement.pdf"),
+        acceptance_required=True,
+        environment_variable="NETTCR_DIR",
+        legacy_paths=("~/NetTCR-2.2", "~/code/NetTCR-2.2"),
+    ),
+    "tulip": _Snapshot(
+        repository="https://github.com/barthelemymp/TULIP-TCR.git",
+        revision="798fab97a3b13d08dcbfc381ea643e8dc14297c2",
+        sparse_paths=(
+            "aatok", "configs", "mhctok", "model_weights", "src"),
+        required_paths=(
+            "predict.py", "aatok", "configs", "mhctok", "model_weights",
+            "src"),
+        license_name="GPL-3.0",
+        license_url=(
+            "https://github.com/barthelemymp/TULIP-TCR/blob/"
+            "798fab97a3b13d08dcbfc381ea643e8dc14297c2/LICENSE"),
+        environment_variable="TULIP_HOME",
+        legacy_paths=("~/TULIP-TCR", "~/code/TULIP-TCR"),
+    ),
+}
+
+
+# These distributions cannot be fetched safely and unattended. They still
+# belong in the inventory so ``mhctools ls`` reports the executable/checkout
+# actually used by their wrappers and identifies who manages it.
+_MANUAL_EXECUTABLES = {
+    "mixmhc2pred": {
+        "environment_variables": ("MIXMHC2PRED_EXECUTABLE",),
+        "executables": ("MixMHC2pred", "MixMHC2pred_unix"),
+        "detail": "Install MixMHC2pred under its upstream license",
+    },
+    "mixmhcpred": {
+        "environment_variables": ("MIXMHCPRED_PATH",),
+        "executables": ("MixMHCpred",),
+        "detail": "Install MixMHCpred under its academic/non-commercial license",
+    },
+    "netchop": {
+        "executables": ("netChop",),
+        "detail": "Install NetChop from DTU Health Tech",
+    },
+    "netmhc": {
+        "executables": ("netMHC",),
+        "detail": "Install NetMHC from DTU Health Tech",
+    },
+    "netmhccons": {
+        "executables": ("netMHCcons",),
+        "detail": "Install NetMHCcons from DTU Health Tech",
+    },
+    "netmhciipan": {
+        "executables": ("netMHCIIpan",),
+        "detail": "Install NetMHCIIpan from DTU Health Tech",
+    },
+    "netmhcpan": {
+        "executables": ("netMHCpan",),
+        "detail": "Install NetMHCpan from DTU Health Tech",
+    },
+    "netmhcstabpan": {
+        "executables": ("netMHCstabpan",),
+        "detail": "Install NetMHCstabpan from DTU Health Tech",
+    },
+    "prime": {
+        "environment_variables": ("PRIME_EXECUTABLE",),
+        "executables": ("PRIME",),
+        "detail": "Install PRIME under its academic/non-commercial license",
+    },
+}
+
+_MANUAL_DIRECTORIES = {
+    "netcleave": {
+        "environment_variable": "NETCLEAVE_DIR",
+        "legacy_paths": ("~/NetCleave", "~/code/NetCleave"),
+        "required_path": "NetCleave.py",
+        "detail": (
+            "Install NetCleave manually; its repository has no license file"),
+    },
+    "tlimmuno2": {
+        "environment_variable": "TLIMMUNO2_HOME",
+        "legacy_paths": ("~/TLimmuno2",),
+        "required_path": "Python/TLimmuno2.py",
+        "detail": (
+            "Install TLimmuno2 manually; its repository has no license file"),
+    },
+}
+
+
+def data_path(data_dir=None):
+    """Return the base directory used for mhctools-managed artifacts.
+
+    The explicit argument takes precedence over ``MHCTOOLS_DATA_DIR`` and the
+    platform-native user data directory.
+    """
+    if data_dir is not None:
+        return Path(data_dir).expanduser().resolve()
+    configured = os.environ.get("MHCTOOLS_DATA_DIR")
+    if configured:
+        return Path(configured).expanduser().resolve()
+    return Path(user_data_path("mhctools", appauthor=False)).resolve()
+
+
+def managed_path(name, data_dir=None):
+    """Return the pinned installation path for an mhctools-managed snapshot."""
+    canonical = _canonical_name(name)
+    try:
+        snapshot = _SNAPSHOTS[canonical]
+    except KeyError:
+        raise ValueError("%s is not an mhctools-managed artifact" % name)
+    return data_path(data_dir) / "artifacts" / canonical / snapshot.revision
 
 
 def _mhcflurry_downloads():
@@ -151,6 +352,7 @@ _STATUS_FUNCTIONS = {
 
 _ALIASES = {
     "mhcflurry-presentation": "mhcflurry",
+    "tulip-tcr": "tulip",
 }
 
 
@@ -159,29 +361,162 @@ def _canonical_name(name):
     return _ALIASES.get(normalized, normalized)
 
 
-def artifact_status(name):
+def _snapshot_is_valid(path, snapshot):
+    path = Path(path)
+    return (
+        all((path / relative).exists() for relative in snapshot.required_paths)
+        and all(list(path.glob(pattern)) for pattern in snapshot.required_globs)
+    )
+
+
+def _managed_snapshot_is_valid(name, path, snapshot):
+    if not _snapshot_is_valid(path, snapshot):
+        return False
+    try:
+        with (Path(path) / ".mhctools-artifact.json").open() as input_file:
+            manifest = json.load(input_file)
+    except (OSError, ValueError):
+        return False
+    return (
+        manifest.get("name") == name
+        and manifest.get("repository") == snapshot.repository
+        and manifest.get("revision") == snapshot.revision
+    )
+
+
+def _user_snapshot_path(name, snapshot):
+    if name == "eramer":
+        pwm_path = os.environ.get("ERAMER_PWM")
+        if pwm_path and Path(pwm_path).expanduser().is_file():
+            return Path(pwm_path).expanduser().resolve()
+    if snapshot.environment_variable:
+        configured = os.environ.get(snapshot.environment_variable)
+        if configured and _snapshot_is_valid(configured, snapshot):
+            return Path(configured).expanduser().resolve()
+    for legacy in snapshot.legacy_paths:
+        candidate = Path(legacy).expanduser()
+        if _snapshot_is_valid(candidate, snapshot):
+            return candidate.resolve()
+    return None
+
+
+def _snapshot_status(name, data_dir=None):
+    snapshot = _SNAPSHOTS[name]
+    user_path = _user_snapshot_path(name, snapshot)
+    if user_path is not None:
+        return ArtifactStatus(
+            name=name,
+            status="ready",
+            manager="user",
+            version="unknown",
+            path=str(user_path),
+            fetchable=True,
+            detail="Using an existing user-managed upstream installation",
+        )
+
+    path = managed_path(name, data_dir=data_dir)
+    ready = _managed_snapshot_is_valid(name, path, snapshot)
+    detail = "Pinned upstream snapshot managed by mhctools"
+    if path.exists() and not ready:
+        detail = "Managed destination is incomplete or has invalid provenance"
+    if snapshot.acceptance_required:
+        detail += "; initial fetch requires explicit acceptance of %s (%s)" % (
+            snapshot.license_name, snapshot.license_url)
+    return ArtifactStatus(
+        name=name,
+        status="ready" if ready else "missing",
+        manager="mhctools",
+        version=snapshot.revision,
+        path=str(path),
+        fetchable=True,
+        detail=detail,
+    )
+
+
+def _manual_executable_status(name):
+    definition = _MANUAL_EXECUTABLES[name]
+    path = ""
+    for variable in definition.get("environment_variables", ()):
+        configured = os.environ.get(variable)
+        if configured:
+            candidate = Path(configured).expanduser()
+            if candidate.is_dir() and name == "mixmhcpred":
+                candidate = candidate / "MixMHCpred"
+            if candidate.is_file():
+                path = str(candidate)
+                break
+    if not path:
+        for executable in definition["executables"]:
+            path = shutil.which(executable) or ""
+            if path:
+                break
+    return ArtifactStatus(
+        name=name,
+        status="ready" if path else "missing",
+        manager="manual",
+        version="unknown" if path else "",
+        path=os.path.abspath(path) if path else "",
+        fetchable=False,
+        detail=definition["detail"],
+    )
+
+
+def _manual_directory_status(name):
+    definition = _MANUAL_DIRECTORIES[name]
+    candidates = []
+    configured = os.environ.get(definition["environment_variable"])
+    if configured:
+        candidates.append(Path(configured).expanduser())
+    candidates.extend(Path(path).expanduser() for path in definition["legacy_paths"])
+    root = next((
+        path.resolve() for path in candidates
+        if (path / definition["required_path"]).is_file()), None)
+    return ArtifactStatus(
+        name=name,
+        status="ready" if root else "missing",
+        manager="manual",
+        version="unknown" if root else "",
+        path=str(root) if root else "",
+        fetchable=False,
+        detail=definition["detail"],
+    )
+
+
+def _all_names():
+    return set(_STATUS_FUNCTIONS) | set(_SNAPSHOTS) | set(
+        _MANUAL_EXECUTABLES) | set(_MANUAL_DIRECTORIES)
+
+
+def artifact_status(name, data_dir=None):
     """Return the current status for a named predictor's artifacts."""
     canonical = _canonical_name(name)
+    if canonical in _SNAPSHOTS:
+        return _snapshot_status(canonical, data_dir=data_dir)
+    if canonical in _MANUAL_EXECUTABLES:
+        return _manual_executable_status(canonical)
+    if canonical in _MANUAL_DIRECTORIES:
+        return _manual_directory_status(canonical)
     try:
         status_function = _STATUS_FUNCTIONS[canonical]
     except KeyError:
         raise ValueError(
             "Unknown artifact %r. Available: %s" % (
-                name, ", ".join(sorted(_STATUS_FUNCTIONS))))
+                name, ", ".join(sorted(_all_names()))))
     return status_function()
 
 
-def list_artifacts(names=None):
-    """List known packaged, native, and optionally downloadable artifacts."""
+def list_artifacts(names=None, data_dir=None):
+    """List known packaged, native, managed, and manual artifacts."""
     if names is None:
-        canonical_names = sorted(_STATUS_FUNCTIONS)
+        canonical_names = sorted(_all_names())
     else:
         canonical_names = []
         for name in names:
             canonical = _canonical_name(name)
             if canonical not in canonical_names:
                 canonical_names.append(canonical)
-    return [artifact_status(name) for name in canonical_names]
+    return [
+        artifact_status(name, data_dir=data_dir) for name in canonical_names]
 
 
 def _fetch_mhcflurry(name, download_name, relative_path, version=None):
@@ -218,7 +553,8 @@ def _fetch_mhcflurry(name, download_name, relative_path, version=None):
 
     resolved_version = str(version) if version is not None else ""
     if not resolved_version:
-        resolved_version = str(_mhcflurry_downloads().get_current_release() or "custom")
+        resolved_version = str(
+            _mhcflurry_downloads().get_current_release() or "custom")
     return ArtifactStatus(
         name=name,
         status="ready",
@@ -230,11 +566,134 @@ def _fetch_mhcflurry(name, download_name, relative_path, version=None):
     )
 
 
-def fetch(name, version=None):
+def _resolve_revision(name, snapshot, version):
+    if version is None or version == "default":
+        return snapshot.revision
+    requested = str(version).lower()
+    if snapshot.revision.lower().startswith(requested):
+        return snapshot.revision
+    raise ValueError(
+        "%s is tested only at revision %s, not %s" % (
+            name, snapshot.revision, version))
+
+
+def _run_git(arguments):
+    executable = shutil.which("git")
+    if executable is None:
+        raise RuntimeError("git is required to fetch upstream model artifacts")
+    # Keep command progress visible without corrupting ``fetch --json`` stdout.
+    subprocess.run(
+        [executable] + list(arguments), check=True, stdout=sys.stderr)
+
+
+def _fetch_snapshot(name, version=None, data_dir=None, accept_license=False):
+    snapshot = _SNAPSHOTS[name]
+    revision = _resolve_revision(name, snapshot, version)
+    target = managed_path(name, data_dir=data_dir)
+    if target.exists():
+        if _managed_snapshot_is_valid(name, target, snapshot):
+            return ArtifactStatus(
+                name=name,
+                status="ready",
+                manager="mhctools",
+                version=revision,
+                path=str(target),
+                fetchable=True,
+                detail="Pinned upstream snapshot managed by mhctools",
+            )
+        raise RuntimeError(
+            "Artifact directory exists but is incomplete: %s. Move it aside "
+            "and fetch again." % target)
+
+    if snapshot.acceptance_required and not accept_license:
+        raise RuntimeError(
+            "%s is distributed under the %s. Review %s, then rerun with "
+            "--accept-license (or accept_license=True)." % (
+                name, snapshot.license_name, snapshot.license_url))
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    temporary_root = Path(tempfile.mkdtemp(
+        prefix=".%s-" % name, dir=str(target.parent)))
+    checkout = temporary_root / "checkout"
+    try:
+        _run_git(("init", str(checkout)))
+        _run_git(("-C", str(checkout), "remote", "add", "origin",
+                  snapshot.repository))
+        if snapshot.sparse_paths:
+            mode = "--cone" if snapshot.sparse_cone else "--no-cone"
+            _run_git((
+                "-C", str(checkout), "sparse-checkout", "init", mode))
+            _run_git((
+                "-C", str(checkout), "sparse-checkout", "set", mode)
+                + snapshot.sparse_paths)
+        _run_git(("-C", str(checkout), "fetch", "--depth", "1",
+                  "--filter=blob:none", "origin", revision))
+        _run_git(("-C", str(checkout), "checkout", "--detach", "FETCH_HEAD"))
+        executable = shutil.which("git")
+        result = subprocess.run(
+            [executable, "-C", str(checkout), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        actual_revision = result.stdout.strip()
+        if actual_revision != revision:
+            raise RuntimeError(
+                "Expected revision %s but git checked out %s" % (
+                    revision, actual_revision))
+        if not _snapshot_is_valid(checkout, snapshot):
+            raise RuntimeError(
+                "%s revision %s lacks files required by its mhctools wrapper"
+                % (name, revision))
+
+        manifest = {
+            "license": snapshot.license_name,
+            "license_accepted": bool(
+                snapshot.acceptance_required and accept_license),
+            "license_url": snapshot.license_url,
+            "name": name,
+            "repository": snapshot.repository,
+            "revision": revision,
+            "sparse_paths": list(snapshot.sparse_paths),
+        }
+        with (checkout / ".mhctools-artifact.json").open("w") as output:
+            json.dump(manifest, output, indent=2, sort_keys=True)
+            output.write("\n")
+        # The checked-out content is immutable and identified by the manifest;
+        # discard git objects so large model blobs are not stored twice.
+        shutil.rmtree(checkout / ".git")
+        try:
+            checkout.rename(target)
+        except FileExistsError:
+            if not _managed_snapshot_is_valid(name, target, snapshot):
+                raise
+    except subprocess.CalledProcessError as error:
+        raise RuntimeError(
+            "Could not fetch %s revision %s with git" % (name, revision)) from error
+    finally:
+        shutil.rmtree(temporary_root, ignore_errors=True)
+
+    return ArtifactStatus(
+        name=name,
+        status="ready",
+        manager="mhctools",
+        version=revision,
+        path=str(target),
+        fetchable=True,
+        detail="Pinned upstream snapshot managed by mhctools",
+    )
+
+
+def fetch(
+        name,
+        version=None,
+        data_dir=None,
+        accept_license=False):
     """Fetch a predictor's external artifacts and return their status.
 
-    Native download managers retain ownership of their files. Predictors whose
-    parameters are already packaged are treated as successful no-ops.
+    Native download managers retain ownership of their files. Tested upstream
+    snapshots are installed under :func:`data_path`. Predictors whose
+    parameters are already packaged are successful no-ops.
     """
     canonical = _canonical_name(name)
     if canonical == "mhcflurry":
@@ -251,8 +710,18 @@ def fetch(name, version=None):
             relative_path="models.combined",
             version=version,
         )
+    if canonical in _SNAPSHOTS:
+        current = _snapshot_status(canonical, data_dir=data_dir)
+        if data_dir is None and version is None and current.status == "ready":
+            return current
+        return _fetch_snapshot(
+            canonical,
+            version=version,
+            data_dir=data_dir,
+            accept_license=accept_license,
+        )
 
-    status = artifact_status(canonical)
+    status = artifact_status(canonical, data_dir=data_dir)
     if status.status == "ready":
         if version is not None and version != status.version:
             raise ValueError(

--- a/mhctools/bigmhc.py
+++ b/mhctools/bigmhc.py
@@ -56,9 +56,14 @@ def _find_bigmhc_dir(bigmhc_path=None):
     home = os.path.join(os.path.expanduser("~"), "bigmhc")
     if os.path.isdir(home):
         return home
+    from .artifacts import artifact_status
+    managed = artifact_status("bigmhc")
+    if managed.manager == "mhctools" and managed.status == "ready":
+        return managed.path
     raise FileNotFoundError(
         "BigMHC not found. Set BIGMHC_DIR or pass bigmhc_path= to the constructor. "
-        "Clone from https://github.com/KarchinLab/bigmhc")
+        "Run `mhctools fetch bigmhc --accept-license` or clone from "
+        "https://github.com/KarchinLab/bigmhc")
 
 
 def _import_bigmhc_modules(bigmhc_dir):
@@ -101,6 +106,16 @@ class BigMHC(NewModelPredictorMixin):
     """
 
     VALID_MODES = ("el", "im")
+
+    @classmethod
+    def fetch(cls, version=None, data_dir=None, accept_license=False):
+        """Fetch the pinned BigMHC code and weights."""
+        from .artifacts import fetch
+        return fetch(
+            "bigmhc",
+            version=version,
+            data_dir=data_dir,
+            accept_license=accept_license)
 
     def __init__(self, alleles, mode="el", bigmhc_path=None, device="cpu",
                  max_batch_size=4096):

--- a/mhctools/cli/artifacts.py
+++ b/mhctools/cli/artifacts.py
@@ -50,10 +50,13 @@ def ls_main(args_list=None):
     )
     parser.add_argument("name", nargs="*", help="Optional artifact names")
     parser.add_argument(
+        "--data-dir",
+        help="Override MHCTOOLS_DATA_DIR for mhctools-managed artifacts")
+    parser.add_argument(
         "--json", action="store_true", help="Emit machine-readable JSON")
     args = parser.parse_args(args_list)
     try:
-        statuses = list_artifacts(args.name or None)
+        statuses = list_artifacts(args.name or None, data_dir=args.data_dir)
     except ValueError as error:
         parser.error(str(error))
     if args.json:
@@ -72,10 +75,22 @@ def fetch_main(args_list=None):
     parser.add_argument(
         "--version", help="Specific upstream artifact release to fetch")
     parser.add_argument(
+        "--data-dir",
+        help="Override MHCTOOLS_DATA_DIR for mhctools-managed artifacts")
+    parser.add_argument(
+        "--accept-license",
+        action="store_true",
+        help="Confirm acceptance when an upstream license requires it")
+    parser.add_argument(
         "--json", action="store_true", help="Emit machine-readable JSON")
     args = parser.parse_args(args_list)
     try:
-        status = fetch(args.name, version=args.version)
+        status = fetch(
+            args.name,
+            version=args.version,
+            data_dir=args.data_dir,
+            accept_license=args.accept_license,
+        )
     except (RuntimeError, ValueError) as error:
         parser.error(str(error))
     if args.json:

--- a/mhctools/deepimmuno.py
+++ b/mhctools/deepimmuno.py
@@ -22,8 +22,9 @@ BigMHC_IM), emitting ``Kind.immunogenicity`` per (peptide, allele).
 DeepImmuno ships its trained CNN weights in-repo (MIT-licensed) but its
 ``deepimmuno-cnn.py`` script rebuilds the network in code and loads those
 weights with an old Keras 2 / TensorFlow stack. To keep that dependency out of
-the mhctools environment, this wrapper shells out to that script in a
-user-provided checkout (``DEEPIMMUNO_HOME``), run by a user-provided interpreter
+the mhctools environment, this wrapper shells out to that script in an upstream
+checkout (fetched with ``mhctools fetch deepimmuno`` or set by
+``DEEPIMMUNO_HOME``), run by a user-provided interpreter
 (``DEEPIMMUNO_PYTHON``, default the current one). On newer TensorFlow the
 interpreter only needs the ``tf-keras`` shim installed — this wrapper sets
 ``TF_USE_LEGACY_KERAS=1`` for the subprocess so DeepImmuno's Keras-2 model
@@ -70,9 +71,14 @@ def _find_deepimmuno_home(deepimmuno_home=None):
         if isdir(home):
             candidate = home
     if not candidate:
+        from .artifacts import artifact_status
+        managed = artifact_status("deepimmuno")
+        if managed.manager == "mhctools" and managed.status == "ready":
+            candidate = managed.path
+    if not candidate:
         raise FileNotFoundError(
             "DeepImmuno not found. Set DEEPIMMUNO_HOME or pass deepimmuno_home= "
-            "to the constructor. Clone from "
+            "to the constructor. Run `mhctools fetch deepimmuno` or clone from "
             "https://github.com/frankligy/DeepImmuno")
     if not isfile(join(candidate, "deepimmuno-cnn.py")):
         raise FileNotFoundError(
@@ -123,6 +129,12 @@ class DeepImmuno(NewModelPredictorMixin):
         ``$DEEPIMMUNO_PYTHON``, then the current interpreter
         (``sys.executable``).
     """
+
+    @classmethod
+    def fetch(cls, version=None, data_dir=None):
+        """Fetch the pinned DeepImmuno code and weights."""
+        from .artifacts import fetch
+        return fetch("deepimmuno", version=version, data_dir=data_dir)
 
     def __init__(self, alleles, deepimmuno_home=None, deepimmuno_python=None):
         if isinstance(alleles, str):

--- a/mhctools/deeptap.py
+++ b/mhctools/deeptap.py
@@ -26,8 +26,9 @@ peptide once, so ``predict()`` returns one prediction per peptide (with an empty
 
 DeepTAP ships its pretrained weights in-repo (Apache-2.0) but pins an old stack
 (pytorch-lightning==1.9.2, torch). To keep that out of the mhctools environment,
-this wrapper shells out to DeepTAP's own ``deeptap.py`` CLI in a user-provided
-checkout (``DEEPTAP_HOME``), run by a user-provided interpreter
+this wrapper shells out to DeepTAP's own ``deeptap.py`` CLI in an upstream
+checkout (fetched with ``mhctools fetch deeptap`` or set by ``DEEPTAP_HOME``),
+run by a user-provided interpreter
 (``DEEPTAP_PYTHON``, default the current one); the checkpoints also load under
 modern Lightning.
 
@@ -72,9 +73,15 @@ def _find_deeptap_home(deeptap_home=None):
         if isdir(home):
             candidate = home
     if not candidate:
+        from .artifacts import artifact_status
+        managed = artifact_status("deeptap")
+        if managed.manager == "mhctools" and managed.status == "ready":
+            candidate = managed.path
+    if not candidate:
         raise FileNotFoundError(
             "DeepTAP not found. Set DEEPTAP_HOME or pass deeptap_home= to the "
-            "constructor. Clone from https://github.com/zjupgx/DeepTAP")
+            "constructor. Run `mhctools fetch deeptap` or clone from "
+            "https://github.com/zjupgx/DeepTAP")
     if not isfile(join(candidate, "deeptap.py")):
         raise FileNotFoundError(
             "deeptap.py not found in %r — is this a DeepTAP checkout?"
@@ -102,6 +109,12 @@ class DeepTAP(AlleleFreePredictor):
         Peptides longer than this are rejected. Capped at DeepTAP's hard limit
         of 17. Default 17.
     """
+
+    @classmethod
+    def fetch(cls, version=None, data_dir=None):
+        """Fetch the pinned DeepTAP code and weights."""
+        from .artifacts import fetch
+        return fetch("deeptap", version=version, data_dir=data_dir)
 
     def __init__(
             self,

--- a/mhctools/eramer.py
+++ b/mhctools/eramer.py
@@ -24,9 +24,9 @@ over each residue trimmed off as it is cut down to a target epitope length.
 Licensing: ERAMER is GPLv3 and its PWM ships in a GPL-licensed ``PWM.xlsx``;
 mhctools is Apache-2.0 and vendors neither. This is a clean-room Python-3
 reimplementation of the trimming-cascade average (the upstream tool is Python
-2.7) that loads the PWM from a user-provided ERAMER checkout at runtime, as the
-netMHC / MixMHCpred wrappers read user-provided model files. Point at the
-checkout with ``ERAMER_HOME`` (or pass ``eramer_home=`` / ``pwm_path=``).
+2.7) that loads the PWM from an upstream ERAMER checkout at runtime. Fetch the
+tested snapshot with ``mhctools fetch eramer``, or point at a manual checkout
+with ``ERAMER_HOME`` (or pass ``eramer_home=`` / ``pwm_path=``).
 
 Upstream: https://github.com/aalokaily/ERAMER
 Cite: Al-okaily et al., Comput. Biol. Med. 2024 — "ERAMER: A novel in silico
@@ -85,6 +85,10 @@ def _find_pwm_path(eramer_home=None, pwm_path=None):
     home = join(os.path.expanduser("~"), "ERAMER")
     if isdir(home):
         candidates.append(join(home, "PWM.xlsx"))
+    from .artifacts import artifact_status
+    managed = artifact_status("eramer")
+    if managed.manager == "mhctools" and managed.status == "ready":
+        candidates.append(join(managed.path, "PWM.xlsx"))
     for candidate in candidates:
         if isfile(candidate):
             return candidate
@@ -183,6 +187,12 @@ class ERAMER(AlleleFreePredictor):
     """
 
     mhc_class = "I"
+
+    @classmethod
+    def fetch(cls, version=None, data_dir=None):
+        """Fetch the pinned ERAMER PWM and upstream license."""
+        from .artifacts import fetch
+        return fetch("eramer", version=version, data_dir=data_dir)
 
     def __init__(self, epitope_length=8, eramer_home=None, pwm_path=None):
         if not (8 <= epitope_length <= ERAMER_MAX_PRECURSOR_LENGTH - 1):

--- a/mhctools/nettcr.py
+++ b/mhctools/nettcr.py
@@ -22,7 +22,8 @@ Unlike the DTU ``netMHC*`` tools, NetTCR ships its pretrained weights
 directly in its git repository as small TFLite models (the pan ensemble is
 20 models of ~0.4 MB each). This wrapper runs them **in-process** through a
 TFLite interpreter — it does *not* need NetTCR's conda environment. We only
-require the cloned repository (for the weights) and a TFLite runtime
+require the model snapshot (``mhctools fetch nettcr --accept-license``) and a
+TFLite runtime
 (``ai-edge-litert``, ``tflite-runtime``, or ``tensorflow``).
 
 The BLOSUM50 encoding, per-feature padding lengths, and name-based input
@@ -183,9 +184,14 @@ def _find_nettcr_dir(nettcr_path=None):
             os.path.join(home, "code", "NetTCR-2.2")):
         if os.path.isdir(candidate):
             return candidate
+    from .artifacts import artifact_status
+    managed = artifact_status("nettcr")
+    if managed.manager == "mhctools" and managed.status == "ready":
+        return managed.path
     raise FileNotFoundError(
         "NetTCR-2.2 not found. Set NETTCR_DIR or pass nettcr_path= to the "
-        "constructor. %s" % clone_hint)
+        "constructor. Run `mhctools fetch nettcr --accept-license`. %s"
+        % clone_hint)
 
 
 def _encode_feature(sequences, feature):
@@ -236,12 +242,22 @@ class NetTCR(object):
     Notes
     -----
     NetTCR-2.2 is distributed under an academic software license; this
-    wrapper only *runs* a user-provided installation and vendors none of it.
+    wrapper only *runs* an upstream installation and vendors none of it.
 
     The cached ensemble interpreters are stateful, so a single ``NetTCR``
     instance is not safe to call from multiple threads concurrently; use one
     instance per thread.
     """
+
+    @classmethod
+    def fetch(cls, version=None, data_dir=None, accept_license=False):
+        """Fetch the pinned NetTCR pan-ensemble weights."""
+        from .artifacts import fetch
+        return fetch(
+            "nettcr",
+            version=version,
+            data_dir=data_dir,
+            accept_license=accept_license)
 
     def __init__(self, nettcr_path=None, checkpoint_dir=None):
         self.nettcr_dir = _find_nettcr_dir(nettcr_path)

--- a/mhctools/tulip.py
+++ b/mhctools/tulip.py
@@ -24,15 +24,16 @@ TULIP-TCR is distributed under the **GPLv3** and is coupled to a specific,
 old transformers release (``transformers==4.32.1``); mhctools is Apache-2.0
 and depends on neither torch nor transformers. To keep the two apart in both
 senses, this wrapper **vendors none of TULIP** — no source, no weights, no
-tokenizers. It runs the user's own TULIP checkout as a black box, in a
-separate interpreter, by invoking TULIP's own ``predict.py`` via subprocess
+tokenizers. It runs an upstream TULIP checkout as a black box, in a separate
+interpreter, by invoking TULIP's own ``predict.py`` via subprocess
 (the same "shell out to a user-provided install" pattern used for the DTU
 ``netMHC*`` tools and NetTCR). Nothing here imports TULIP's GPL code.
 
 You therefore need two things, supplied via constructor arguments or
 environment variables:
 
-* ``TULIP_HOME`` — a clone of https://github.com/barthelemymp/TULIP-TCR
+* ``TULIP_HOME`` — an optional manual clone of
+  https://github.com/barthelemymp/TULIP-TCR
   (provides ``predict.py``, ``src/``, ``aatok/``, ``mhctok/``, ``configs/``
   and the released ``model_weights/``).
 * ``TULIP_PYTHON`` — a Python interpreter that can import TULIP, i.e. an
@@ -95,9 +96,13 @@ def _find_tulip_home(tulip_home=None):
             os.path.join(home, "code", "TULIP-TCR")):
         if os.path.isfile(os.path.join(candidate, "predict.py")):
             return candidate
+    from .artifacts import artifact_status
+    managed = artifact_status("tulip")
+    if managed.manager == "mhctools" and managed.status == "ready":
+        return managed.path
     raise FileNotFoundError(
         "TULIP-TCR not found. Set TULIP_HOME or pass tulip_home= to the "
-        "constructor. %s" % _CLONE_HINT)
+        "constructor. Run `mhctools fetch tulip`. %s" % _CLONE_HINT)
 
 
 def _find_tulip_python(tulip_python=None):
@@ -144,9 +149,15 @@ class Tulip(object):
 
     Notes
     -----
-    TULIP-TCR is GPLv3; this wrapper vendors none of it and only runs a
-    user-provided installation out-of-process.
+    TULIP-TCR is GPLv3; this wrapper vendors none of it and only runs an
+    upstream installation out-of-process.
     """
+
+    @classmethod
+    def fetch(cls, version=None, data_dir=None):
+        """Fetch the pinned TULIP code, tokenizers, and weights."""
+        from .artifacts import fetch
+        return fetch("tulip", version=version, data_dir=data_dir)
 
     def __init__(
             self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
   "sercol>=0.0.2",
   "mhcflurry>=2.0.0",
   "mhcgnomes>=3.4.0",
+  "platformdirs>=3.0.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ varcode>=0.5.9
 sercol>=0.0.2,<1.0.0
 mhcflurry>=2.0.0,<3.0.0
 mhcgnomes>=3.4.0
+platformdirs>=3.0.0

--- a/scripts/setup_tulip_env.sh
+++ b/scripts/setup_tulip_env.sh
@@ -16,7 +16,8 @@
 #   scripts/setup_tulip_env.sh [ENV_DIR] [TULIP_HOME]
 #
 #   ENV_DIR     where to create the venv        (default: ./tulip-env)
-#   TULIP_HOME  where to clone/find TULIP-TCR   (default: ./TULIP-TCR)
+#   TULIP_HOME  existing TULIP-TCR snapshot (default: `mhctools fetch tulip`,
+#               falling back to ./TULIP-TCR when mhctools is unavailable)
 #
 # After it runs, export the two variables it prints, e.g.:
 #   export TULIP_HOME=/path/to/TULIP-TCR
@@ -25,7 +26,7 @@
 set -euo pipefail
 
 ENV_DIR="${1:-./tulip-env}"
-TULIP_HOME="${2:-./TULIP-TCR}"
+TULIP_HOME="${2:-${TULIP_HOME:-}}"
 PY311="${TULIP_SETUP_PYTHON:-python3.11}"
 TULIP_REPO="https://github.com/barthelemymp/TULIP-TCR.git"
 
@@ -37,8 +38,17 @@ if ! command -v "$PY311" >/dev/null 2>&1; then
     exit 1
 fi
 
-# Clone TULIP-TCR (GPLv3) if it isn't already present. We never redistribute
-# it; you obtain it yourself under its own license.
+# Prefer mhctools' pinned, sparse snapshot. JSON stdout remains parseable while
+# git progress goes to stderr; Python 3.11 is already guaranteed above.
+if [[ -z "$TULIP_HOME" ]] && command -v mhctools >/dev/null 2>&1; then
+    log "Fetching the pinned TULIP-TCR snapshot with mhctools"
+    TULIP_JSON="$(mhctools fetch tulip --json)"
+    TULIP_HOME="$(printf '%s' "$TULIP_JSON" | "$PY311" -c \
+        'import json, sys; print(json.load(sys.stdin)["path"])')"
+fi
+TULIP_HOME="${TULIP_HOME:-./TULIP-TCR}"
+
+# Clone TULIP-TCR (GPLv3) if neither the managed nor a supplied snapshot exists.
 if [[ ! -f "$TULIP_HOME/predict.py" ]]; then
     log "Cloning TULIP-TCR (GPLv3) into $TULIP_HOME"
     git clone --depth 1 "$TULIP_REPO" "$TULIP_HOME"

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -4,7 +4,10 @@
 #
 #       http://www.apache.org/licenses/LICENSE-2.0
 
+import json
 from pathlib import Path
+import subprocess
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -18,13 +21,20 @@ from mhctools.cli.script import main
 def test_list_includes_native_and_packaged_artifacts():
     statuses = {status.name: status for status in list_artifacts()}
     assert set(statuses) == {
-        "calis", "mhcflurry", "mhcflurry-affinity", "pepsickle"}
+        "bigmhc", "calis", "deepimmuno", "deeptap", "eramer",
+        "mhcflurry", "mhcflurry-affinity", "mixmhc2pred", "mixmhcpred",
+        "netchop", "netcleave", "netmhc", "netmhccons", "netmhciipan",
+        "netmhcpan", "netmhcstabpan", "nettcr", "pepsickle", "prime",
+        "tlimmuno2", "tulip"}
     assert statuses["calis"].manager == "mhctools package"
     assert statuses["calis"].status == "ready"
     assert statuses["calis"].fetchable is False
     assert statuses["pepsickle"].manager == "pepsickle package"
     assert statuses["mhcflurry"].manager == "mhcflurry"
     assert statuses["mhcflurry"].fetchable is True
+    assert statuses["deeptap"].manager == "mhctools"
+    assert statuses["mixmhcpred"].manager == "manual"
+    assert statuses["mixmhcpred"].fetchable is False
 
 
 def test_alias_resolves_to_presentation_artifact():
@@ -32,7 +42,7 @@ def test_alias_resolves_to_presentation_artifact():
 
 
 def test_unknown_artifact_error_lists_choices():
-    with pytest.raises(ValueError, match="Available: calis, mhcflurry"):
+    with pytest.raises(ValueError, match="Available: bigmhc, calis"):
         artifact_status("unknown")
 
 
@@ -46,6 +56,117 @@ def test_fetch_packaged_artifact_is_noop():
 def test_fetch_packaged_artifact_rejects_other_version():
     with pytest.raises(ValueError, match="cannot fetch version never"):
         fetch("calis", version="never")
+
+
+def test_data_path_precedence(monkeypatch, tmp_path):
+    configured = tmp_path / "configured"
+    explicit = tmp_path / "explicit"
+    monkeypatch.setenv("MHCTOOLS_DATA_DIR", str(configured))
+    assert artifacts.data_path() == configured
+    assert artifacts.data_path(explicit) == explicit
+
+
+def test_managed_status_reports_destination_and_pinned_version(tmp_path):
+    status = artifact_status("eramer", data_dir=tmp_path)
+    snapshot = artifacts._SNAPSHOTS["eramer"]
+    assert status.status == "missing"
+    assert status.manager == "mhctools"
+    assert status.version == snapshot.revision
+    assert status.path == str(
+        tmp_path / "artifacts" / "eramer" / snapshot.revision)
+
+
+def test_managed_status_rejects_missing_provenance(tmp_path):
+    target = artifacts.managed_path("eramer", data_dir=tmp_path)
+    target.mkdir(parents=True)
+    (target / "PWM.xlsx").touch()
+    status = artifact_status("eramer", data_dir=tmp_path)
+    assert status.status == "missing"
+    assert "invalid provenance" in status.detail
+
+
+def test_managed_status_finds_user_install(monkeypatch, tmp_path):
+    (tmp_path / "PWM.xlsx").touch()
+    monkeypatch.setenv("ERAMER_HOME", str(tmp_path))
+    status = artifact_status("eramer")
+    assert status.status == "ready"
+    assert status.manager == "user"
+    assert status.path == str(tmp_path)
+
+
+def test_eramer_status_finds_direct_pwm(monkeypatch, tmp_path):
+    pwm_path = tmp_path / "custom.xlsx"
+    pwm_path.touch()
+    monkeypatch.setenv("ERAMER_PWM", str(pwm_path))
+    status = artifact_status("eramer")
+    assert status.status == "ready"
+    assert status.manager == "user"
+    assert status.path == str(pwm_path)
+
+
+def test_license_gated_snapshot_requires_acceptance(tmp_path):
+    with pytest.raises(RuntimeError, match="--accept-license"):
+        fetch("nettcr", data_dir=tmp_path)
+
+
+def test_snapshot_rejects_untested_revision(tmp_path):
+    with pytest.raises(ValueError, match="tested only at revision"):
+        fetch("eramer", version="main", data_dir=tmp_path)
+
+
+def test_fetches_pinned_sparse_snapshot(monkeypatch, tmp_path):
+    source = tmp_path / "source"
+    source.mkdir()
+    subprocess.run(["git", "init", str(source)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(source), "config", "user.email", "test@example.com"],
+        check=True)
+    subprocess.run(
+        ["git", "-C", str(source), "config", "user.name", "Test"],
+        check=True)
+    (source / "models").mkdir()
+    (source / "models" / "model.bin").write_bytes(b"weights")
+    (source / "ignored").mkdir()
+    (source / "ignored" / "large.bin").write_bytes(b"ignored")
+    subprocess.run(
+        ["git", "-C", str(source), "add", "."], check=True)
+    subprocess.run(
+        ["git", "-C", str(source), "commit", "-m", "fixture"],
+        check=True,
+        capture_output=True)
+    revision = subprocess.check_output(
+        ["git", "-C", str(source), "rev-parse", "HEAD"], text=True).strip()
+    snapshot = artifacts._Snapshot(
+        repository=str(source),
+        revision=revision,
+        sparse_paths=("models",),
+        required_paths=("models/model.bin",),
+        license_name="MIT",
+    )
+    monkeypatch.setitem(artifacts._SNAPSHOTS, "fixture", snapshot)
+
+    status = fetch("fixture", data_dir=tmp_path / "data")
+    path = Path(status.path)
+    assert (path / "models" / "model.bin").read_bytes() == b"weights"
+    assert not (path / "ignored").exists()
+    assert not (path / ".git").exists()
+    manifest = json.loads((path / ".mhctools-artifact.json").read_text())
+    assert manifest["revision"] == revision
+    assert artifact_status("fixture", data_dir=tmp_path / "data").status == "ready"
+
+
+def test_git_progress_is_sent_to_stderr(monkeypatch):
+    calls = []
+    monkeypatch.setattr(artifacts.shutil, "which", lambda name: "/bin/git")
+    monkeypatch.setattr(
+        artifacts.subprocess,
+        "run",
+        lambda command, **kwargs: calls.append((command, kwargs)))
+    artifacts._run_git(("status",))
+    assert calls == [(["/bin/git", "status"], {
+        "check": True,
+        "stdout": sys.stderr,
+    })]
 
 
 def test_mhcflurry_status_uses_native_manager(monkeypatch, tmp_path):
@@ -101,7 +222,10 @@ def test_ls_cli_table(monkeypatch, capsys):
         fetchable=False,
         detail="example",
     )
-    monkeypatch.setattr(artifact_cli, "list_artifacts", lambda names: [status])
+    monkeypatch.setattr(
+        artifact_cli,
+        "list_artifacts",
+        lambda names, data_dir=None: [status])
     result = main(["ls"])
     output = capsys.readouterr().out
     assert result is None
@@ -120,7 +244,10 @@ def test_ls_cli_json(monkeypatch, capsys):
         fetchable=True,
         detail="example",
     )
-    monkeypatch.setattr(artifact_cli, "list_artifacts", lambda names: [status])
+    monkeypatch.setattr(
+        artifact_cli,
+        "list_artifacts",
+        lambda names, data_dir=None: [status])
     main(["ls", "--json"])
     output = capsys.readouterr().out
     assert '"name": "example"' in output
@@ -138,7 +265,11 @@ def test_fetch_cli_dispatch(monkeypatch, capsys):
         detail="example",
     )
     monkeypatch.setattr(
-        artifact_cli, "fetch", lambda name, version=None: status)
-    result = main(["fetch", "example", "--version", "v1"])
+        artifact_cli,
+        "fetch",
+        lambda name, version=None, data_dir=None, accept_license=False: status)
+    result = main([
+        "fetch", "example", "--version", "v1", "--data-dir", "/models",
+        "--accept-license"])
     assert result is None
     assert "upstream" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

- add atomic, commit-pinned sparse fetches for DeepTAP, DeepImmuno, ERAMER, TULIP-TCR, NetTCR, and BigMHC
- require explicit license acceptance for NetTCR and BigMHC, and preserve repository, revision, sparse-path, and license provenance in each installation
- teach wrapper constructors and class-level `fetch()` methods to use the managed snapshots automatically
- expand `mhctools ls` to inventory bundled weights, MHCflurry-managed downloads, mhctools-managed snapshots, user checkouts, and manual licensed executables
- add `MHCTOOLS_DATA_DIR` / `--data-dir`, JSON-safe fetch output, and TULIP setup-script integration

MixMHCpred, MixMHC2pred, PRIME, DTU tools, NetCleave, and TLimmuno2 remain inventory-only because mhctools cannot safely redistribute them under their current terms.

## Verification

- `./lint.sh`
- `./test.sh` — 699 passed, 53 skipped, 2 xfailed
- real ERAMER fetch and wrapper resolution
- real NetTCR sparse fetch: 20 checkpoints, 7.9 MB installed, all checkpoints load
- NetTCR upstream-reference regression: 28 passed, including all six published ensemble anchors

This builds on #271 and removes the artifact-acquisition part of iskandr/eureka-bench#159.