### PR TITLE
Add PeptiVerse serum half-life predictor and the serum_half_life kind

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ The canonical prediction kind strings are defined in `mhctools.pred.Kind`.
 | `endolysosomal_cleavage` | Endolysosomal (MHC-II, cathepsin) C-terminal cleavage score |
 | `tap_transport` | TAP transport / binding score |
 | `erap_trimming` | ERAP1 N-terminal trimming score |
+| `serum_half_life` | Degradation half-life of the free peptide in serum, in hours |
 
 Predictors also expose `kind_support()` so downstream code can tell what MHC
 context is meaningful for each emitted kind:
@@ -294,6 +295,7 @@ Examples:
 | `DeepImmuno` | `immunogenicity` | `single_allele` | `I` |
 | `TLimmuno2` | `immunogenicity` | `single_allele` | `II` |
 | `Calis` | `immunogenicity` | `none` | `I` |
+| `PeptiVerse` | `serum_half_life` | `none` | `none` |
 
 ### TCR predictors (`NetTCR`, `Tulip`, `MixTCRpred`)
 
@@ -653,6 +655,50 @@ results[0].erap_trimming.score
 
 > ⚠️ ERAMER's evaluation is self-reported and ERAP1 trimming is an intrinsically
 > noisy signal; treat the score as a pathway prior, not a validated oracle.
+
+### Serum half-life
+
+| Predictor | Kinds produced | Requires |
+|---|---|---|
+| `PeptiVerse` | Serum half-life (`serum_half_life`) | a PeptiVerse snapshot (`PEPTIVERSE_HOME`) + a torch/transformers Python |
+
+How long a **free peptide** survives in blood serum before proteases degrade it,
+in hours. This is a peptide-drug property rather than an immunological one: it
+speaks to whether a synthesized vaccine peptide is still intact when it reaches
+its destination, not to how it is presented.
+
+It is deliberately a separate kind from `pMHC_stability`, which is the
+dissociation half-life of an assembled peptide-MHC complex — a different
+molecule in a different assay — and from the cleavage kinds, which are
+site-resolved and intracellular. Nothing in a `Prediction` records the assay
+matrix, so the kind string carries it: a predictor trained on whole blood,
+plasma or in-vivo PK is not this kind.
+
+`PeptiVerse` wraps one endpoint of the upstream multi-property platform. Its
+dependencies (torch, `transformers==4.46.0`, xgboost, lightning, and the ESM2 /
+PeptideCLM / ChemBERTa embedding models) stay out of the mhctools environment:
+inference runs in a subprocess under `PEPTIVERSE_PYTHON`.
+
+```python
+from mhctools import PeptiVerse
+
+predictor = PeptiVerse(device="cpu")       # resolves PEPTIVERSE_HOME / ~/PeptiVerse
+results = predictor.predict(["SIINFEKL", "KLGGALQAK"])
+results[0].serum_half_life.value           # hours, higher = longer-lived
+```
+
+Sequence input only. Upstream's SMILES models return a number that is *not* on
+the hours scale (the `expm1` inverse transform is applied only to the sequence
+model), and mhctools has nowhere to record a chemical form, so peptides
+containing non-standard residues are rejected rather than scored as their
+unmodified sequence.
+
+> ⚠️ The sequence half-life model was fit on **130 examples** and evaluated by
+> cross-validation only, from a preprint, with no external test set and no
+> evaluation on long vaccine peptides. Upstream declares Apache-2.0 on its model
+> card and MIT in its README. Checkpoints load through
+> `torch.load(weights_only=False)`, which executes pickled code — point
+> `PEPTIVERSE_HOME` only at a snapshot you trust.
 
 ### Immunogenicity
 

--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -44,6 +44,7 @@ from .deeptap import DeepTAP
 from .calis import Calis
 from .eramer import ERAMER
 from .deepimmuno import DeepImmuno
+from .peptiverse import PeptiVerse
 from .tlimmuno2 import TLimmuno2
 from .processing_predictor import (
     ProcessingPredictor,
@@ -106,7 +107,7 @@ def __getattr__(name):
     raise AttributeError(
         "module %r has no attribute %r" % (__name__, name))
 
-__version__ = "3.35.1"
+__version__ = "3.36.0"
 
 __all__ = [
     "Prediction",
@@ -149,6 +150,7 @@ __all__ = [
     "Calis",
     "ERAMER",
     "DeepImmuno",
+    "PeptiVerse",
     "TLimmuno2",
     "MHCflurry",
     "MHCflurry_Affinity",

--- a/mhctools/annotate.py
+++ b/mhctools/annotate.py
@@ -75,6 +75,9 @@ _OUTPUT_FIELDS = {
     "immunogenicity": (Kind.immunogenicity, "score"),
     "tap_transport": (Kind.tap_transport, "score"),
     "erap_trimming": (Kind.erap_trimming, "score"),
+    # Serum half-life of the free peptide, in hours -- distinct from
+    # "stability", which is pMHC complex dissociation.
+    "serum_half_life": (Kind.serum_half_life, "value"),
 }
 
 

--- a/mhctools/peptiverse.py
+++ b/mhctools/peptiverse.py
@@ -1,0 +1,361 @@
+# Copyright (c) 2026 Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Wrapper for PeptiVerse's serum half-life endpoint.
+
+PeptiVerse is a multi-property peptide platform; this wrapper deliberately
+exposes **one** of its endpoints — the degradation half-life of a free peptide
+in human serum, in hours — and emits ``Kind.serum_half_life``.
+
+That is not ``Kind.pMHC_stability``. NetMHCstabpan measures how long an
+assembled peptide-MHC complex holds together; this measures how long the free
+peptide survives in serum before proteases degrade it. Different molecule,
+different assay, different matrix. It is also not a cleavage-site map: a single
+number per peptide says nothing about *where* a peptide gets cut, and must never
+be turned into per-bond probabilities.
+
+Sequence input only
+-------------------
+Upstream also offers SMILES half-life models (``chemberta`` / ``peptideclm``
+embeddings), and this wrapper does not use them, for two reasons. First,
+``inference.py`` applies the ``expm1`` inverse transform only when
+``col == "wt"`` and the model name contains ``log``, so the SMILES models return
+an untransformed number that is *not* on the hours scale the sequence model
+reports — pooling them into one field would mix units. Second, mhctools
+identifies a peptide by its residue sequence and has nowhere to record a
+chemical form, so a modified construct would silently be reported under its
+unmodified sequence. Modified peptides are rejected rather than misattributed.
+
+Installation
+------------
+Snapshot the upstream model repository (git-lfs; roughly 3 GB) and point
+``PEPTIVERSE_HOME`` at it::
+
+    git clone https://huggingface.co/ChatterjeeLab/PeptiVerse
+    cd PeptiVerse && git checkout 8cf0b21dae356278ae96b414a088e4360357d16c
+
+The upstream stack (torch, transformers==4.46.0, xgboost, lightning) is kept out
+of the mhctools environment: inference runs in a subprocess under
+``PEPTIVERSE_PYTHON``. Constructing upstream's predictor also instantiates ESM2
+(``esm2_t33_650M_UR50D``), PeptideCLM and ChemBERTa, which are fetched from the
+HuggingFace hub on first use and cached — so the first call needs network access
+even though prediction itself does not.
+
+Provenance and limits
+---------------------
+Upstream: https://huggingface.co/ChatterjeeLab/PeptiVerse
+Cite: https://pmc.ncbi.nlm.nih.gov/articles/PMC12773018/
+
+The retrieved version is a January 2026 preprint. The sequence half-life model
+was fit on **130 examples** and evaluated by cross-validation only, with no
+external test set — a weak evidence base for ranking decisions, and untested on
+the long peptides used in vaccine constructs. Upstream's model card declares
+Apache-2.0 while its README declares MIT; both are permissive, but the artifacts
+carry no single unambiguous grant. The separate UI Space is CC-BY-NC-ND and is
+not used here.
+
+Checkpoints load through ``torch.load(..., weights_only=False)``, which executes
+pickled code. Point ``PEPTIVERSE_HOME`` only at a snapshot you trust.
+"""
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+
+import pandas as pd
+
+from .pred import Kind, PeptideResult, Prediction
+from .wrapper_base import AlleleFreePredictor
+
+#: Upstream revision this wrapper was written and verified against.
+UPSTREAM_REVISION = "8cf0b21dae356278ae96b414a088e4360357d16c"
+
+#: ESM2's positional limit; upstream's WTEmbedder truncates beyond it.
+PEPTIVERSE_MAX_PEPTIDE_LENGTH = 1022
+
+_VALID_AMINO_ACIDS = frozenset("ACDEFGHIKLMNPQRSTVWY")
+
+# A one-row manifest in upstream's format. Restricting it to Halflife (with the
+# SMILES column blanked out with "-") makes `_load_all_best_models` load the
+# single sequence half-life model rather than every property's best model.
+# "Transformer" resolves to transformer_wt_log, whose output is expm1'd by
+# upstream into hours.
+_HALF_LIFE_MANIFEST = (
+    "Properties, Best_Model_WT, Best_Model_SMILES, Type, "
+    "Threshold_WT, Threshold_SMILES,\n"
+    "Halflife, Transformer, -, Regression, -, -,\n"
+)
+
+
+def _find_peptiverse_home(peptiverse_home=None):
+    """Resolve the PeptiVerse snapshot directory.
+
+    Checks, in order: the *peptiverse_home* argument, ``$PEPTIVERSE_HOME``,
+    then ``~/PeptiVerse``.
+    """
+    candidate = peptiverse_home or os.environ.get("PEPTIVERSE_HOME")
+    if not candidate:
+        home = Path.home() / "PeptiVerse"
+        if home.is_dir():
+            candidate = str(home)
+    if not candidate:
+        raise FileNotFoundError(
+            "PeptiVerse not found. Set PEPTIVERSE_HOME or pass "
+            "peptiverse_home= to the constructor. Clone from "
+            "https://huggingface.co/ChatterjeeLab/PeptiVerse")
+    candidate = str(Path(candidate).expanduser())
+    if not Path(candidate, "inference.py").is_file():
+        raise FileNotFoundError(
+            "inference.py not found in %r — is this a PeptiVerse snapshot?"
+            % candidate)
+    weights = Path(candidate, "training_classifiers", "half_life")
+    if not weights.is_dir():
+        raise FileNotFoundError(
+            "training_classifiers/half_life not found in %r — the snapshot is "
+            "missing its half-life weights (git-lfs not pulled?)" % candidate)
+    return candidate
+
+
+def _resolve_python(peptiverse_python=None):
+    value = peptiverse_python or os.environ.get("PEPTIVERSE_PYTHON")
+    if not value:
+        return sys.executable
+    path = Path(value).expanduser()
+    if path.is_file():
+        # Do not resolve a virtualenv interpreter symlink: invoking the target
+        # binary directly would discard the environment prefix.
+        return str(path.absolute())
+    executable = shutil.which(str(value))
+    if executable:
+        return executable
+    raise FileNotFoundError("PeptiVerse Python does not exist: %s" % value)
+
+
+class PeptiVerse(AlleleFreePredictor):
+    """Serum half-life predictions from a local PeptiVerse snapshot.
+
+    Parameters
+    ----------
+    peptiverse_home : str, optional
+        Path to a PeptiVerse snapshot (holds ``inference.py`` and
+        ``training_classifiers/``). Resolved from the argument, then
+        ``$PEPTIVERSE_HOME``, then ``~/PeptiVerse``.
+    peptiverse_python : str, optional
+        Interpreter that has PeptiVerse's dependencies. Resolved from the
+        argument, then ``$PEPTIVERSE_PYTHON``, then the current interpreter.
+    device : str, optional
+        Passed to upstream (``"cpu"``, ``"cuda"``, ...). Default lets upstream
+        choose: CUDA when available, otherwise CPU.
+    uncertainty : bool
+        Ask upstream for its conformal interval alongside each prediction, kept
+        in :attr:`last_qc` with upstream's own status string. Off by default and
+        never surfaced in the returned ``Prediction``, for two reasons.
+
+        In practice it does not load: the shipped
+        ``half_life/transformer_wt_log/mapie_calibration.joblib`` unpickles a
+        ``__main__.PassthroughRegressor``, a class defined in the training
+        script rather than in any importable module, so upstream reports
+        ``"unavailable (no MAPIE bundle and no seed ensemble)"``.
+
+        And were it loadable, the bounds would not be on the hours scale the
+        point estimate uses: upstream calls ``_compute_uncertainty`` with the
+        already-``expm1``-ed score and adds a quantile calibrated on log-space
+        residuals. Treat anything that appears here as a raw upstream
+        diagnostic, not a calibrated confidence interval.
+    max_peptide_length : int
+        Peptides longer than this are rejected instead of being silently
+        truncated by ESM2. Default 1022.
+    """
+
+    mhc_class = "none"
+
+    def __init__(
+            self,
+            peptiverse_home=None,
+            peptiverse_python=None,
+            device=None,
+            uncertainty=False,
+            max_peptide_length=PEPTIVERSE_MAX_PEPTIDE_LENGTH):
+        if max_peptide_length > PEPTIVERSE_MAX_PEPTIDE_LENGTH:
+            raise ValueError(
+                "ESM2 accepts at most %d residues; max_peptide_length cannot "
+                "exceed that (got %d)"
+                % (PEPTIVERSE_MAX_PEPTIDE_LENGTH, max_peptide_length))
+        self.peptiverse_home = _find_peptiverse_home(peptiverse_home)
+        self.peptiverse_python = _resolve_python(peptiverse_python)
+        self.device = device
+        self.uncertainty = uncertainty
+        self.max_peptide_length = max_peptide_length
+        self.last_qc = pd.DataFrame()
+
+    def __str__(self):
+        return "PeptiVerse(peptiverse_home=%r, device=%r)" % (
+            self.peptiverse_home, self.device)
+
+    def _default_pred_kind(self):
+        return Kind.serum_half_life
+
+    def _predictor_name(self):
+        return "peptiverse"
+
+    @property
+    def predictor_version(self):
+        return "%s:transformer_wt_log" % UPSTREAM_REVISION
+
+    def _check_peptides(self, peptides):
+        for peptide in peptides:
+            if not peptide:
+                raise ValueError("Empty peptide is not allowed")
+            if len(peptide) > self.max_peptide_length:
+                raise ValueError(
+                    "PeptiVerse supports peptides up to %d residues; got %r "
+                    "(length %d)"
+                    % (self.max_peptide_length, peptide, len(peptide)))
+            invalid = set(peptide) - _VALID_AMINO_ACIDS
+            if invalid:
+                raise ValueError(
+                    "Peptide %r contains characters the sequence model cannot "
+                    "encode: %s. PeptiVerse's chemical-form (SMILES) models are "
+                    "not wrapped, so modified peptides are rejected rather than "
+                    "scored as their unmodified sequence."
+                    % (peptide, "".join(sorted(invalid))))
+
+    def predict(self, peptides):
+        """Predict serum half-life for a list of peptides.
+
+        Returns
+        -------
+        list of PeptideResult
+            One entry per input peptide, in input order, each holding a single
+            ``Kind.serum_half_life`` prediction with an empty ``allele``. Both
+            ``score`` and ``value`` carry the predicted half-life in **hours**
+            (higher = longer-lived); ``value`` is the units-bearing field and
+            ``score`` repeats it so that rank-based consumers work without
+            knowing the unit.
+        """
+        peptide_list = self._normalize_peptides(peptides)
+        self._check_peptides(peptide_list)
+        if not peptide_list:
+            self.last_qc = pd.DataFrame()
+            return []
+
+        output = self._run_sidecar(peptide_list)
+        return [
+            PeptideResult(preds=(Prediction(
+                kind=Kind.serum_half_life,
+                score=hours,
+                value=hours,
+                peptide=peptide,
+                predictor_name=self._predictor_name(),
+                predictor_version=self.predictor_version),))
+            for peptide, hours in zip(peptide_list, output["hours"])
+        ]
+
+    def _run_sidecar(self, peptide_list):
+        with tempfile.TemporaryDirectory(prefix="mhctools_peptiverse_") as tmp:
+            tmp_path = Path(tmp)
+            input_path = tmp_path / "input.csv"
+            output_path = tmp_path / "output.csv"
+            manifest_path = tmp_path / "half_life_only_manifest.txt"
+            manifest_path.write_text(_HALF_LIFE_MANIFEST)
+            pd.DataFrame({
+                "__mhctools_id": range(len(peptide_list)),
+                "peptide": peptide_list,
+            }).to_csv(input_path, index=False)
+
+            sidecar = Path(__file__).with_name("peptiverse_sidecar.py")
+            command = [
+                self.peptiverse_python,
+                # Run through runpy rather than passing the script path
+                # directly: that would put mhctools/ on sys.path[0], where
+                # mhctools/logging.py shadows the stdlib logging module that
+                # torch imports.
+                "-c",
+                (
+                    "import runpy,sys; sys.argv=sys.argv[1:]; "
+                    "runpy.run_path(sys.argv[0],run_name='__main__')"
+                ),
+                str(sidecar),
+                "--home", self.peptiverse_home,
+                "--manifest", str(manifest_path),
+                "--input", str(input_path),
+                "--output", str(output_path),
+                "--device", self.device or "",
+            ]
+            if self.uncertainty:
+                command.append("--uncertainty")
+
+            environment = os.environ.copy()
+            environment["PYTHONNOUSERSITE"] = "1"
+            process = subprocess.run(
+                command,
+                cwd=self.peptiverse_home,
+                env=environment,
+                capture_output=True,
+                text=True,
+            )
+            if process.returncode != 0:
+                raise RuntimeError(
+                    "PeptiVerse inference failed (exit %d):\n%s" % (
+                        process.returncode,
+                        (process.stderr or process.stdout).strip()))
+            output = parse_peptiverse_results(output_path, peptide_list)
+
+        self.last_qc = output.drop(columns=["hours"])
+        return output
+
+
+def parse_peptiverse_results(filename, peptide_list):
+    """Parse sidecar output into a DataFrame aligned with *peptide_list*.
+
+    Every input peptide must come back exactly once, identified by the
+    ``__mhctools_id`` the caller assigned, and with the peptide it was scored
+    under unchanged — upstream's embedders truncate or alter unsupported input
+    rather than failing, so a mismatch is an error rather than something to
+    reconcile silently. Duplicate input peptides keep separate rows.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Sorted by ``__mhctools_id``, with ``hours`` as float.
+    """
+    output = pd.read_csv(filename, keep_default_na=False)
+    for column in ("__mhctools_id", "peptide", "hours"):
+        if column not in output.columns:
+            raise ValueError(
+                "PeptiVerse output missing column %r; got %s"
+                % (column, list(output.columns)))
+    output["__mhctools_id"] = output["__mhctools_id"].astype(int)
+    if sorted(output["__mhctools_id"].tolist()) != list(range(len(peptide_list))):
+        raise RuntimeError(
+            "PeptiVerse output did not preserve every input peptide: expected "
+            "%d rows with ids 0..%d, got ids %s"
+            % (len(peptide_list), len(peptide_list) - 1,
+               sorted(output["__mhctools_id"].tolist())))
+    output = output.sort_values("__mhctools_id").reset_index(drop=True)
+    returned = output["peptide"].tolist()
+    if returned != list(peptide_list):
+        mismatched = [
+            (i, sent, got)
+            for i, (sent, got) in enumerate(zip(peptide_list, returned))
+            if sent != got
+        ]
+        raise RuntimeError(
+            "PeptiVerse returned a different peptide than it was given "
+            "(id, sent, got): %s" % mismatched[:5])
+    output["hours"] = output["hours"].astype(float)
+    return output

--- a/mhctools/peptiverse_sidecar.py
+++ b/mhctools/peptiverse_sidecar.py
@@ -1,0 +1,89 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Isolated runtime bridge to a user-provided PeptiVerse snapshot.
+
+Runs in the interpreter that owns PeptiVerse's dependency stack (torch,
+transformers, xgboost, the ESM2 / PeptideCLM / ChemBERTa embedding models) so
+none of it has to be importable from the mhctools environment.
+
+Only the half-life endpoint is exposed. The manifest written by the caller lists
+``Halflife`` and nothing else, so ``PeptiVersePredictor`` loads one model
+instead of the nine it would otherwise pull in for hemolysis, solubility,
+permeability, toxicity, non-fouling and binding affinity.
+"""
+
+from argparse import ArgumentParser
+import csv
+import json
+from pathlib import Path
+import sys
+
+
+def _parse_args():
+    parser = ArgumentParser()
+    parser.add_argument("--home", required=True)
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--input", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--device", default="")
+    parser.add_argument("--uncertainty", action="store_true")
+    return parser.parse_args()
+
+
+def main():
+    args = _parse_args()
+    home = Path(args.home).resolve()
+    sys.path.insert(0, str(home))
+
+    # Imported only inside this subprocess; these modules belong to the
+    # separately licensed upstream snapshot, not to mhctools.
+    from inference import PeptiVersePredictor
+
+    predictor = PeptiVersePredictor(
+        manifest_path=args.manifest,
+        classifier_weight_root=str(home),
+        device=args.device or None,
+    )
+
+    with open(args.input, newline="") as handle:
+        rows = list(csv.DictReader(handle))
+
+    results = []
+    for row in rows:
+        # `predict_property` takes (prop_key, col, input_str) positionally --
+        # upstream's README examples pass `mode=`, which is not a parameter of
+        # the shipped signature and raises TypeError.
+        out = predictor.predict_property(
+            "halflife",
+            "wt",
+            row["peptide"],
+            uncertainty=args.uncertainty)
+        results.append({
+            "__mhctools_id": row["__mhctools_id"],
+            "peptide": row["peptide"],
+            # `inference.py` applies np.expm1 to the log-trained wt model
+            # itself, so this is already hours. Do not transform again.
+            "hours": out["score"],
+            "emb_tag": out.get("emb_tag", ""),
+            "uncertainty": (
+                "" if out.get("uncertainty") is None
+                else json.dumps(out["uncertainty"])),
+            "uncertainty_type": out.get("uncertainty_type", ""),
+        })
+
+    fieldnames = [
+        "__mhctools_id", "peptide", "hours",
+        "emb_tag", "uncertainty", "uncertainty_type",
+    ]
+    with open(args.output, "w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/mhctools/pred.py
+++ b/mhctools/pred.py
@@ -53,6 +53,14 @@ class Kind:
     endolysosomal_cleavage = "endolysosomal_cleavage"
     tap_transport = "tap_transport"
     erap_trimming = "erap_trimming"
+    # Degradation half-life of the free peptide in blood serum, in hours.
+    # Deliberately NOT ``pMHC_stability``, which is the dissociation half-life
+    # of an assembled peptide-MHC complex: different molecule, different assay,
+    # different matrix. A predictor trained on whole blood, plasma, intestinal
+    # fluid or in-vivo PK is also not this kind — it needs its own constant
+    # rather than being folded in here, since nothing else in a ``Prediction``
+    # records the matrix.
+    serum_half_life = "serum_half_life"
 
 
 # Canonical "best direction" for each prediction field. Used by
@@ -76,6 +84,7 @@ VALUE_BEST_DIRECTIONS = {
     Kind.pMHC_affinity: "min",   # IC50 nM
     Kind.pMHC_stability: "max",  # half-life
     Kind.tap_transport: "min",   # predicted TAP-binding affinity, nM
+    Kind.serum_half_life: "max",  # hours in serum
 }
 
 
@@ -284,6 +293,11 @@ class PeptideResult:
     def erap_trimming(self) -> Optional[Prediction]:
         """Best ERAP1 trimming prediction, or None."""
         return self.best_by_score(Kind.erap_trimming)
+
+    @property
+    def serum_half_life(self) -> Optional[Prediction]:
+        """Longest-lived serum half-life prediction, or None."""
+        return self.best_by_score(Kind.serum_half_life)
 
     @property
     def tcr_binding(self) -> Optional[Prediction]:

--- a/tests/test_peptiverse.py
+++ b/tests/test_peptiverse.py
@@ -1,0 +1,322 @@
+# Copyright (c) 2026 Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the PeptiVerse serum half-life wrapper.
+
+Parser, manifest, kind and validation tests need no model and no network. The
+end-to-end test runs only when ``PEPTIVERSE_HOME`` points at a snapshot with its
+half-life weights pulled, optionally with ``PEPTIVERSE_PYTHON`` naming an
+interpreter that has torch + transformers.
+"""
+
+import os
+from pathlib import Path
+import tempfile
+
+import pytest
+
+from mhctools import Kind, PeptiVerse
+from mhctools.peptiverse import (
+    PEPTIVERSE_MAX_PEPTIDE_LENGTH,
+    _HALF_LIFE_MANIFEST,
+    parse_peptiverse_results,
+)
+from mhctools.pred import VALUE_BEST_DIRECTIONS, best_direction
+
+
+# Sidecar output for three peptides, in the shape peptiverse_sidecar.py writes.
+_OUTPUT = (
+    "__mhctools_id,peptide,hours,emb_tag,uncertainty,uncertainty_type\n"
+    "0,SIINFEKL,1.4832,wt,,\n"
+    "1,GILGFVFTL,0.6271,wt,,\n"
+    "2,KLGGALQAK,12.9044,wt,,\n")
+
+
+def _write(text):
+    handle = tempfile.NamedTemporaryFile(
+        "w", suffix="_peptiverse.csv", delete=False)
+    handle.write(text)
+    handle.close()
+    return handle.name
+
+
+# --- kind semantics (no model, no network) ----------------------------------
+
+def test_serum_half_life_is_not_pmhc_stability():
+    # The whole point of the new kind: a serum half-life must never land in the
+    # field NetMHCstabpan writes, which is pMHC complex dissociation.
+    assert Kind.serum_half_life != Kind.pMHC_stability
+    assert Kind.serum_half_life == "serum_half_life"
+
+
+def test_serum_half_life_value_direction_is_max():
+    # Hours in serum: longer-lived is "better", same as pMHC stability but for
+    # an unrelated reason, so it needs its own registered direction.
+    assert VALUE_BEST_DIRECTIONS[Kind.serum_half_life] == "max"
+    assert best_direction(Kind.serum_half_life, "value") == "max"
+    assert best_direction(Kind.serum_half_life, "score") == "max"
+
+
+def test_annotate_exposes_serum_half_life_as_a_units_bearing_field():
+    from mhctools.annotate import _OUTPUT_FIELDS, output_field_tokens
+    assert "serum_half_life" in output_field_tokens()
+    # `value` and not `score`, because hours are the meaningful quantity.
+    assert _OUTPUT_FIELDS["serum_half_life"] == (Kind.serum_half_life, "value")
+
+
+def test_peptide_result_accessor():
+    from mhctools.pred import PeptideResult, Prediction
+    result = PeptideResult(preds=(
+        Prediction(kind=Kind.serum_half_life, score=2.0, value=2.0,
+                   peptide="SIINFEKL"),
+        Prediction(kind=Kind.serum_half_life, score=9.0, value=9.0,
+                   peptide="SIINFEKL"),
+        Prediction(kind=Kind.pMHC_stability, score=99.0, peptide="SIINFEKL"),
+    ))
+    assert result.serum_half_life.value == 9.0
+    # The pMHC stability prediction must not leak into the serum accessor.
+    assert result.stability.score == 99.0
+
+
+# --- manifest ---------------------------------------------------------------
+
+def test_manifest_selects_only_the_half_life_sequence_model():
+    lines = [
+        line for line in _HALF_LIFE_MANIFEST.strip().split("\n") if line.strip()
+    ]
+    assert len(lines) == 2, "header plus exactly one property row"
+    header, row = lines
+    assert "Best_Model_WT" in header and "Best_Model_SMILES" in header
+    fields = [field.strip() for field in row.split(",")]
+    assert fields[0] == "Halflife"
+    # "Transformer" resolves upstream to transformer_wt_log, the only half-life
+    # variant whose output is expm1'd into hours.
+    assert fields[1] == "Transformer"
+    # SMILES model blanked: its output is not on the hours scale.
+    assert fields[2] == "-"
+    assert fields[3] == "Regression"
+
+
+# --- parser (no model) ------------------------------------------------------
+
+def test_parse_results():
+    path = _write(_OUTPUT)
+    try:
+        frame = parse_peptiverse_results(
+            path, ["SIINFEKL", "GILGFVFTL", "KLGGALQAK"])
+    finally:
+        os.remove(path)
+    assert frame["hours"].tolist() == [1.4832, 0.6271, 12.9044]
+    assert frame["peptide"].tolist() == ["SIINFEKL", "GILGFVFTL", "KLGGALQAK"]
+
+
+def test_parse_results_restores_input_order():
+    shuffled = (
+        "__mhctools_id,peptide,hours,emb_tag,uncertainty,uncertainty_type\n"
+        "2,KLGGALQAK,12.9044,wt,,\n"
+        "0,SIINFEKL,1.4832,wt,,\n"
+        "1,GILGFVFTL,0.6271,wt,,\n")
+    path = _write(shuffled)
+    try:
+        frame = parse_peptiverse_results(
+            path, ["SIINFEKL", "GILGFVFTL", "KLGGALQAK"])
+    finally:
+        os.remove(path)
+    assert frame["peptide"].tolist() == ["SIINFEKL", "GILGFVFTL", "KLGGALQAK"]
+    assert frame["hours"].tolist() == [1.4832, 0.6271, 12.9044]
+
+
+def test_parse_results_keeps_duplicate_peptides_separate():
+    duplicated = (
+        "__mhctools_id,peptide,hours,emb_tag,uncertainty,uncertainty_type\n"
+        "0,SIINFEKL,1.4832,wt,,\n"
+        "1,SIINFEKL,1.4832,wt,,\n")
+    path = _write(duplicated)
+    try:
+        frame = parse_peptiverse_results(path, ["SIINFEKL", "SIINFEKL"])
+    finally:
+        os.remove(path)
+    assert len(frame) == 2
+
+
+def test_parse_results_rejects_dropped_peptide():
+    truncated = (
+        "__mhctools_id,peptide,hours,emb_tag,uncertainty,uncertainty_type\n"
+        "0,SIINFEKL,1.4832,wt,,\n")
+    path = _write(truncated)
+    try:
+        with pytest.raises(RuntimeError, match="did not preserve"):
+            parse_peptiverse_results(path, ["SIINFEKL", "GILGFVFTL"])
+    finally:
+        os.remove(path)
+
+
+def test_parse_results_rejects_altered_peptide():
+    # Upstream's embedders truncate over-long input rather than failing, so a
+    # peptide coming back changed means the score is for a different molecule.
+    altered = (
+        "__mhctools_id,peptide,hours,emb_tag,uncertainty,uncertainty_type\n"
+        "0,SIINFEK,1.4832,wt,,\n")
+    path = _write(altered)
+    try:
+        with pytest.raises(RuntimeError, match="different peptide"):
+            parse_peptiverse_results(path, ["SIINFEKL"])
+    finally:
+        os.remove(path)
+
+
+def test_parse_results_rejects_missing_column():
+    path = _write("__mhctools_id,peptide\n0,SIINFEKL\n")
+    try:
+        with pytest.raises(ValueError, match="missing column 'hours'"):
+            parse_peptiverse_results(path, ["SIINFEKL"])
+    finally:
+        os.remove(path)
+
+
+# --- construction and validation (no model) ---------------------------------
+
+def _fake_home(tmp_path):
+    """A directory shaped enough like a snapshot to pass resolution."""
+    (tmp_path / "inference.py").write_text("")
+    (tmp_path / "training_classifiers" / "half_life").mkdir(parents=True)
+    return str(tmp_path)
+
+
+def test_missing_home_is_reported(tmp_path, monkeypatch):
+    monkeypatch.delenv("PEPTIVERSE_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    with pytest.raises(FileNotFoundError, match="PeptiVerse not found"):
+        PeptiVerse()
+
+
+def test_home_without_inference_is_reported(tmp_path):
+    with pytest.raises(FileNotFoundError, match="inference.py not found"):
+        PeptiVerse(peptiverse_home=str(tmp_path))
+
+
+def test_home_without_weights_is_reported(tmp_path):
+    (tmp_path / "inference.py").write_text("")
+    with pytest.raises(FileNotFoundError, match="half_life not found"):
+        PeptiVerse(peptiverse_home=str(tmp_path))
+
+
+def test_supported_kinds_and_mhc_context(tmp_path):
+    predictor = PeptiVerse(peptiverse_home=_fake_home(tmp_path))
+    assert predictor.supported_kinds == (Kind.serum_half_life,)
+    support = predictor.kind_support()[Kind.serum_half_life]
+    assert support["mhc_dependence"] == "none"
+    assert support["mhc_class"] == "none"
+
+
+def test_empty_peptide_list_returns_nothing(tmp_path):
+    predictor = PeptiVerse(peptiverse_home=_fake_home(tmp_path))
+    assert predictor.predict([]) == []
+
+
+def test_modified_residues_are_rejected_not_silently_stripped(tmp_path):
+    predictor = PeptiVerse(peptiverse_home=_fake_home(tmp_path))
+    with pytest.raises(ValueError, match="unmodified sequence"):
+        predictor.predict(["SIINFEKLB"])
+
+
+def test_empty_peptide_is_rejected(tmp_path):
+    predictor = PeptiVerse(peptiverse_home=_fake_home(tmp_path))
+    with pytest.raises(ValueError, match="Empty peptide"):
+        predictor.predict([""])
+
+
+def test_over_long_peptide_is_rejected_rather_than_truncated(tmp_path):
+    predictor = PeptiVerse(peptiverse_home=_fake_home(tmp_path))
+    with pytest.raises(ValueError, match="up to 1022 residues"):
+        predictor.predict(["A" * (PEPTIVERSE_MAX_PEPTIDE_LENGTH + 1)])
+
+
+def test_max_peptide_length_cannot_exceed_model_limit(tmp_path):
+    with pytest.raises(ValueError, match="at most 1022 residues"):
+        PeptiVerse(
+            peptiverse_home=_fake_home(tmp_path),
+            max_peptide_length=PEPTIVERSE_MAX_PEPTIDE_LENGTH + 1)
+
+
+def test_missing_python_is_reported(tmp_path):
+    with pytest.raises(FileNotFoundError, match="Python does not exist"):
+        PeptiVerse(
+            peptiverse_home=_fake_home(tmp_path),
+            peptiverse_python="/nonexistent/python")
+
+
+def test_predictor_version_pins_the_upstream_revision(tmp_path):
+    predictor = PeptiVerse(peptiverse_home=_fake_home(tmp_path))
+    assert predictor.predictor_version.startswith("8cf0b21")
+    assert predictor.predictor_version.endswith("transformer_wt_log")
+
+
+# --- end-to-end (opt-in; needs a real snapshot) -----------------------------
+
+PEPTIVERSE_HOME = os.environ.get("PEPTIVERSE_HOME")
+
+requires_peptiverse = pytest.mark.skipif(
+    not PEPTIVERSE_HOME,
+    reason="set PEPTIVERSE_HOME to a PeptiVerse snapshot to run this")
+
+
+@requires_peptiverse
+def test_end_to_end_returns_hours():
+    predictor = PeptiVerse(device="cpu")
+    peptides = ["SIINFEKL", "KLGGALQAK"]
+    results = predictor.predict(peptides)
+    assert len(results) == len(peptides)
+    for peptide, result in zip(peptides, results):
+        assert len(result.preds) == 1
+        pred = result.preds[0]
+        assert pred.kind == Kind.serum_half_life
+        assert pred.peptide == peptide
+        assert pred.allele == ""
+        assert pred.predictor_name == "peptiverse"
+        # expm1 of a log1p-trained target: a duration in hours, so positive and
+        # not a 0-1 probability.
+        assert pred.value > 0
+        assert pred.value == pred.score
+    assert len(predictor.last_qc) == len(peptides)
+
+
+@requires_peptiverse
+def test_end_to_end_is_deterministic():
+    predictor = PeptiVerse(device="cpu")
+    first = predictor.predict(["SIINFEKL"])[0].preds[0].value
+    second = predictor.predict(["SIINFEKL"])[0].preds[0].value
+    assert first == second
+
+
+@requires_peptiverse
+def test_end_to_end_dataframe_has_the_standard_columns():
+    from mhctools.pred import COLUMNS
+    predictor = PeptiVerse(device="cpu")
+    frame = predictor.predict_dataframe(["SIINFEKL"])
+    assert list(frame.columns) == list(COLUMNS)
+    assert frame["kind"].tolist() == [Kind.serum_half_life]
+
+
+@requires_peptiverse
+def test_end_to_end_uncertainty_stays_out_of_the_prediction():
+    # Upstream's half-life conformal bundle references a class defined in its
+    # training script's __main__, so it cannot be unpickled at inference time.
+    # Whatever upstream reports must stay in last_qc, never in a field that
+    # would read as a calibrated bound on the hours estimate.
+    predictor = PeptiVerse(device="cpu", uncertainty=True)
+    pred = predictor.predict(["SIINFEKL"])[0].preds[0]
+    assert pred.percentile_rank is None
+    assert pred.value == pred.score
+    assert "uncertainty_type" in predictor.last_qc.columns


### PR DESCRIPTION
Closes #280.

Adds `Kind.serum_half_life` and a `PeptiVerse` wrapper that emits it.

## The kind

The degradation half-life of a **free peptide** in blood serum, in hours. Deliberately *not* `pMHC_stability`, which is the dissociation half-life of an assembled peptide-MHC complex — different molecule, different assay, different matrix, and #279 requires they stay distinct. Since nothing in a `Prediction` records an assay matrix, the kind string is the only place that distinction can live; a predictor trained on whole blood, plasma or in-vivo PK needs its own constant rather than being folded in here.

This is the first non-immunological (peptide-drug PK) axis in the taxonomy. It is allele-independent, `value` carries hours with a `"max"` direction, and `serum_half_life` is registered as a `predict-table` output field bound to `value` rather than `score`.

## What was verified, not assumed

Checked against upstream revision `8cf0b21`, with the model actually run on CPU:

- **Units are hours in serum** (upstream README L575), and `inference.py` applies the `expm1` inverse of its `log1p`-trained target itself (L933/L950). The wrapper must not transform again.
- That inverse is gated on `col == "wt"`, so upstream's **SMILES half-life models return a number on a different scale**. Sequence input only here; peptides containing non-standard residues are rejected rather than scored as their unmodified sequence, since mhctools has nowhere to record a chemical form.
- Upstream's README calls `predict_property(..., mode=)`, which **is not a parameter of the shipped signature** — it would raise `TypeError`. The sidecar passes positionally.
- The half-life MAPIE bundle unpickles a **`__main__.PassthroughRegressor`**, a class defined in the training script rather than any importable module, so the conformal calibration cannot load at inference time. `uncertainty=` is off by default and never reaches a `Prediction`; whatever upstream reports lands in `last_qc` with upstream's own status string. Even if it loaded, the interval is built around the already-`expm1`-ed score from log-space residuals, so it would not be on the hours scale.

## Isolation

The upstream stack (torch, `transformers==4.46.0`, xgboost, lightning, plus the ESM2 / PeptideCLM / ChemBERTa embedding models) stays out of the mhctools environment — inference runs in a subprocess under `PEPTIVERSE_PYTHON`, following the DeepTAP / MixTCRpred pattern.

Two things worth a reviewer's eye:

- The sidecar is invoked through `runpy` rather than by script path. Passing the path directly puts `mhctools/` on `sys.path[0]`, where `mhctools/logging.py` shadows the stdlib `logging` that torch imports. This was a real failure, caught by running it.
- A generated one-row manifest restricts `_load_all_best_models` to the half-life sequence model instead of all nine properties' best models. Confirmed by running against a snapshot containing *only* `training_classifiers/half_life/transformer_wt_log`.

## Tests

Parser, manifest, kind-semantics and validation tests are offline and need no model. The four end-to-end tests are opt-in on `PEPTIVERSE_HOME` and were run against the real checkpoint on CPU: `SIINFEKL` → 0.542 h, `KLGGALQAK` → 0.990 h, reproducible across calls. Full suite: 756 passed.

## Caveats recorded in the docs

The sequence half-life model was fit on **130 examples**, evaluated by cross-validation only, from a January 2026 preprint, with no external test set and no evaluation on long vaccine peptides. Upstream declares Apache-2.0 on its model card and MIT in its README footer — both permissive, but not a single unambiguous grant. Checkpoints load via `torch.load(weights_only=False)`, which executes pickled code.

https://claude.ai/code/session_01NGKWupeNWvqdmWcWYsXaTc
