### PR TITLE
Add MixTCRpred model catalog and wrapper

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,6 +67,7 @@ jobs:
             tests/test_caphla.py \
             tests/test_unparseable_alleles.py \
             tests/test_nettcr.py \
+            tests/test_mixtcrpred.py \
             tests/test_tulip.py \
             tests/test_random.py
 
@@ -240,3 +241,41 @@ jobs:
 
       - name: Run CapHLA official regression
         run: python -m pytest tests/test_caphla.py -ra
+
+  integration-mixtcrpred:
+    # Upstream code is academic/non-commercial and is fetched directly after
+    # explicit acceptance; it is never copied into the mhctools distribution.
+    if: github.repository == 'openvax/mhctools'
+    runs-on: ubuntu-22.04
+    env:
+      MHCTOOLS_DATA_DIR: ${{ github.workspace }}/mhctools-data
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install current CPU PyTorch, Lightning, and mhctools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install torch torchvision \
+            --index-url https://download.pytorch.org/whl/cpu
+          python -m pip install -e ".[dev,mixtcrpred]"
+
+      - name: Cache pinned MixTCRpred source and weights
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.MHCTOOLS_DATA_DIR }}
+          key: mixtcrpred-${{ runner.os }}-${{ hashFiles('mhctools/artifacts.py', 'mhctools/mixtcrpred.py') }}
+
+      - name: Fetch licensed source and one optional Zenodo model
+        run: |
+          mhctools fetch mixtcrpred --accept-license \
+            --model A0201_NLVPMVATV
+
+      - name: Run MixTCRpred catalog, download, and inference regression
+        run: python -m pytest tests/test_mixtcrpred.py -ra

--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ mhctools fetch eramer
 # Academic licenses must be reviewed and accepted explicitly.
 mhctools fetch nettcr --accept-license
 
+# MixTCRpred includes two upstream checkpoints; fetch another by model name.
+mhctools fetch mixtcrpred --accept-license
+mhctools fetch mixtcrpred --model A0201_NLVPMVATV
+mhctools ls mixtcrpred --models --downloaded
+
 # Machine-readable inventory, optionally rooted somewhere else.
 mhctools ls --json
 mhctools ls --data-dir /shared/models
@@ -79,6 +84,13 @@ The `MANAGER` column distinguishes four ownership models:
 - `mhctools`: a pinned snapshot fetched into the directory above;
 - `user` / `manual`: an existing checkout or licensed executable owned by the
   user. Manual artifacts are listed but `fetch` will not redistribute them.
+
+Small published models such as CALIS remain fully embedded in the mhctools
+package and appear as `mhctools package`; they never require a separate fetch.
+The DTU NetMHC-family downloads are identity-bound licenses: DTU requires a
+name, position, academic email, affiliation, acceptance, and then sends a
+private download link. Therefore `--accept-license` cannot substitute for the
+official DTU request form, and these installations remain `manual` inventory.
 
 ## Quick start
 
@@ -276,18 +288,60 @@ Examples:
 | `ERAMER` | `erap_trimming` | `none` | `I` |
 | `NetTCR` | `pMHC_TCR_binding` | `none` | `I` |
 | `Tulip` | `pMHC_TCR_binding` | `single_allele` | `I` |
+| `MixTCRpred` | `pMHC_TCR_binding` | `single_allele` | model-specific |
 | `BigMHC_IM` | `immunogenicity` | `single_allele` | `I` |
 | `PRIME` | `immunogenicity` | `single_allele` | `I` |
 | `DeepImmuno` | `immunogenicity` | `single_allele` | `I` |
 | `TLimmuno2` | `immunogenicity` | `single_allele` | `II` |
 | `Calis` | `immunogenicity` | `none` | `I` |
 
-### TCR predictors (`NetTCR`, `Tulip`)
+### TCR predictors (`NetTCR`, `Tulip`, `MixTCRpred`)
 
 `NetTCR` and `Tulip` predict pMHC:TCR binding — whether a paired αβ T-cell
 receptor (an `mhctools.TCR`, described by its CDR loops) recognises a peptide.
 Both take `(peptide, TCR)` inputs; `Tulip` additionally takes the presenting
 MHC allele.
+
+MixTCRpred has a different, deliberately explicit shape: each checkpoint is
+trained for one fixed peptide/MHC target. Its catalog currently contains 147
+models (43 marked high-confidence by upstream), spanning human/mouse class I
+and II targets. The input `TCR` stores paired CDR3s and optional `trav`, `traj`,
+`trbv`, and `trbj` assignments. Released models use CDR3alpha/beta plus CDR1/2
+derived from the V genes; J assignments are accepted and QC-reported but are
+not network inputs.
+
+```sh
+pip install "mhctools[mixtcrpred]"
+mhctools fetch mixtcrpred --accept-license
+mhctools ls mixtcrpred --models --high-confidence
+mhctools fetch mixtcrpred --model A0201_GILGFVFTL
+mhctools mixtcrpred --model A0201_GILGFVFTL \
+  --input paired-tcrs.csv --out scored-tcrs.csv
+```
+
+```python
+from mhctools import MixTCRpred, TCR
+
+models = MixTCRpred.catalog()
+target = MixTCRpred.resolve_model("GILGFVFTL", "HLA-A*02:01")
+predictor = MixTCRpred(target.name)
+tcr = TCR(
+    cdr3a="CAGASGNTGKLIF", cdr3b="CASSIRASYEQYF",
+    trav="TRAV27", traj="TRAJ42", trbv="TRBV19", trbj="TRBJ2-6",
+)
+prediction = predictor.predict_tcrs([tcr])[0]
+prediction.score
+prediction.percentile_rank
+```
+
+`annotate_dataframe()` and the CSV command retain the original table and add
+the raw score, percentile rank, fixed target metadata, corrected V/J names,
+V-derived CDR1/2 loops, and upstream-equivalent QC warning. MixTCRpred code is
+academic/non-commercial and fetched directly from its original repository
+only after explicit acceptance. Optional checkpoints come from the authors'
+immutable CC-BY-4.0 Zenodo record and are checksum-verified before use.
+As with any PyTorch checkpoint, explicit overrides and user-managed model files
+must come from a trusted source because loading can execute serialized code.
 
 ```python
 from mhctools import Tulip, TCR
@@ -711,6 +765,7 @@ results[0].immunogenicity.score                    # 0.9874 (higher = more immun
 | Predictor | Kinds produced | Requires |
 |---|---|---|
 | `NetTCR` | pMHC:TCR binding | `mhctools fetch nettcr --accept-license` + a TFLite runtime (`pip install mhctools[nettcr]`) |
+| `MixTCRpred` | fixed-pMHC:TCR binding | `pip install "mhctools[mixtcrpred]"` + `mhctools fetch mixtcrpred --accept-license` |
 
 `NetTCR` predicts whether a paired αβ T-cell receptor recognises a
 (class-I) peptide. Unlike the MHC-ligand predictors, its input is a peptide

--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -87,6 +87,8 @@ _LAZY_IMPORTS = {
     "CapHLA_EL": (".caphla", "CapHLA_EL"),
     "MHCflurry": (".mhcflurry", "MHCflurry"),
     "MHCflurry_Affinity": (".mhcflurry", "MHCflurry_Affinity"),
+    "MixTCRpred": (".mixtcrpred", "MixTCRpred"),
+    "MixTCRpredModel": (".mixtcrpred", "MixTCRpredModel"),
     "NetTCR": (".nettcr", "NetTCR"),
     "Tulip": (".tulip", "Tulip"),
 }
@@ -196,6 +198,8 @@ __all__ = [
     "CapHLA",
     "CapHLA_BA",
     "CapHLA_EL",
+    "MixTCRpred",
+    "MixTCRpredModel",
     "NetTCR",
     "Tulip",
     "RandomBindingPredictor",

--- a/mhctools/artifacts.py
+++ b/mhctools/artifacts.py
@@ -154,6 +154,32 @@ _SNAPSHOTS = {
         environment_variable="NETTCR_DIR",
         legacy_paths=("~/NetTCR-2.2", "~/code/NetTCR-2.2"),
     ),
+    "mixtcrpred": _Snapshot(
+        repository="https://github.com/GfellerLab/MixTCRpred.git",
+        revision="acd6f57444bde675840890207c74ca3b0c7ffac2",
+        sparse_paths=("src", "pretrained_models"),
+        required_paths=(
+            "LICENSE.md",
+            "MixTCRpred.py",
+            "src/dataloaders.py",
+            "src/models.py",
+            "src/utils.py",
+            "pretrained_models/anchors_perc_rank.pickle",
+            "pretrained_models/info_models.csv",
+            # These two checkpoints ship in the upstream repository. Keep
+            # them visible alongside optional Zenodo downloads rather than
+            # copying them into a second cache.
+            "pretrained_models/model_A0201_ELAGIGILTV.ckpt",
+            "pretrained_models/model_A0201_GILGFVFTL.ckpt",
+        ),
+        license_name="MixTCRpred Academic Non-Commercial License",
+        license_url=(
+            "https://github.com/GfellerLab/MixTCRpred/blob/"
+            "acd6f57444bde675840890207c74ca3b0c7ffac2/LICENSE.md"),
+        acceptance_required=True,
+        environment_variable="MIXTCRPRED_HOME",
+        legacy_paths=("~/MixTCRpred", "~/code/MixTCRpred"),
+    ),
     "tulip": _Snapshot(
         repository="https://github.com/barthelemymp/TULIP-TCR.git",
         revision="798fab97a3b13d08dcbfc381ea643e8dc14297c2",
@@ -188,27 +214,45 @@ _MANUAL_EXECUTABLES = {
     },
     "netchop": {
         "executables": ("netChop",),
-        "detail": "Install NetChop from DTU Health Tech",
+        "detail": (
+            "Install NetChop from DTU Health Tech; its identity-bound "
+            "request form and emailed private link cannot be replaced by "
+            "--accept-license"),
     },
     "netmhc": {
         "executables": ("netMHC",),
-        "detail": "Install NetMHC from DTU Health Tech",
+        "detail": (
+            "Install NetMHC from DTU Health Tech; its identity-bound "
+            "request form and emailed private link cannot be replaced by "
+            "--accept-license"),
     },
     "netmhccons": {
         "executables": ("netMHCcons",),
-        "detail": "Install NetMHCcons from DTU Health Tech",
+        "detail": (
+            "Install NetMHCcons from DTU Health Tech; its identity-bound "
+            "request form and emailed private link cannot be replaced by "
+            "--accept-license"),
     },
     "netmhciipan": {
         "executables": ("netMHCIIpan",),
-        "detail": "Install NetMHCIIpan from DTU Health Tech",
+        "detail": (
+            "Install NetMHCIIpan from DTU Health Tech; its identity-bound "
+            "request form and emailed private link cannot be replaced by "
+            "--accept-license"),
     },
     "netmhcpan": {
         "executables": ("netMHCpan",),
-        "detail": "Install NetMHCpan from DTU Health Tech",
+        "detail": (
+            "Install NetMHCpan from DTU Health Tech; its identity-bound "
+            "request form and emailed private link cannot be replaced by "
+            "--accept-license"),
     },
     "netmhcstabpan": {
         "executables": ("netMHCstabpan",),
-        "detail": "Install NetMHCstabpan from DTU Health Tech",
+        "detail": (
+            "Install NetMHCstabpan from DTU Health Tech; its identity-bound "
+            "request form and emailed private link cannot be replaced by "
+            "--accept-license"),
     },
     "prime": {
         "environment_variables": ("PRIME_EXECUTABLE",),
@@ -436,6 +480,15 @@ def _snapshot_status(name, data_dir=None):
     if snapshot.acceptance_required:
         detail += "; initial fetch requires explicit acceptance of %s (%s)" % (
             snapshot.license_name, snapshot.license_url)
+    if name == "mixtcrpred" and ready:
+        try:
+            from .mixtcrpred import model_catalog
+            models = model_catalog(mixtcrpred_path=path)
+            downloaded = sum(model.status == "ready" for model in models)
+            detail += "; %d/%d pMHC model weights available" % (
+                downloaded, len(models))
+        except (OSError, RuntimeError, ValueError):
+            pass
     return ArtifactStatus(
         name=name,
         status="ready" if ready else "missing",
@@ -702,7 +755,10 @@ def fetch(
         name,
         version=None,
         data_dir=None,
-        accept_license=False):
+        accept_license=False,
+        models=None,
+        all_models=False,
+        high_confidence=False):
     """Fetch a predictor's external artifacts and return their status.
 
     Native download managers retain ownership of their files. Tested upstream
@@ -710,6 +766,10 @@ def fetch(
     parameters are already packaged are successful no-ops.
     """
     canonical = _canonical_name(name)
+    model_selection = bool(models or all_models or high_confidence)
+    if model_selection and canonical != "mixtcrpred":
+        raise ValueError(
+            "Model selection is supported only for the mixtcrpred artifact")
     if canonical == "mhcflurry":
         return _fetch_mhcflurry(
             name="mhcflurry",
@@ -727,13 +787,24 @@ def fetch(
     if canonical in _SNAPSHOTS:
         current = _snapshot_status(canonical, data_dir=data_dir)
         if data_dir is None and version is None and current.status == "ready":
-            return current
-        return _fetch_snapshot(
-            canonical,
-            version=version,
-            data_dir=data_dir,
-            accept_license=accept_license,
-        )
+            status = current
+        else:
+            status = _fetch_snapshot(
+                canonical,
+                version=version,
+                data_dir=data_dir,
+                accept_license=accept_license,
+            )
+        if canonical == "mixtcrpred" and model_selection:
+            from .mixtcrpred import fetch_models
+            fetch_models(
+                mixtcrpred_path=status.path,
+                models=models,
+                all_models=all_models,
+                high_confidence=high_confidence,
+            )
+            return _snapshot_status(canonical, data_dir=data_dir)
+        return status
 
     status = artifact_status(canonical, data_dir=data_dir)
     if status.status == "ready":

--- a/mhctools/cli/artifacts.py
+++ b/mhctools/cli/artifacts.py
@@ -54,7 +54,31 @@ def ls_main(args_list=None):
         help="Override MHCTOOLS_DATA_DIR for mhctools-managed artifacts")
     parser.add_argument(
         "--json", action="store_true", help="Emit machine-readable JSON")
+    parser.add_argument(
+        "--models", action="store_true",
+        help="List the per-pMHC model catalog (mixtcrpred only)")
+    parser.add_argument(
+        "--downloaded", action="store_true",
+        help="With --models, show only locally available weights")
+    parser.add_argument(
+        "--high-confidence", action="store_true",
+        help="With --models, show only upstream high-confidence models")
     args = parser.parse_args(args_list)
+    if args.models:
+        if args.name != ["mixtcrpred"]:
+            parser.error("--models requires exactly: mhctools ls mixtcrpred")
+        from ..mixtcrpred import print_model_catalog
+        try:
+            return print_model_catalog(
+                data_dir=args.data_dir,
+                downloaded=args.downloaded,
+                high_confidence=args.high_confidence,
+                json_output=args.json,
+            )
+        except (OSError, RuntimeError, ValueError) as error:
+            parser.error(str(error))
+    if args.downloaded or args.high_confidence:
+        parser.error("--downloaded/--high-confidence require --models")
     try:
         statuses = list_artifacts(args.name or None, data_dir=args.data_dir)
     except ValueError as error:
@@ -81,6 +105,16 @@ def fetch_main(args_list=None):
         "--accept-license",
         action="store_true",
         help="Confirm acceptance when an upstream license requires it")
+    selection = parser.add_mutually_exclusive_group()
+    selection.add_argument(
+        "--model", dest="models", action="append", metavar="NAME",
+        help="Fetch one model weight; repeat for multiple models")
+    selection.add_argument(
+        "--all-models", action="store_true",
+        help="Fetch every available model weight (mixtcrpred only)")
+    selection.add_argument(
+        "--high-confidence", action="store_true",
+        help="Fetch upstream's high-confidence weights (mixtcrpred only)")
     parser.add_argument(
         "--json", action="store_true", help="Emit machine-readable JSON")
     args = parser.parse_args(args_list)
@@ -90,6 +124,9 @@ def fetch_main(args_list=None):
             version=args.version,
             data_dir=args.data_dir,
             accept_license=args.accept_license,
+            models=args.models,
+            all_models=args.all_models,
+            high_confidence=args.high_confidence,
         )
     except (RuntimeError, ValueError) as error:
         parser.error(str(error))

--- a/mhctools/cli/mixtcrpred.py
+++ b/mhctools/cli/mixtcrpred.py
@@ -1,0 +1,48 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""CSV prediction command for the MixTCRpred wrapper."""
+
+from argparse import ArgumentParser
+
+import pandas as pd
+
+
+def main(args_list=None):
+    parser = ArgumentParser(
+        prog="mhctools mixtcrpred",
+        description=(
+            "Score a paired-alpha/beta TCR table with one pMHC-specific "
+            "MixTCRpred model."),
+    )
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--input", required=True, help="Input TCR CSV")
+    parser.add_argument("--out", required=True, help="Output annotated CSV")
+    parser.add_argument(
+        "--mixtcrpred-path",
+        help="Licensed upstream checkout (default: MIXTCRPRED_HOME/cache)")
+    parser.add_argument(
+        "--mixtcrpred-python",
+        help="Python with the MixTCRpred optional dependencies")
+    parser.add_argument("--batch-size", type=int, default=256)
+    args = parser.parse_args(args_list)
+
+    # Keep heavyweight/optional predictor imports out of ordinary CLI startup.
+    from ..mixtcrpred import MixTCRpred
+    try:
+        predictor = MixTCRpred(
+            model=args.model,
+            mixtcrpred_path=args.mixtcrpred_path,
+            mixtcrpred_python=args.mixtcrpred_python,
+            batch_size=args.batch_size,
+        )
+        dataframe = pd.read_csv(args.input, keep_default_na=False)
+        output = predictor.annotate_dataframe(dataframe)
+    except (FileNotFoundError, RuntimeError, TypeError, ValueError) as error:
+        parser.error(str(error))
+    output.to_csv(args.out, index=False)
+    print("Wrote: %s (%d rows, %d columns)" % (
+        args.out, len(output), len(output.columns)))

--- a/mhctools/cli/script.py
+++ b/mhctools/cli/script.py
@@ -178,6 +178,9 @@ def main(args_list=None):
     if args_list and args_list[0] == "predict-table":
         from .annotate_table import main as annotate_table_main
         return annotate_table_main(args_list[1:])
+    if args_list and args_list[0] == "mixtcrpred":
+        from .mixtcrpred import main as mixtcrpred_main
+        return mixtcrpred_main(args_list[1:])
 
     args = parse_args(args_list)
     binding_predictions = run_predictor(args)

--- a/mhctools/mixtcrpred.py
+++ b/mhctools/mixtcrpred.py
@@ -1,0 +1,637 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Wrapper for the pMHC-specific MixTCRpred TCR-binding models.
+
+MixTCRpred has one transformer checkpoint per fixed peptide/MHC target. The
+upstream program is academic/non-commercial software and is never vendored by
+mhctools. ``mhctools fetch mixtcrpred --accept-license`` obtains a pinned copy
+from its original repository; additional CC-BY-4.0 checkpoints are downloaded
+individually from the immutable Zenodo record 7930623.
+
+Inference runs upstream's model and input-encoding classes in a subprocess.
+This keeps its runtime dependencies and license boundary separate from the
+Apache-licensed mhctools process while preserving upstream V-gene correction,
+V-derived CDR1/2 encoding, raw binding score, and calibrated percentile rank.
+"""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import asdict, dataclass
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+from urllib.request import urlopen
+
+import pandas as pd
+
+from .allele_normalization import normalize_allele_name_or_raw
+from .pred import COLUMNS, Kind, PeptideResult, Prediction
+from .tcr import TCR
+
+
+UPSTREAM_REVISION = "acd6f57444bde675840890207c74ca3b0c7ffac2"
+ZENODO_RECORD = "7930623"
+ZENODO_API_URL = "https://zenodo.org/api/records/%s" % ZENODO_RECORD
+_MODEL_MANIFEST = ".mhctools-mixtcrpred-models.json"
+_STANDARD_AMINO_ACIDS = frozenset("ACDEFGHIKLMNPQRSTVWYX-")
+_REQUIRED_HOME_PATHS = (
+    "MixTCRpred.py",
+    "src/dataloaders.py",
+    "src/models.py",
+    "src/utils.py",
+    "pretrained_models/anchors_perc_rank.pickle",
+    "pretrained_models/info_models.csv",
+)
+
+
+@dataclass(frozen=True)
+class MixTCRpredModel:
+    """One pMHC-specific model in the upstream MixTCRpred catalog."""
+
+    name: str
+    peptide: str
+    allele: str
+    upstream_allele: str
+    mhc_class: str
+    host_species: str
+    origin: str
+    training_tcrs: int
+    auc_5fold: float
+    high_confidence: bool
+    status: str
+    manager: str
+    path: str
+    version: str = "zenodo.%s" % ZENODO_RECORD
+
+    def to_dict(self):
+        """Return a JSON-serializable representation."""
+        return asdict(self)
+
+
+def _valid_home(path):
+    path = Path(path)
+    return all((path / relative).is_file() for relative in _REQUIRED_HOME_PATHS)
+
+
+def _resolve_home(mixtcrpred_path=None, data_dir=None):
+    """Resolve a user-managed or mhctools-managed MixTCRpred checkout."""
+    for source, value in (
+            ("mixtcrpred_path argument", mixtcrpred_path),
+            ("MIXTCRPRED_HOME", os.environ.get("MIXTCRPRED_HOME"))):
+        if value:
+            path = Path(value).expanduser().resolve()
+            if not _valid_home(path):
+                raise FileNotFoundError(
+                    "MixTCRpred directory from %s is incomplete: %s" % (
+                        source, path))
+            return path
+
+    for value in ("~/MixTCRpred", "~/code/MixTCRpred"):
+        path = Path(value).expanduser()
+        if _valid_home(path):
+            return path.resolve()
+
+    from .artifacts import artifact_status
+    status = artifact_status("mixtcrpred", data_dir=data_dir)
+    if status.status == "ready":
+        return Path(status.path).resolve()
+    raise FileNotFoundError(
+        "MixTCRpred is not installed. Run `mhctools fetch mixtcrpred "
+        "--accept-license`, or set MIXTCRPRED_HOME to a licensed checkout.")
+
+
+def _manager_for_home(home):
+    return (
+        "mhctools"
+        if (Path(home) / ".mhctools-artifact.json").is_file()
+        else "user"
+    )
+
+
+def model_catalog(mixtcrpred_path=None, data_dir=None):
+    """Return all pMHC-specific MixTCRpred models and local weight status."""
+    home = _resolve_home(mixtcrpred_path, data_dir=data_dir)
+    manager = _manager_for_home(home)
+    catalog_path = home / "pretrained_models" / "info_models.csv"
+    result = []
+    with catalog_path.open(newline="") as input_file:
+        for row in csv.DictReader(input_file):
+            name = row["MixTCRpred_model_name"].strip()
+            checkpoint = (
+                home / "pretrained_models" / ("model_%s.ckpt" % name))
+            upstream_class = row["MHC_class"].strip()
+            result.append(MixTCRpredModel(
+                name=name,
+                peptide=row["Peptide"].strip(),
+                allele=normalize_allele_name_or_raw(row["MHC"].strip()),
+                upstream_allele=row["MHC"].strip(),
+                mhc_class={"MHCI": "I", "MHCII": "II"}.get(
+                    upstream_class, upstream_class),
+                host_species=row["Host_species"].strip(),
+                origin=row["Origin"].strip(),
+                training_tcrs=int(row["Number_training_abTCR"]),
+                auc_5fold=float(row["AUC_5fold"]),
+                # Match upstream's --download_high implementation.
+                high_confidence=int(row["Number_training_abTCR"]) >= 50,
+                status="ready" if checkpoint.is_file() else "missing",
+                manager=manager,
+                path=str(checkpoint),
+            ))
+    return tuple(result)
+
+
+def _select_catalog_models(
+        catalog,
+        models=None,
+        all_models=False,
+        high_confidence=False):
+    if sum(bool(value) for value in (models, all_models, high_confidence)) > 1:
+        raise ValueError(
+            "Choose model names, all_models, or high_confidence, not multiple")
+    if all_models:
+        return list(catalog)
+    if high_confidence:
+        return [model for model in catalog if model.high_confidence]
+    if not models:
+        return []
+    if isinstance(models, str):
+        models = [models]
+    by_name = {model.name.lower(): model for model in catalog}
+    selected = []
+    for requested in models:
+        try:
+            model = by_name[str(requested).lower()]
+        except KeyError:
+            raise ValueError(
+                "Unknown MixTCRpred model %r. Use `mhctools ls mixtcrpred "
+                "--models` to inspect the catalog." % requested)
+        if model not in selected:
+            selected.append(model)
+    return selected
+
+
+def _zenodo_files():
+    try:
+        with urlopen(ZENODO_API_URL, timeout=60) as response:
+            record = json.load(response)
+    except (OSError, ValueError) as error:
+        raise RuntimeError(
+            "Could not read MixTCRpred model metadata from %s" %
+            ZENODO_API_URL) from error
+    if str(record.get("id")) != ZENODO_RECORD:
+        raise RuntimeError("Zenodo returned unexpected MixTCRpred record")
+    return {entry["key"]: entry for entry in record.get("files", ())}
+
+
+def _hashes(path):
+    # Zenodo publishes MD5 as its file identity; SHA-256 is recorded too.
+    md5 = hashlib.md5(usedforsecurity=False)
+    sha256 = hashlib.sha256()
+    with Path(path).open("rb") as input_file:
+        for block in iter(lambda: input_file.read(1024 * 1024), b""):
+            md5.update(block)
+            sha256.update(block)
+    return md5.hexdigest(), sha256.hexdigest()
+
+
+def _read_model_manifest(model_dir):
+    path = Path(model_dir) / _MODEL_MANIFEST
+    if not path.is_file():
+        return {"record": ZENODO_RECORD, "models": {}}
+    try:
+        with path.open() as input_file:
+            value = json.load(input_file)
+    except (OSError, ValueError) as error:
+        raise RuntimeError("Invalid MixTCRpred model manifest: %s" % path) from error
+    if str(value.get("record")) != ZENODO_RECORD:
+        raise RuntimeError("Unexpected Zenodo record in %s" % path)
+    value.setdefault("models", {})
+    return value
+
+
+def _write_model_manifest(model_dir, manifest):
+    model_dir = Path(model_dir)
+    destination = model_dir / _MODEL_MANIFEST
+    with tempfile.NamedTemporaryFile(
+            mode="w", dir=str(model_dir), prefix=".manifest-",
+            delete=False) as output:
+        temporary = Path(output.name)
+        json.dump(manifest, output, indent=2, sort_keys=True)
+        output.write("\n")
+    os.replace(str(temporary), str(destination))
+
+
+def _fetch_one_model(model, files, manifest):
+    filename = "model_%s.ckpt" % model.name
+    try:
+        remote = files[filename]
+    except KeyError:
+        raise RuntimeError(
+            "%s is in the upstream catalog but absent from Zenodo record %s"
+            % (model.name, ZENODO_RECORD))
+    expected_md5 = remote["checksum"].removeprefix("md5:")
+    expected_size = int(remote["size"])
+    destination = Path(model.path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+
+    if destination.is_file():
+        actual_md5, actual_sha256 = _hashes(destination)
+        if destination.stat().st_size != expected_size or actual_md5 != expected_md5:
+            raise RuntimeError(
+                "Existing MixTCRpred checkpoint does not match Zenodo: %s. "
+                "Move it aside before fetching again." % destination)
+    else:
+        url = remote["links"]["self"]
+        print("Downloading %s from Zenodo" % model.name, file=sys.stderr)
+        temporary = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                    mode="wb", dir=str(destination.parent),
+                    prefix=".%s-" % filename, delete=False) as output:
+                temporary = Path(output.name)
+                with urlopen(url, timeout=120) as response:
+                    shutil.copyfileobj(response, output, length=1024 * 1024)
+            actual_md5, actual_sha256 = _hashes(temporary)
+            if temporary.stat().st_size != expected_size or actual_md5 != expected_md5:
+                raise RuntimeError(
+                    "Downloaded MixTCRpred checkpoint failed its Zenodo "
+                    "size/checksum verification: %s" % model.name)
+            os.replace(str(temporary), str(destination))
+        finally:
+            if temporary is not None and temporary.exists():
+                temporary.unlink()
+
+    manifest["models"][model.name] = {
+        "filename": filename,
+        "md5": actual_md5,
+        "sha256": actual_sha256,
+        "size": expected_size,
+        "url": remote["links"]["self"],
+    }
+
+
+def fetch_models(
+        mixtcrpred_path=None,
+        data_dir=None,
+        models=None,
+        all_models=False,
+        high_confidence=False):
+    """Fetch selected MixTCRpred weights and return their catalog entries."""
+    home = _resolve_home(mixtcrpred_path, data_dir=data_dir)
+    catalog = model_catalog(mixtcrpred_path=home)
+    selected = _select_catalog_models(
+        catalog,
+        models=models,
+        all_models=all_models,
+        high_confidence=high_confidence,
+    )
+    if not selected:
+        return ()
+    files = _zenodo_files()
+    model_dir = home / "pretrained_models"
+    manifest = _read_model_manifest(model_dir)
+    for model in selected:
+        _fetch_one_model(model, files, manifest)
+        _write_model_manifest(model_dir, manifest)
+    refreshed = {model.name: model for model in model_catalog(mixtcrpred_path=home)}
+    return tuple(refreshed[model.name] for model in selected)
+
+
+def print_model_catalog(
+        mixtcrpred_path=None,
+        data_dir=None,
+        downloaded=False,
+        high_confidence=False,
+        json_output=False):
+    """Print the model catalog for ``mhctools ls mixtcrpred --models``."""
+    models = model_catalog(mixtcrpred_path, data_dir=data_dir)
+    if downloaded:
+        models = tuple(model for model in models if model.status == "ready")
+    if high_confidence:
+        models = tuple(model for model in models if model.high_confidence)
+    if json_output:
+        print(json.dumps([model.to_dict() for model in models], indent=2))
+        return
+    headers = (
+        "MODEL", "PEPTIDE", "MHC", "CLASS", "SPECIES", "TRAINING",
+        "AUC", "CONFIDENCE", "STATUS", "MANAGER", "PATH")
+    rows = [(
+        model.name,
+        model.peptide,
+        model.allele,
+        model.mhc_class,
+        model.host_species,
+        str(model.training_tcrs),
+        "%.3f" % model.auc_5fold,
+        "high" if model.high_confidence else "low",
+        model.status,
+        model.manager,
+        model.path,
+    ) for model in models]
+    widths = [
+        max([len(headers[index])] + [len(row[index]) for row in rows])
+        for index in range(len(headers))
+    ]
+    print("  ".join(
+        value.ljust(widths[index]) for index, value in enumerate(headers)))
+    for row in rows:
+        print("  ".join(
+            value.ljust(widths[index]) for index, value in enumerate(row)))
+
+
+def _resolve_python(mixtcrpred_python=None):
+    value = mixtcrpred_python or os.environ.get("MIXTCRPRED_PYTHON")
+    if value:
+        path = Path(value).expanduser()
+        if path.is_file():
+            # Do not resolve a virtualenv's interpreter symlink: invoking the
+            # target binary directly would discard the environment prefix.
+            return str(path.absolute())
+        executable = shutil.which(str(value))
+        if executable:
+            return executable
+        raise FileNotFoundError("MixTCRpred Python does not exist: %s" % value)
+    return sys.executable
+
+
+def _validate_tcr(tcr):
+    if not isinstance(tcr, TCR):
+        raise TypeError("Expected mhctools.TCR, got %r" % type(tcr))
+    for name in ("cdr3a", "cdr3b"):
+        sequence = getattr(tcr, name)
+        if not sequence:
+            raise ValueError("MixTCRpred requires %s" % name)
+        if len(sequence) > 20:
+            raise ValueError(
+                "MixTCRpred %s is limited to 20 residues: %r" % (
+                    name, sequence))
+        invalid = sorted(set(sequence) - _STANDARD_AMINO_ACIDS)
+        if invalid:
+            raise ValueError(
+                "MixTCRpred %s contains unsupported residues %s: %r" % (
+                    name, ", ".join(invalid), sequence))
+
+
+class MixTCRpred:
+    """Score paired alpha/beta TCRs for one fixed pMHC target.
+
+    Parameters
+    ----------
+    model : str
+        A model name from :meth:`catalog`, for example
+        ``"A0201_GILGFVFTL"``. Each model fixes both peptide and MHC.
+    mixtcrpred_path : str, optional
+        Licensed upstream checkout. Otherwise ``MIXTCRPRED_HOME``, common
+        checkout paths, and the mhctools artifact cache are searched.
+    mixtcrpred_python : str, optional
+        Python interpreter containing upstream's PyTorch/Lightning runtime.
+        Defaults to ``MIXTCRPRED_PYTHON`` and then the current interpreter.
+    checkpoint_path : str, optional
+        Explicit trusted checkpoint override. PyTorch checkpoints may execute
+        code while loading; the normal path is resolved from the pinned or
+        user-managed catalog instead.
+    batch_size : int, optional
+        Deterministic CPU inference batch size.
+
+    Notes
+    -----
+    MixTCRpred accepts J-gene columns but its released network consumes only
+    CDR3alpha/beta and CDR1/2 sequences derived from the V genes. J genes are
+    retained in :class:`TCR` and reported by QC, but do not affect scores.
+    """
+
+    @classmethod
+    def fetch(
+            cls,
+            models=None,
+            version=None,
+            data_dir=None,
+            accept_license=False,
+            all_models=False,
+            high_confidence=False):
+        """Fetch licensed upstream code and selected CC-BY model weights."""
+        from .artifacts import fetch
+        return fetch(
+            "mixtcrpred",
+            version=version,
+            data_dir=data_dir,
+            accept_license=accept_license,
+            models=models,
+            all_models=all_models,
+            high_confidence=high_confidence,
+        )
+
+    @classmethod
+    def catalog(cls, mixtcrpred_path=None, data_dir=None):
+        """Return the available pMHC model catalog."""
+        return model_catalog(mixtcrpred_path, data_dir=data_dir)
+
+    @classmethod
+    def resolve_model(
+            cls, peptide, allele, mixtcrpred_path=None, data_dir=None):
+        """Resolve a unique catalog model from its peptide/MHC target."""
+        normalized = normalize_allele_name_or_raw(allele)
+        matches = [
+            model for model in cls.catalog(mixtcrpred_path, data_dir=data_dir)
+            if model.peptide == str(peptide).upper()
+            and model.allele == normalized
+        ]
+        if len(matches) != 1:
+            raise ValueError(
+                "Expected one MixTCRpred model for %s / %s, found %d" % (
+                    peptide, normalized, len(matches)))
+        return matches[0]
+
+    def __init__(
+            self,
+            model,
+            mixtcrpred_path=None,
+            mixtcrpred_python=None,
+            checkpoint_path=None,
+            batch_size=256):
+        self.mixtcrpred_home = _resolve_home(mixtcrpred_path)
+        self.mixtcrpred_python = _resolve_python(mixtcrpred_python)
+        catalog = model_catalog(mixtcrpred_path=self.mixtcrpred_home)
+        selected = _select_catalog_models(catalog, models=[model])
+        self.model_info = selected[0]
+        self.checkpoint_path = str(
+            Path(checkpoint_path).expanduser().resolve()
+            if checkpoint_path else self.model_info.path)
+        if not Path(self.checkpoint_path).is_file():
+            raise FileNotFoundError(
+                "MixTCRpred checkpoint is missing: %s. Run `mhctools fetch "
+                "mixtcrpred --model %s --accept-license`." % (
+                    self.checkpoint_path, self.model_info.name))
+        if batch_size < 1:
+            raise ValueError("batch_size must be positive")
+        self.batch_size = int(batch_size)
+        self.last_qc = pd.DataFrame()
+
+    def __repr__(self):
+        return "MixTCRpred(model=%s)" % self.model_info.name
+
+    def __str__(self):
+        return repr(self)
+
+    def _predictor_name(self):
+        return "mixtcrpred"
+
+    @property
+    def predictor_version(self):
+        return "%s+zenodo.%s:%s" % (
+            UPSTREAM_REVISION, ZENODO_RECORD, self.model_info.name)
+
+    def kind_support(self):
+        return {
+            Kind.pMHC_TCR_binding: {
+                "mhc_dependence": "single_allele",
+                "mhc_class": self.model_info.mhc_class,
+            }
+        }
+
+    @property
+    def supported_kinds(self):
+        return tuple(self.kind_support())
+
+    def _run_sidecar(self, tcrs):
+        if not tcrs:
+            self.last_qc = pd.DataFrame()
+            return pd.DataFrame(columns=(
+                "__mhctools_id", "score", "percentile_rank"))
+        rows = []
+        for index, tcr in enumerate(tcrs):
+            _validate_tcr(tcr)
+            rows.append({
+                "__mhctools_id": index,
+                "cdr3_TRA": tcr.cdr3a,
+                "cdr3_TRB": tcr.cdr3b,
+                "TRAV": tcr.trav,
+                "TRAJ": tcr.traj,
+                "TRBV": tcr.trbv,
+                "TRBJ": tcr.trbj,
+            })
+        with tempfile.TemporaryDirectory(prefix="mhctools_mixtcrpred_") as tmp:
+            input_path = Path(tmp) / "input.csv"
+            output_path = Path(tmp) / "output.csv"
+            pd.DataFrame(rows).to_csv(input_path, index=False)
+            sidecar = Path(__file__).with_name("mixtcrpred_sidecar.py")
+            command = [
+                self.mixtcrpred_python,
+                "-c",
+                (
+                    "import runpy,sys; sys.argv=sys.argv[1:]; "
+                    "runpy.run_path(sys.argv[0],run_name='__main__')"
+                ),
+                str(sidecar),
+                "--home", str(self.mixtcrpred_home),
+                "--model", self.model_info.name,
+                "--peptide", self.model_info.peptide,
+                "--checkpoint", self.checkpoint_path,
+                "--input", str(input_path),
+                "--output", str(output_path),
+                "--batch-size", str(self.batch_size),
+                "--host", self.model_info.host_species,
+            ]
+            environment = os.environ.copy()
+            # PyTorch 2.6 changed the default and otherwise rejects upstream's
+            # Lightning 1.6 checkpoints before loading their state dict. A
+            # checkpoint can execute code, so managed files are source-pinned
+            # or checksummed and custom/user-managed paths must be trusted.
+            environment["TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD"] = "1"
+            environment["PYTHONNOUSERSITE"] = "1"
+            process = subprocess.run(
+                command,
+                cwd=str(self.mixtcrpred_home),
+                env=environment,
+                capture_output=True,
+                text=True,
+            )
+            if process.returncode != 0:
+                raise RuntimeError(
+                    "MixTCRpred inference failed (exit %d):\n%s" % (
+                        process.returncode,
+                        (process.stderr or process.stdout).strip()))
+            output = pd.read_csv(output_path, keep_default_na=False)
+
+        expected_ids = list(range(len(tcrs)))
+        if sorted(output["__mhctools_id"].tolist()) != expected_ids:
+            raise RuntimeError(
+                "MixTCRpred output did not preserve every input TCR")
+        output = output.sort_values("__mhctools_id").reset_index(drop=True)
+        qc_columns = [
+            column for column in output.columns
+            if column not in ("score", "percentile_rank")
+        ]
+        self.last_qc = output[qc_columns].copy()
+        return output
+
+    def predict_tcrs(self, tcrs):
+        """Return one :class:`Prediction` per input TCR, in input order."""
+        if isinstance(tcrs, TCR):
+            tcrs = [tcrs]
+        tcrs = list(tcrs)
+        output = self._run_sidecar(tcrs)
+        return [
+            Prediction(
+                kind=Kind.pMHC_TCR_binding,
+                score=float(row.score),
+                peptide=self.model_info.peptide,
+                allele=self.model_info.allele,
+                tcr=tcr.identifier,
+                percentile_rank=float(row.percentile_rank),
+                predictor_name=self._predictor_name(),
+                predictor_version=self.predictor_version,
+            )
+            for tcr, row in zip(tcrs, output.itertuples(index=False))
+        ]
+
+    def predict(self, tcrs):
+        """Return one single-prediction :class:`PeptideResult` per TCR."""
+        return [
+            PeptideResult(preds=(prediction,))
+            for prediction in self.predict_tcrs(tcrs)
+        ]
+
+    def predict_dataframe(self, tcrs, sample_name=""):
+        """Return standard mhctools prediction columns for the input TCRs."""
+        if isinstance(tcrs, pd.DataFrame):
+            tcrs = [TCR.from_series(row) for _, row in tcrs.iterrows()]
+        rows = [
+            prediction.to_row(sample_name)
+            for prediction in self.predict_tcrs(tcrs)
+        ]
+        return pd.DataFrame(rows, columns=COLUMNS)
+
+    def annotate_dataframe(self, dataframe):
+        """Preserve a TCR table and append scores, target metadata, and QC.
+
+        This captures the two primary upstream outputs (``score`` and
+        ``perc_rank``), its model-level metadata, and the corrected V/J genes,
+        V-derived CDR1/2 loops, and warning status otherwise written only to
+        upstream's optional logfile.
+        """
+        dataframe = dataframe.copy()
+        tcrs = [TCR.from_series(row) for _, row in dataframe.iterrows()]
+        output = self._run_sidecar(tcrs)
+        dataframe["mixtcrpred_model"] = self.model_info.name
+        dataframe["mixtcrpred_peptide"] = self.model_info.peptide
+        dataframe["mixtcrpred_allele"] = self.model_info.allele
+        dataframe["mixtcrpred_score"] = output["score"].to_numpy()
+        dataframe["mixtcrpred_percentile_rank"] = output[
+            "percentile_rank"].to_numpy()
+        for column in (
+                "trav_corrected", "traj_corrected", "trbv_corrected",
+                "trbj_corrected", "cdr1a_derived", "cdr2a_derived",
+                "cdr1b_derived", "cdr2b_derived", "warning"):
+            dataframe["mixtcrpred_%s" % column] = output[column].to_numpy()
+        return dataframe

--- a/mhctools/mixtcrpred_sidecar.py
+++ b/mhctools/mixtcrpred_sidecar.py
@@ -1,0 +1,123 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Isolated runtime bridge to a user-licensed MixTCRpred checkout."""
+
+from argparse import ArgumentParser
+import os
+from pathlib import Path
+import pickle
+import sys
+
+
+def _parse_args():
+    parser = ArgumentParser()
+    parser.add_argument("--home", required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--peptide", required=True)
+    parser.add_argument("--checkpoint", required=True)
+    parser.add_argument("--input", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--batch-size", type=int, required=True)
+    parser.add_argument("--host", required=True)
+    return parser.parse_args()
+
+
+def _clean_derived(value):
+    return str(value).replace("X", "") if value == value else ""
+
+
+def main():
+    args = _parse_args()
+    home = Path(args.home).resolve()
+    sys.path.insert(0, str(home))
+
+    # Imports deliberately happen only inside this subprocess. The modules
+    # below belong to the separately licensed upstream checkout.
+    import pandas as pd
+    import torch
+    from torch.utils.data import DataLoader
+    from src.dataloaders import db_transformer
+    from src.models import TransformerPredictor_AB_cdr123
+    from src.utils import compute_perc_rank
+
+    frame = pd.read_csv(args.input, keep_default_na=False)
+    dataset = db_transformer(
+        frame,
+        padding=[len(args.peptide), 20, 20, 10],
+        istrain=False,
+        host=args.host,
+    )
+    if len(dataset) != len(frame):
+        raise RuntimeError(
+            "MixTCRpred's input encoder removed one or more validated rows")
+
+    loader = DataLoader(
+        dataset,
+        batch_size=args.batch_size,
+        shuffle=False,
+        num_workers=0,
+    )
+    # The wrapper sets TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD for compatibility with
+    # both the original Lightning 1.6 runtime and current PL. Managed files are
+    # pinned/checksummed; callers must trust explicit or user-managed paths.
+    model = TransformerPredictor_AB_cdr123.load_from_checkpoint(
+        checkpoint_path=args.checkpoint,
+        map_location=torch.device("cpu"),
+    )
+    model.eval()
+    scores = []
+    encoded_names = []
+    with torch.inference_mode():
+        for names, inputs, _ in loader:
+            encoded_names.extend(names)
+            scores.extend(model(inputs, mask=True)[:, 1].cpu().tolist())
+
+    anchor_path = home / "pretrained_models" / "anchors_perc_rank.pickle"
+    with anchor_path.open("rb") as input_file:
+        anchors = pickle.load(input_file)
+    ranks = compute_perc_rank(args.model, anchors, scores)
+
+    if len(scores) != len(frame) or len(encoded_names) != len(frame):
+        raise RuntimeError("MixTCRpred returned an unexpected number of rows")
+
+    corrected = []
+    for encoded in encoded_names:
+        parts = encoded.split("_")
+        if len(parts) != 7:
+            raise RuntimeError("Unexpected MixTCRpred encoded TCR identifier")
+        corrected.append(parts[1:])
+
+    output = pd.DataFrame({
+        "__mhctools_id": frame["__mhctools_id"].astype(int),
+        "score": scores,
+        "percentile_rank": ranks,
+        "trav_corrected": [_clean_derived(value) for value in dataset.TRAV],
+        "traj_corrected": [_clean_derived(value) for value in dataset.TRAJ],
+        "trbv_corrected": [_clean_derived(value) for value in dataset.TRBV],
+        "trbj_corrected": [_clean_derived(value) for value in dataset.TRBJ],
+        "cdr1a_derived": [_clean_derived(row[1]) for row in corrected],
+        "cdr2a_derived": [_clean_derived(row[2]) for row in corrected],
+        "cdr1b_derived": [_clean_derived(row[4]) for row in corrected],
+        "cdr2b_derived": [_clean_derived(row[5]) for row in corrected],
+    })
+    alpha_error = (
+        (output["cdr1a_derived"] == "") |
+        (output["cdr2a_derived"] == ""))
+    beta_error = (
+        (output["cdr1b_derived"] == "") |
+        (output["cdr2b_derived"] == ""))
+    output["warning"] = "-"
+    output.loc[alpha_error, "warning"] = "Error TRAV"
+    output.loc[beta_error, "warning"] = "Error TRBV"
+    output.loc[alpha_error & beta_error, "warning"] = "Error TRAV-TRBV"
+    output.to_csv(args.output, index=False)
+
+
+if __name__ == "__main__":
+    # Avoid user-site packages leaking into an explicitly selected sidecar env.
+    os.environ.setdefault("PYTHONNOUSERSITE", "1")
+    main()

--- a/mhctools/tcr.py
+++ b/mhctools/tcr.py
@@ -18,7 +18,8 @@ predictors (e.g. NetTCR) add a new input modality — the receptor itself,
 represented by its complementarity-determining regions (CDRs) — and a new
 output kind (:attr:`~mhctools.pred.Kind.pMHC_TCR_binding`).
 
-A :class:`TCR` is a paired αβ receptor described by its six CDR loops.
+A :class:`TCR` is a paired αβ receptor described by its six CDR loops and,
+when available, its V/J gene assignments.
 The field names use the biological convention (``cdr1a`` = CDR1 of the α
 chain, ``cdr3b`` = CDR3 of the β chain, ...); the ``a1``/``b3`` short
 forms used by NetTCR are exposed as properties.
@@ -36,6 +37,12 @@ _SHORT_CDR_ALIASES = {
     "b1": "cdr1b",
     "b2": "cdr2b",
     "b3": "cdr3b",
+    "cdr1_tra": "cdr1a",
+    "cdr2_tra": "cdr2a",
+    "cdr3_tra": "cdr3a",
+    "cdr1_trb": "cdr1b",
+    "cdr2_trb": "cdr2b",
+    "cdr3_trb": "cdr3b",
 }
 
 
@@ -52,6 +59,10 @@ class TCR:
     name : str, optional
         Human-readable identifier (e.g. a clonotype name). If omitted,
         :attr:`identifier` falls back to the CDR3α/CDR3β pair.
+    trav, traj, trbv, trbj : str, optional
+        TCR alpha/beta V and J gene assignments. These fields intentionally
+        preserve the caller's spelling: predictor-specific correction and
+        allele handling belong in the predictor adapter.
 
     Notes
     -----
@@ -67,6 +78,12 @@ class TCR:
     cdr2b: str = ""
     cdr3b: str = ""
     name: str = ""
+    # Keep gene fields after ``name`` so existing positional construction of
+    # the original seven-field TCR dataclass remains backward compatible.
+    trav: str = ""
+    traj: str = ""
+    trbv: str = ""
+    trbj: str = ""
 
     # NetTCR-style short aliases -------------------------------------------
     @property
@@ -115,6 +132,15 @@ class TCR:
             "b3": self.cdr3b,
         }
 
+    def gene_dict(self) -> dict:
+        """Return V/J assignments using standard AIRR-style gene names."""
+        return {
+            "TRAV": self.trav,
+            "TRAJ": self.traj,
+            "TRBV": self.trbv,
+            "TRBJ": self.trbj,
+        }
+
     def __str__(self):
         return "TCR(%s)" % self.identifier
 
@@ -129,9 +155,10 @@ class TCR:
     def from_dict(cls, d):
         """Deserialize from a dict.
 
-        Accepts canonical ``cdr1a``..``cdr3b`` keys plus NetTCR/IMMREP-style
-        short aliases ``a1``..``b3`` / ``A1``..``B3``. Canonical field names
-        win if both a canonical key and an alias are present.
+        Accepts canonical ``cdr1a``..``cdr3b`` and ``trav``..``trbj`` keys
+        case-insensitively, plus NetTCR/IMMREP-style short aliases
+        ``a1``..``b3`` / ``A1``..``B3``. Canonical field names win if both a
+        canonical key and an alias are present.
         """
         valid = {f.name for f in fields(cls)}
         values = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,16 @@ nettcr = [
 caphla = [
   "torch>=1.12",
 ]
+mixtcrpred = [
+  # Runtime for the separately licensed upstream checkout. MixTCRpred's
+  # checkpoints were created with Lightning 1.6 but are exercised in CI on a
+  # current PyTorch/Lightning CPU stack.
+  "torch>=1.12",
+  "torchvision",
+  "pytorch-lightning>=1.6",
+  "scipy",
+  "scikit-learn",
+]
 dev = [
   "build",
   # Ruff 0.16 changed its default rule set; keep lint reproducible until #268.

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -23,6 +23,7 @@ def test_list_includes_native_and_packaged_artifacts():
     assert set(statuses) == {
         "bigmhc", "calis", "caphla", "deepimmuno", "deeptap", "eramer",
         "mhcflurry", "mhcflurry-affinity", "mixmhc2pred", "mixmhcpred",
+        "mixtcrpred",
         "netchop", "netcleave", "netmhc", "netmhccons", "netmhciipan",
         "netmhcpan", "netmhcstabpan", "nettcr", "pepsickle", "prime",
         "tlimmuno2", "tulip"}
@@ -35,6 +36,10 @@ def test_list_includes_native_and_packaged_artifacts():
     assert statuses["deeptap"].manager == "mhctools"
     assert statuses["mixmhcpred"].manager == "manual"
     assert statuses["mixmhcpred"].fetchable is False
+    assert "identity-bound" in statuses["netmhcpan"].detail
+    assert "--accept-license" in statuses["netmhcpan"].detail
+    assert statuses["mixtcrpred"].manager == "mhctools"
+    assert statuses["mixtcrpred"].fetchable is True
 
 
 def test_alias_resolves_to_presentation_artifact():
@@ -107,6 +112,8 @@ def test_eramer_status_finds_direct_pwm(monkeypatch, tmp_path):
 def test_license_gated_snapshot_requires_acceptance(tmp_path):
     with pytest.raises(RuntimeError, match="--accept-license"):
         fetch("nettcr", data_dir=tmp_path)
+    with pytest.raises(RuntimeError, match="--accept-license"):
+        fetch("mixtcrpred", data_dir=tmp_path)
 
 
 def test_snapshot_rejects_untested_revision(tmp_path):
@@ -267,9 +274,30 @@ def test_fetch_cli_dispatch(monkeypatch, capsys):
     monkeypatch.setattr(
         artifact_cli,
         "fetch",
-        lambda name, version=None, data_dir=None, accept_license=False: status)
+        lambda name, version=None, data_dir=None, accept_license=False,
+        models=None, all_models=False, high_confidence=False: status)
     result = main([
         "fetch", "example", "--version", "v1", "--data-dir", "/models",
         "--accept-license"])
     assert result is None
     assert "upstream" in capsys.readouterr().out
+
+
+def test_fetch_cli_passes_mixtcrpred_model_selection(monkeypatch):
+    calls = []
+    status = ArtifactStatus(
+        name="mixtcrpred", status="ready", manager="mhctools",
+        version="v1", path="/models", fetchable=True, detail="example")
+
+    def fake_fetch(name, **kwargs):
+        calls.append((name, kwargs))
+        return status
+
+    monkeypatch.setattr(artifact_cli, "fetch", fake_fetch)
+    main([
+        "fetch", "mixtcrpred", "--model", "A0201_GILGFVFTL",
+        "--accept-license",
+    ])
+    assert calls[0][0] == "mixtcrpred"
+    assert calls[0][1]["models"] == ["A0201_GILGFVFTL"]
+    assert calls[0][1]["accept_license"] is True

--- a/tests/test_mixtcrpred.py
+++ b/tests/test_mixtcrpred.py
@@ -277,9 +277,12 @@ def test_real_checkpoint_regression_current_pytorch():
             trbv="TRBV999", trbj="TRBJ999", name="bad-v"),
     ]
     output = predictor.predict_dataframe(tcrs)
+    # Upstream's reference output is published to three decimal places. Keep
+    # that scientifically meaningful precision while tolerating the observed
+    # ~4e-5 CPU-kernel difference between macOS and Linux.
     assert output["score"].tolist() == pytest.approx([
-        3.076019, -1.651455, -1.870569], abs=1e-5)
+        3.076, -1.651, -1.871], abs=5e-4)
     assert output["percentile_rank"].tolist() == pytest.approx([
-        0.001, 22.141987, 28.796943], abs=1e-5)
+        0.001, 22.142, 28.797], abs=5e-4)
     assert predictor.last_qc["warning"].tolist() == [
         "-", "-", "Error TRAV-TRBV"]

--- a/tests/test_mixtcrpred.py
+++ b/tests/test_mixtcrpred.py
@@ -1,0 +1,285 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+"""Tests for the MixTCRpred catalog, downloads, and wrapper."""
+
+from io import BytesIO
+import hashlib
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from mhctools import Kind, MixTCRpred, TCR
+from mhctools import mixtcrpred
+from mhctools.cli.script import main
+
+
+MODEL = "A0201_GILGFVFTL"
+
+
+def _make_home(tmp_path, checkpoint=True):
+    home = tmp_path / "MixTCRpred"
+    for relative in mixtcrpred._REQUIRED_HOME_PATHS:
+        path = home / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.touch()
+    catalog = pd.DataFrame([{
+        "MixTCRpred_model_name": MODEL,
+        "Peptide": "GILGFVFTL",
+        "Origin": "Influenza A virus",
+        "MHC_class": "MHCI",
+        "MHC": "HLA-A*02:01",
+        "Host_species": "HomoSapiens",
+        "Number_training_abTCR": 2079,
+        "AUC_5fold": 0.9432831141,
+    }, {
+        "MixTCRpred_model_name": "DPB10401_TFEYVSQPFLMDLE",
+        "Peptide": "TFEYVSQPFLMDLE",
+        "Origin": "SARS-CoV-2",
+        "MHC_class": "MHCII",
+        "MHC": "HLA-DPB1*04:01",
+        "Host_species": "HomoSapiens",
+        "Number_training_abTCR": 20,
+        "AUC_5fold": 0.7,
+    }])
+    catalog.to_csv(
+        home / "pretrained_models" / "info_models.csv", index=False)
+    model_path = home / "pretrained_models" / ("model_%s.ckpt" % MODEL)
+    if checkpoint:
+        model_path.write_bytes(b"checkpoint")
+    return home
+
+
+def _tcr(name="clone1"):
+    return TCR(
+        cdr3a="CAGASGNTGKLIF",
+        cdr3b="CASSIRASYEQYF",
+        name=name,
+        trav="TRAV27",
+        traj="TRAJ42",
+        trbv="TRBV19",
+        trbj="TRBJ2-6",
+    )
+
+
+def _sidecar_output(count=1):
+    return pd.DataFrame({
+        "__mhctools_id": range(count),
+        "score": [3.076019] * count,
+        "percentile_rank": [0.001] * count,
+        "trav_corrected": ["TRAV27"] * count,
+        "traj_corrected": ["TRAJ42"] * count,
+        "trbv_corrected": ["TRBV19"] * count,
+        "trbj_corrected": ["TRBJ2-6"] * count,
+        "cdr1a_derived": ["SVFSS"] * count,
+        "cdr2a_derived": ["VVTGGEV"] * count,
+        "cdr1b_derived": ["LNHDA"] * count,
+        "cdr2b_derived": ["SQIVND"] * count,
+        "warning": ["-"] * count,
+    })
+
+
+def test_model_catalog_includes_target_metadata_and_weight_status(tmp_path):
+    home = _make_home(tmp_path)
+    models = mixtcrpred.model_catalog(home)
+    assert len(models) == 2
+    assert models[0].name == MODEL
+    assert models[0].allele == "HLA-A*02:01"
+    assert models[0].mhc_class == "I"
+    assert models[0].training_tcrs == 2079
+    assert models[0].high_confidence is True
+    assert models[0].status == "ready"
+    assert models[0].manager == "user"
+    assert models[1].mhc_class == "II"
+    assert models[1].high_confidence is False
+    assert models[1].status == "missing"
+
+
+def test_resolve_model_uses_normalized_allele(tmp_path):
+    home = _make_home(tmp_path)
+    model = MixTCRpred.resolve_model("GILGFVFTL", "HLA-A0201", home)
+    assert model.name == MODEL
+
+
+def test_constructor_requires_selected_checkpoint(tmp_path):
+    home = _make_home(tmp_path, checkpoint=False)
+    with pytest.raises(FileNotFoundError, match="mhctools fetch mixtcrpred"):
+        MixTCRpred(MODEL, mixtcrpred_path=home)
+
+
+def test_predict_maps_score_rank_target_and_version(monkeypatch, tmp_path):
+    home = _make_home(tmp_path)
+    predictor = MixTCRpred(MODEL, mixtcrpred_path=home)
+    monkeypatch.setattr(
+        predictor, "_run_sidecar", lambda tcrs: _sidecar_output(len(tcrs)))
+    result = predictor.predict([_tcr()])[0].preds[0]
+    assert result.kind == Kind.pMHC_TCR_binding
+    assert result.peptide == "GILGFVFTL"
+    assert result.allele == "HLA-A*02:01"
+    assert result.tcr == "clone1"
+    assert result.score == pytest.approx(3.076019)
+    assert result.percentile_rank == pytest.approx(0.001)
+    assert MODEL in result.predictor_version
+    assert predictor.kind_support()[Kind.pMHC_TCR_binding] == {
+        "mhc_dependence": "single_allele",
+        "mhc_class": "I",
+    }
+
+
+def test_annotate_dataframe_captures_scores_metadata_and_qc(
+        monkeypatch, tmp_path):
+    home = _make_home(tmp_path)
+    predictor = MixTCRpred(MODEL, mixtcrpred_path=home)
+    monkeypatch.setattr(
+        predictor, "_run_sidecar", lambda tcrs: _sidecar_output(len(tcrs)))
+    input_df = pd.DataFrame([{
+        "sample": "s1",
+        "cdr3_TRA": "CAGASGNTGKLIF",
+        "cdr3_TRB": "CASSIRASYEQYF",
+        "TRAV": "TRAV27",
+        "TRAJ": "TRAJ42",
+        "TRBV": "TRBV19",
+        "TRBJ": "TRBJ2-6",
+    }])
+    output = predictor.annotate_dataframe(input_df)
+    assert output["sample"].tolist() == ["s1"]
+    assert output["mixtcrpred_model"].tolist() == [MODEL]
+    assert output["mixtcrpred_score"].tolist() == pytest.approx([3.076019])
+    assert output["mixtcrpred_percentile_rank"].tolist() == [0.001]
+    assert output["mixtcrpred_trav_corrected"].tolist() == ["TRAV27"]
+    assert output["mixtcrpred_cdr1a_derived"].tolist() == ["SVFSS"]
+    assert output["mixtcrpred_warning"].tolist() == ["-"]
+
+
+@pytest.mark.parametrize("field,value,error", [
+    ("cdr3a", "", "requires cdr3a"),
+    ("cdr3b", "C" * 21, "limited to 20"),
+    ("cdr3a", "CAV?", "unsupported residues"),
+])
+def test_input_validation(field, value, error):
+    values = _tcr().to_dict()
+    values[field] = value
+    with pytest.raises(ValueError, match=error):
+        mixtcrpred._validate_tcr(TCR.from_dict(values))
+
+
+def test_fetch_models_downloads_atomically_and_records_hashes(
+        monkeypatch, tmp_path):
+    home = _make_home(tmp_path, checkpoint=False)
+    content = b"downloaded checkpoint"
+    md5 = hashlib.md5(content, usedforsecurity=False).hexdigest()
+    record = {
+        "id": int(mixtcrpred.ZENODO_RECORD),
+        "files": [{
+            "key": "model_%s.ckpt" % MODEL,
+            "size": len(content),
+            "checksum": "md5:%s" % md5,
+            "links": {"self": "https://zenodo.example/model"},
+        }],
+    }
+
+    def fake_urlopen(url, timeout):
+        if url == mixtcrpred.ZENODO_API_URL:
+            return BytesIO(json.dumps(record).encode())
+        assert url == "https://zenodo.example/model"
+        return BytesIO(content)
+
+    monkeypatch.setattr(mixtcrpred, "urlopen", fake_urlopen)
+    selected = mixtcrpred.fetch_models(home, models=[MODEL])
+    assert selected[0].status == "ready"
+    assert Path(selected[0].path).read_bytes() == content
+    manifest = json.loads((
+        home / "pretrained_models" /
+        mixtcrpred._MODEL_MANIFEST).read_text())
+    assert manifest["record"] == mixtcrpred.ZENODO_RECORD
+    assert manifest["models"][MODEL]["md5"] == md5
+    assert len(manifest["models"][MODEL]["sha256"]) == 64
+
+
+def test_model_catalog_json_is_serializable(tmp_path):
+    home = _make_home(tmp_path)
+    json.dumps([model.to_dict() for model in MixTCRpred.catalog(home)])
+
+
+def test_ls_models_cli_reports_downloaded_weights(
+        monkeypatch, tmp_path, capsys):
+    home = _make_home(tmp_path)
+    monkeypatch.setenv("MIXTCRPRED_HOME", str(home))
+    main(["ls", "mixtcrpred", "--models", "--downloaded", "--json"])
+    output = json.loads(capsys.readouterr().out)
+    assert [row["name"] for row in output] == [MODEL]
+    assert output[0]["manager"] == "user"
+    assert output[0]["status"] == "ready"
+
+
+def test_prediction_cli_preserves_input_and_appends_all_outputs(
+        monkeypatch, tmp_path):
+    home = _make_home(tmp_path)
+    input_path = tmp_path / "tcrs.csv"
+    output_path = tmp_path / "scored.csv"
+    pd.DataFrame([{
+        "sample": "s1",
+        "cdr3_TRA": "CAGASGNTGKLIF",
+        "cdr3_TRB": "CASSIRASYEQYF",
+        "TRAV": "TRAV27",
+        "TRAJ": "TRAJ42",
+        "TRBV": "TRBV19",
+        "TRBJ": "TRBJ2-6",
+    }]).to_csv(input_path, index=False)
+    monkeypatch.setattr(
+        MixTCRpred,
+        "_run_sidecar",
+        lambda self, tcrs: _sidecar_output(len(tcrs)),
+    )
+
+    main([
+        "mixtcrpred", "--model", MODEL,
+        "--mixtcrpred-path", str(home),
+        "--input", str(input_path), "--out", str(output_path),
+    ])
+
+    output = pd.read_csv(output_path, keep_default_na=False)
+    assert output["sample"].tolist() == ["s1"]
+    assert output["mixtcrpred_score"].tolist() == pytest.approx([3.076019])
+    assert output["mixtcrpred_percentile_rank"].tolist() == [0.001]
+    assert output["mixtcrpred_trav_corrected"].tolist() == ["TRAV27"]
+    assert output["mixtcrpred_warning"].tolist() == ["-"]
+
+
+def _integration_predictor():
+    try:
+        catalog = MixTCRpred.catalog()
+    except FileNotFoundError:
+        pytest.skip("MixTCRpred checkout is not available")
+    model = next((entry for entry in catalog if entry.name == MODEL), None)
+    if model is None or model.status != "ready":
+        pytest.skip("MixTCRpred GILGFVFTL checkpoint is not available")
+    return MixTCRpred(MODEL, batch_size=3)
+
+
+def test_real_checkpoint_regression_current_pytorch():
+    predictor = _integration_predictor()
+    tcrs = [
+        _tcr("one"),
+        TCR(
+            cdr3a="CALSGETSGSRLTF",
+            cdr3b="CASGLVPGGLVYEQYF",
+            trav="TRAV12-2", traj="TRAJ45",
+            trbv="TRBV2", trbj="TRBJ2-5", name="two"),
+        TCR(
+            cdr3a="CAVR", cdr3b="CASS",
+            trav="TRAV999", traj="TRAJ999",
+            trbv="TRBV999", trbj="TRBJ999", name="bad-v"),
+    ]
+    output = predictor.predict_dataframe(tcrs)
+    assert output["score"].tolist() == pytest.approx([
+        3.076019, -1.651455, -1.870569], abs=1e-5)
+    assert output["percentile_rank"].tolist() == pytest.approx([
+        0.001, 22.141987, 28.796943], abs=1e-5)
+    assert predictor.last_qc["warning"].tolist() == [
+        "-", "-", "Error TRAV-TRBV"]

--- a/tests/test_tcr.py
+++ b/tests/test_tcr.py
@@ -43,6 +43,31 @@ def test_cdr_dict_keys_and_values():
         "b1": "LNHDA", "b2": "SQIVND", "b3": "ASSIRAAYEQY"}
 
 
+def test_gene_fields_and_upstream_style_deserialization():
+    t = TCR.from_dict({
+        "cdr3_TRA": "CAVR",
+        "cdr3_TRB": "CASS",
+        "TRAV": "TRAV12-2",
+        "TRAJ": "TRAJ45",
+        "TRBV": "TRBV2",
+        "TRBJ": "TRBJ2-5",
+    })
+    assert t.cdr3a == "CAVR"
+    assert t.cdr3b == "CASS"
+    assert t.gene_dict() == {
+        "TRAV": "TRAV12-2",
+        "TRAJ": "TRAJ45",
+        "TRBV": "TRBV2",
+        "TRBJ": "TRBJ2-5",
+    }
+
+
+def test_gene_fields_do_not_break_original_positional_name_argument():
+    t = TCR("a1", "a2", "a3", "b1", "b2", "b3", "clone")
+    assert t.name == "clone"
+    assert t.trav == ""
+
+
 def test_identifier_uses_name_when_present():
     assert _tcr().identifier == "clone1"
 


### PR DESCRIPTION
## Summary

- extend `TCR` with backward-compatible paired-chain V/J fields and common upstream column aliases
- add a pinned, license-gated MixTCRpred source fetch plus selective checksum-verified Zenodo model downloads
- expose the full 147-target model catalog in Python and through `mhctools ls mixtcrpred --models`, including shipped and optional weights, paths, managers, provenance, training counts, AUCs, and confidence tier
- add fixed-pMHC prediction APIs and a CSV CLI that preserve raw score, percentile rank, corrected V/J genes, V-derived CDR1/2 loops, and QC warnings
- exercise an upstream checkpoint on a current PyTorch/Lightning CPU stack in dedicated CI
- document why small CALIS parameters stay packaged and why DTU identity-bound registrations cannot be automated by `--accept-license`

The released MixTCRpred network consumes paired CDR3s and V-derived CDR1/2. J genes are accepted, corrected, and reported for schema completeness, but they are not network inputs.

Closes #230.
Related: #274.
Upstream runtime report: https://github.com/GfellerLab/MixTCRpred/issues/10

## Verification

- `./lint.sh`
- `./test.sh` — 734 passed, 56 skipped, 2 xfailed
- live current-runtime regression — 13 passed, including the real bundled checkpoint
- clean managed fetch, optional Zenodo download, checksum/provenance manifest, catalog listing, and the official 1,003-row example reproduced locally