### PR TITLE
Add PlifePred2 whole-blood half-life predictor and the blood_half_life kind

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ The canonical prediction kind strings are defined in `mhctools.pred.Kind`.
 | `tap_transport` | TAP transport / binding score |
 | `erap_trimming` | ERAP1 N-terminal trimming score |
 | `serum_half_life` | Degradation half-life of the free peptide in serum, in hours |
+| `blood_half_life` | Degradation half-life of the free peptide in whole blood, in hours |
 
 Predictors also expose `kind_support()` so downstream code can tell what MHC
 context is meaningful for each emitted kind:
@@ -296,6 +297,7 @@ Examples:
 | `TLimmuno2` | `immunogenicity` | `single_allele` | `II` |
 | `Calis` | `immunogenicity` | `none` | `I` |
 | `PeptiVerse` | `serum_half_life` | `none` | `none` |
+| `PlifePred2` | `blood_half_life` | `none` | `none` |
 
 ### TCR predictors (`NetTCR`, `Tulip`, `MixTCRpred`)
 
@@ -656,11 +658,12 @@ results[0].erap_trimming.score
 > ⚠️ ERAMER's evaluation is self-reported and ERAP1 trimming is an intrinsically
 > noisy signal; treat the score as a pathway prior, not a validated oracle.
 
-### Serum half-life
+### Peptide half-life in blood and serum
 
 | Predictor | Kinds produced | Requires |
 |---|---|---|
 | `PeptiVerse` | Serum half-life (`serum_half_life`) | a PeptiVerse snapshot (`PEPTIVERSE_HOME`) + a torch/transformers Python |
+| `PlifePred2` | Whole-blood half-life (`blood_half_life`) | `plifepred2` (`PLIFEPRED2_HOME`) + a Pfeature checkout (`PFEATURE_HOME`) |
 
 How long a **free peptide** survives in blood serum before proteases degrade it,
 in hours. This is a peptide-drug property rather than an immunological one: it
@@ -699,6 +702,47 @@ unmodified sequence.
 > card and MIT in its README. Checkpoints load through
 > `torch.load(weights_only=False)`, which executes pickled code — point
 > `PEPTIVERSE_HOME` only at a snapshot you trust.
+
+`PlifePred2` predicts the same quantity in **whole blood** rather than serum, so
+it emits a different kind: serum is blood with the cells and clotting factors
+removed, and peptide stability differs measurably between the two. Its training
+data is mammalian rather than specifically human.
+
+```python
+from mhctools import PlifePred2
+
+predictor = PlifePred2()                       # PLIFEPRED2_HOME + PFEATURE_HOME
+results = predictor.predict(["SIINFEKLGGALQAKKY"])
+results[0].blood_half_life.value               # hours, higher = longer-lived
+predictor.last_qc["log10_seconds"]             # the raw model output
+```
+
+Upstream's docs call this column `Halflife` and describe it as a "Predicted
+probability". It is neither a probability nor a raw duration: both shipped
+models are `RandomForestRegressor` (so upstream's `predict_proba` branch is dead
+code) and the target is `log10(half-life in seconds)`. That transform is
+established, not assumed — the lineage paper discarded peptides below 20 seconds,
+and inverting the shipped forests' extreme leaf values under log10-seconds
+reproduces that floor (20.2 s) and gives round durations at the top (exactly
+7.000 days); under log2 or ln the whole training range falls below the
+documented floor.
+
+Natural peptides only, 12–100 residues. Upstream's CLI silently drops
+out-of-range and modified sequences into an `eliminated_sequences.csv` and
+returns a shorter result set; mhctools rejects them instead so a caller never
+gets a quietly truncated answer.
+
+The Linux-only `pfeature_comp` binary that `plifepred2` bundles is **not** used
+— it is a PyInstaller freeze of Pfeature's `pfeature_comp.py`, and that plain
+Python source computes the same descriptor on any platform. Both upstreams are
+GPLv3, so neither is vendored and neither is imported into the mhctools
+interpreter.
+
+> ⚠️ PlifePred2 cites no publication of its own, so its training set is
+> unverified beyond what the artifacts reveal. In the lineage paper the
+> composition-based natural model was the weaker of the pair (r = 0.643 against
+> 0.743), and sequences up to 90% similar were deliberately kept in the data, so
+> reported accuracy is optimistic for novel peptides.
 
 ### Immunogenicity
 

--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -45,6 +45,7 @@ from .calis import Calis
 from .eramer import ERAMER
 from .deepimmuno import DeepImmuno
 from .peptiverse import PeptiVerse
+from .plifepred2 import PlifePred2
 from .tlimmuno2 import TLimmuno2
 from .processing_predictor import (
     ProcessingPredictor,
@@ -107,7 +108,7 @@ def __getattr__(name):
     raise AttributeError(
         "module %r has no attribute %r" % (__name__, name))
 
-__version__ = "3.36.0"
+__version__ = "3.37.0"
 
 __all__ = [
     "Prediction",
@@ -151,6 +152,7 @@ __all__ = [
     "ERAMER",
     "DeepImmuno",
     "PeptiVerse",
+    "PlifePred2",
     "TLimmuno2",
     "MHCflurry",
     "MHCflurry_Affinity",

--- a/mhctools/annotate.py
+++ b/mhctools/annotate.py
@@ -78,6 +78,7 @@ _OUTPUT_FIELDS = {
     # Serum half-life of the free peptide, in hours -- distinct from
     # "stability", which is pMHC complex dissociation.
     "serum_half_life": (Kind.serum_half_life, "value"),
+    "blood_half_life": (Kind.blood_half_life, "value"),
 }
 
 

--- a/mhctools/plifepred2.py
+++ b/mhctools/plifepred2.py
@@ -1,0 +1,362 @@
+# Copyright (c) 2026 Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Wrapper for PlifePred2's natural-peptide blood half-life model.
+
+How long a free peptide survives incubated in **mammalian whole blood**, in
+hours. That matrix matters and is why this emits ``Kind.blood_half_life`` rather
+than the ``Kind.serum_half_life`` that :mod:`mhctools.peptiverse` emits: serum
+is blood with the cells and clotting factors removed, and peptide stability
+differs measurably between the two. Neither is ``pMHC_stability``, which is
+peptide-MHC complex dissociation, and neither is a cleavage-site map.
+
+Units
+-----
+Upstream's README calls the output column ``Halflife`` and describes it as a
+"Predicted probability". It is neither a probability nor a raw duration. Both
+shipped models are ``RandomForestRegressor``, so the ``predict_proba`` branch in
+upstream's CLI is dead code, and the target is ``log10(half-life in seconds)``.
+
+That transform is established rather than assumed. The lineage paper (Mathur et
+al. 2018, PLoS ONE 13(6):e0196829) built its dataset from PEPlife filtered to
+mammalian blood, discarding anything below 20 seconds. Inverting the extreme
+leaf values of the shipped forests under log10-seconds reproduces that floor
+(20.2 s) and yields round durations at the top (exactly 7.000 days for the
+natural model, 95.0 days for the modified one); under log2 or ln the entire
+training range falls below the documented 20-second floor, which is impossible.
+
+Note that PlifePred2 departs from that paper in two ways, so its numbers are not
+the paper's: the transform is log10 where the paper used log2 (a constant factor
+of ~3.32), and the paper's 24-hour ceiling is gone.
+
+Natural peptides only
+---------------------
+Upstream ships a second model for modified peptides. It is not wrapped. Its
+modification flags (D-amino acid, terminal modifications, cyclization, PTM) are
+applied uniformly to every sequence in one invocation rather than per peptide,
+and mhctools identifies a peptide by its residue sequence with nowhere to record
+a chemical form — so a batch of differently modified constructs would be
+mislabelled. Peptides with non-standard residues are rejected instead.
+
+Installation
+------------
+Two GPLv3 checkouts, neither vendored:
+
+- ``PLIFEPRED2_HOME`` — the installed ``plifepred2`` package directory, holding
+  ``models/plifepred2_natural_model.sav`` (``pip install plifepred2`` into any
+  environment, then point at its ``site-packages/plifepred2``).
+- ``PFEATURE_HOME`` — a checkout of ``raghavagps/Pfeature``'s ``Standalone``
+  directory, holding ``pfeature_comp.py`` and ``Data/``.
+
+The Linux-only ``pfeature_comp`` binary that PlifePred2 bundles is **not** used.
+It is a PyInstaller freeze of Pfeature's ``pfeature_comp.py``, and that plain
+Python source computes the same descriptor on any platform.
+
+Provenance and limits
+---------------------
+Upstream: https://pypi.org/project/plifepred2/ and
+https://github.com/shindebpratik/plifepred2
+Lineage: https://doi.org/10.1371/journal.pone.0196829
+
+PlifePred2 itself cites no publication, so its training set is unverified beyond
+what the artifacts reveal; the ceiling change suggests a larger, later dataset
+than the 2018 one. In the lineage paper the composition-based natural model was
+the weaker of the pair (r = 0.643, against 0.743 for chemical descriptors), and
+sequences up to 90% similar were deliberately kept in the data, so reported
+accuracy is optimistic for novel peptides.
+"""
+
+import math
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+
+import pandas as pd
+
+from .pred import Kind, PeptideResult, Prediction
+from .wrapper_base import AlleleFreePredictor
+
+#: Upstream package version this wrapper was written and verified against.
+UPSTREAM_VERSION = "1.0"
+
+#: sha256 of the ``plifepred2-1.0-py3-none-any.whl`` these paths were read from.
+UPSTREAM_WHEEL_SHA256 = (
+    "e0eb32928b7970d5a113d8826ef9e451c94f0156e0b628dddb0da7103ac2c32e")
+
+# Upstream's CLI silently drops anything outside this range; the wrapper rejects
+# instead, so a caller never gets a short result set with no explanation.
+PLIFEPRED2_MIN_PEPTIDE_LENGTH = 12
+PLIFEPRED2_MAX_PEPTIDE_LENGTH = 100
+
+_VALID_AMINO_ACIDS = frozenset("ACDEFGHIKLMNPQRSTVWY")
+
+_NATURAL_MODEL = os.path.join("models", "plifepred2_natural_model.sav")
+
+_SECONDS_PER_HOUR = 3600.0
+
+
+def half_life_hours(log10_seconds):
+    """Convert a raw PlifePred2 prediction to hours.
+
+    The model's target is ``log10(half-life in seconds)``; see the module
+    docstring for how that was established.
+    """
+    return (10.0 ** log10_seconds) / _SECONDS_PER_HOUR
+
+
+def _find_plifepred2_home(plifepred2_home=None):
+    """Resolve the installed ``plifepred2`` package directory."""
+    candidate = plifepred2_home or os.environ.get("PLIFEPRED2_HOME")
+    if not candidate:
+        home = Path.home() / "plifepred2"
+        if home.is_dir():
+            candidate = str(home)
+    if not candidate:
+        raise FileNotFoundError(
+            "PlifePred2 not found. Set PLIFEPRED2_HOME or pass "
+            "plifepred2_home= to the constructor. `pip install plifepred2` "
+            "into an environment and point at its site-packages/plifepred2.")
+    candidate = str(Path(candidate).expanduser())
+    if not Path(candidate, _NATURAL_MODEL).is_file():
+        raise FileNotFoundError(
+            "%s not found in %r — is this an installed plifepred2 package?"
+            % (_NATURAL_MODEL, candidate))
+    return candidate
+
+
+def _find_pfeature_home(pfeature_home=None):
+    """Resolve the Pfeature ``Standalone`` directory."""
+    candidate = pfeature_home or os.environ.get("PFEATURE_HOME")
+    if not candidate:
+        home = Path.home() / "Pfeature" / "Standalone"
+        if home.is_dir():
+            candidate = str(home)
+    if not candidate:
+        raise FileNotFoundError(
+            "Pfeature not found. Set PFEATURE_HOME or pass pfeature_home= to "
+            "the constructor. Clone https://github.com/raghavagps/Pfeature and "
+            "point at its Standalone directory.")
+    candidate = str(Path(candidate).expanduser())
+    if not Path(candidate, "pfeature_comp.py").is_file():
+        raise FileNotFoundError(
+            "pfeature_comp.py not found in %r — point at Pfeature's Standalone "
+            "directory, not the repository root." % candidate)
+    for data_file in ("Schneider-Wrede.csv", "Grantham.csv"):
+        if not Path(candidate, "Data", data_file).is_file():
+            raise FileNotFoundError(
+                "Data/%s not found in %r — Pfeature's QSO descriptor reads its "
+                "distance matrices from that directory." % (data_file, candidate))
+    return candidate
+
+
+def _resolve_python(plifepred2_python=None):
+    value = plifepred2_python or os.environ.get("PLIFEPRED2_PYTHON")
+    if not value:
+        return sys.executable
+    path = Path(value).expanduser()
+    if path.is_file():
+        # Do not resolve a virtualenv interpreter symlink: invoking the target
+        # binary directly would discard the environment prefix.
+        return str(path.absolute())
+    executable = shutil.which(str(value))
+    if executable:
+        return executable
+    raise FileNotFoundError("PlifePred2 Python does not exist: %s" % value)
+
+
+class PlifePred2(AlleleFreePredictor):
+    """Whole-blood half-life predictions from local PlifePred2 + Pfeature.
+
+    Parameters
+    ----------
+    plifepred2_home : str, optional
+        Installed ``plifepred2`` package directory. Resolved from the argument,
+        then ``$PLIFEPRED2_HOME``, then ``~/plifepred2``.
+    pfeature_home : str, optional
+        Pfeature ``Standalone`` directory. Resolved from the argument, then
+        ``$PFEATURE_HOME``, then ``~/Pfeature/Standalone``.
+    plifepred2_python : str, optional
+        Interpreter with scikit-learn, joblib, pandas and tqdm. Resolved from
+        the argument, then ``$PLIFEPRED2_PYTHON``, then the current interpreter.
+        Upstream pins ``scikit-learn==1.4.2``; a different version loads the
+        forest but warns, so give this its own environment to be exact.
+    """
+
+    mhc_class = "none"
+
+    def __init__(
+            self,
+            plifepred2_home=None,
+            pfeature_home=None,
+            plifepred2_python=None):
+        self.plifepred2_home = _find_plifepred2_home(plifepred2_home)
+        self.pfeature_home = _find_pfeature_home(pfeature_home)
+        self.plifepred2_python = _resolve_python(plifepred2_python)
+        self.last_qc = pd.DataFrame()
+
+    def __str__(self):
+        return "PlifePred2(plifepred2_home=%r, pfeature_home=%r)" % (
+            self.plifepred2_home, self.pfeature_home)
+
+    def _default_pred_kind(self):
+        return Kind.blood_half_life
+
+    def _predictor_name(self):
+        return "plifepred2"
+
+    @property
+    def predictor_version(self):
+        return "%s:natural" % UPSTREAM_VERSION
+
+    def _check_peptides(self, peptides):
+        for peptide in peptides:
+            if not peptide:
+                raise ValueError("Empty peptide is not allowed")
+            if not (PLIFEPRED2_MIN_PEPTIDE_LENGTH
+                    <= len(peptide) <= PLIFEPRED2_MAX_PEPTIDE_LENGTH):
+                raise ValueError(
+                    "PlifePred2 supports peptides of %d-%d residues; got %r "
+                    "(length %d). Upstream drops out-of-range sequences "
+                    "silently, so they are rejected here instead."
+                    % (PLIFEPRED2_MIN_PEPTIDE_LENGTH,
+                       PLIFEPRED2_MAX_PEPTIDE_LENGTH, peptide, len(peptide)))
+            invalid = set(peptide) - _VALID_AMINO_ACIDS
+            if invalid:
+                raise ValueError(
+                    "Peptide %r contains non-standard residues: %s. Only the "
+                    "natural-peptide model is wrapped, so modified peptides "
+                    "are rejected rather than scored as their unmodified "
+                    "sequence." % (peptide, "".join(sorted(invalid))))
+
+    def predict(self, peptides):
+        """Predict whole-blood half-life for a list of peptides.
+
+        Returns
+        -------
+        list of PeptideResult
+            One entry per input peptide, in input order, each holding a single
+            ``Kind.blood_half_life`` prediction with an empty ``allele``. Both
+            ``score`` and ``value`` carry the half-life in **hours**; the raw
+            ``log10(seconds)`` model output is kept in :attr:`last_qc`.
+        """
+        peptide_list = self._normalize_peptides(peptides)
+        self._check_peptides(peptide_list)
+        if not peptide_list:
+            self.last_qc = pd.DataFrame()
+            return []
+
+        output = self._run_sidecar(peptide_list)
+        return [
+            PeptideResult(preds=(Prediction(
+                kind=Kind.blood_half_life,
+                score=hours,
+                value=hours,
+                peptide=peptide,
+                predictor_name=self._predictor_name(),
+                predictor_version=self.predictor_version),))
+            for peptide, hours in zip(peptide_list, output["hours"])
+        ]
+
+    def _run_sidecar(self, peptide_list):
+        with tempfile.TemporaryDirectory(prefix="mhctools_plifepred2_") as tmp:
+            tmp_path = Path(tmp)
+            input_path = tmp_path / "input.csv"
+            output_path = tmp_path / "output.csv"
+            pd.DataFrame({
+                "__mhctools_id": range(len(peptide_list)),
+                "peptide": peptide_list,
+            }).to_csv(input_path, index=False)
+
+            sidecar = Path(__file__).with_name("plifepred2_sidecar.py")
+            command = [
+                self.plifepred2_python,
+                # runpy rather than the script path, so that mhctools/ does not
+                # land on sys.path[0] where mhctools/logging.py would shadow
+                # the stdlib logging module.
+                "-c",
+                ("import runpy,sys; sys.argv=sys.argv[1:]; "
+                 "runpy.run_path(sys.argv[0],run_name='__main__')"),
+                str(sidecar),
+                "--pfeature-home", self.pfeature_home,
+                "--model", str(Path(self.plifepred2_home, _NATURAL_MODEL)),
+                "--input", str(input_path),
+                "--output", str(output_path),
+            ]
+            environment = os.environ.copy()
+            environment["PYTHONNOUSERSITE"] = "1"
+            process = subprocess.run(
+                command,
+                env=environment,
+                capture_output=True,
+                text=True,
+            )
+            if process.returncode != 0:
+                raise RuntimeError(
+                    "PlifePred2 inference failed (exit %d):\n%s" % (
+                        process.returncode,
+                        (process.stderr or process.stdout).strip()))
+            output = parse_plifepred2_results(output_path, peptide_list)
+
+        self.last_qc = output.drop(columns=["hours"])
+        return output
+
+
+def parse_plifepred2_results(filename, peptide_list):
+    """Parse sidecar output into a DataFrame aligned with *peptide_list*.
+
+    Pfeature links its feature rows to inputs by position only, so every input
+    peptide must come back exactly once, under the ``__mhctools_id`` it was
+    given and with its sequence unchanged. Anything else means the rows have
+    shifted relative to the peptides and the scores belong to the wrong ones.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Sorted by ``__mhctools_id``, with the raw ``log10_seconds`` output and
+        the derived ``hours``.
+    """
+    output = pd.read_csv(filename, keep_default_na=False)
+    for column in ("__mhctools_id", "peptide", "log10_seconds"):
+        if column not in output.columns:
+            raise ValueError(
+                "PlifePred2 output missing column %r; got %s"
+                % (column, list(output.columns)))
+    output["__mhctools_id"] = output["__mhctools_id"].astype(int)
+    if sorted(output["__mhctools_id"].tolist()) != list(range(len(peptide_list))):
+        raise RuntimeError(
+            "PlifePred2 output did not preserve every input peptide: expected "
+            "%d rows with ids 0..%d, got ids %s"
+            % (len(peptide_list), len(peptide_list) - 1,
+               sorted(output["__mhctools_id"].tolist())))
+    output = output.sort_values("__mhctools_id").reset_index(drop=True)
+    returned = output["peptide"].tolist()
+    if returned != list(peptide_list):
+        mismatched = [
+            (i, sent, got)
+            for i, (sent, got) in enumerate(zip(peptide_list, returned))
+            if sent != got
+        ]
+        raise RuntimeError(
+            "PlifePred2 returned a different peptide than it was given "
+            "(id, sent, got): %s" % mismatched[:5])
+    output["log10_seconds"] = output["log10_seconds"].astype(float)
+    if not output["log10_seconds"].map(math.isfinite).all():
+        raise RuntimeError(
+            "PlifePred2 returned a non-finite prediction; the feature matrix "
+            "is probably misaligned with the model")
+    output["hours"] = output["log10_seconds"].map(half_life_hours)
+    return output

--- a/mhctools/plifepred2_sidecar.py
+++ b/mhctools/plifepred2_sidecar.py
@@ -1,0 +1,115 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Isolated runtime bridge to user-provided PlifePred2 and Pfeature checkouts.
+
+Both upstreams are GPLv3, so nothing is vendored and neither is imported into
+the mhctools interpreter. This script runs in whatever interpreter owns them
+(``PLIFEPRED2_PYTHON``) and does two things:
+
+1. Shells out to Pfeature's ``pfeature_comp.py`` for the quasi-sequence-order
+   descriptor. That script reads ``Data/Schneider-Wrede.csv`` and
+   ``Data/Grantham.csv`` by relative path, so it must run with its own
+   directory as the working directory.
+2. Loads PlifePred2's natural-peptide RandomForest and predicts.
+
+The model is loaded with joblib, which unpickles; the caller is responsible for
+pointing at checkouts it trusts.
+"""
+
+from argparse import ArgumentParser
+import csv
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+
+def _parse_args():
+    parser = ArgumentParser()
+    parser.add_argument("--pfeature-home", required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--input", required=True)
+    parser.add_argument("--output", required=True)
+    return parser.parse_args()
+
+
+def _run_pfeature(pfeature_home, fasta_path, features_path):
+    """Run Pfeature's QSO job, returning nothing but writing *features_path*."""
+    script = Path(pfeature_home) / "pfeature_comp.py"
+    command = [
+        sys.executable,
+        # runpy rather than the script path so that the Pfeature directory is
+        # not prepended to sys.path in this process's child.
+        "-c",
+        ("import runpy,sys; sys.argv=sys.argv[1:]; "
+         "runpy.run_path(sys.argv[0],run_name='__main__')"),
+        str(script),
+        "-i", str(fasta_path),
+        "-o", str(features_path),
+        "-j", "QSO",
+    ]
+    process = subprocess.run(
+        command,
+        cwd=str(pfeature_home),
+        capture_output=True,
+        text=True,
+    )
+    if process.returncode != 0:
+        raise RuntimeError(
+            "Pfeature QSO extraction failed (exit %d):\n%s" % (
+                process.returncode,
+                (process.stderr or process.stdout).strip()))
+
+
+def main():
+    args = _parse_args()
+
+    import joblib
+    import pandas as pd
+
+    with open(args.input, newline="") as handle:
+        rows = list(csv.DictReader(handle))
+
+    with tempfile.TemporaryDirectory(prefix="mhctools_pfeature_") as tmp:
+        fasta_path = Path(tmp) / "input.fasta"
+        features_path = Path(tmp) / "qso.csv"
+        with open(fasta_path, "w") as handle:
+            for row in rows:
+                handle.write(">%s\n%s\n" % (row["__mhctools_id"], row["peptide"]))
+        _run_pfeature(args.pfeature_home, fasta_path, features_path)
+        features = pd.read_csv(features_path)
+
+    if len(features) != len(rows):
+        raise RuntimeError(
+            "Pfeature returned %d feature rows for %d peptides"
+            % (len(features), len(rows)))
+
+    model = joblib.load(args.model)
+    expected = list(model.feature_names_in_)
+    missing = [name for name in expected if name not in features.columns]
+    if missing:
+        raise RuntimeError(
+            "Pfeature output is missing feature(s) the model requires: %s. "
+            "Is the Pfeature checkout the version PlifePred2 was built "
+            "against?" % missing[:10])
+    # Raw model output is log10(half-life in seconds); the wrapper converts.
+    predictions = model.predict(features[expected])
+
+    with open(args.output, "w", newline="") as handle:
+        writer = csv.DictWriter(
+            handle, fieldnames=["__mhctools_id", "peptide", "log10_seconds"])
+        writer.writeheader()
+        for row, prediction in zip(rows, predictions):
+            writer.writerow({
+                "__mhctools_id": row["__mhctools_id"],
+                "peptide": row["peptide"],
+                "log10_seconds": float(prediction),
+            })
+
+
+if __name__ == "__main__":
+    main()

--- a/mhctools/pred.py
+++ b/mhctools/pred.py
@@ -61,6 +61,11 @@ class Kind:
     # rather than being folded in here, since nothing else in a ``Prediction``
     # records the matrix.
     serum_half_life = "serum_half_life"
+    # Ex-vivo degradation half-life of the free peptide in whole blood, in
+    # hours. Separate from ``serum_half_life``: serum is blood with the cells
+    # and clotting factors removed, and peptide stability differs measurably
+    # between the two (Jenssen & Aspmo 2008).
+    blood_half_life = "blood_half_life"
 
 
 # Canonical "best direction" for each prediction field. Used by
@@ -85,6 +90,7 @@ VALUE_BEST_DIRECTIONS = {
     Kind.pMHC_stability: "max",  # half-life
     Kind.tap_transport: "min",   # predicted TAP-binding affinity, nM
     Kind.serum_half_life: "max",  # hours in serum
+    Kind.blood_half_life: "max",  # hours in whole blood
 }
 
 
@@ -298,6 +304,11 @@ class PeptideResult:
     def serum_half_life(self) -> Optional[Prediction]:
         """Longest-lived serum half-life prediction, or None."""
         return self.best_by_score(Kind.serum_half_life)
+
+    @property
+    def blood_half_life(self) -> Optional[Prediction]:
+        """Longest-lived whole-blood half-life prediction, or None."""
+        return self.best_by_score(Kind.blood_half_life)
 
     @property
     def tcr_binding(self) -> Optional[Prediction]:

--- a/tests/test_plifepred2.py
+++ b/tests/test_plifepred2.py
@@ -1,0 +1,343 @@
+# Copyright (c) 2026 Mount Sinai School of Medicine
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the PlifePred2 whole-blood half-life wrapper.
+
+Parser, unit-conversion, kind and validation tests need no model. The
+end-to-end tests run only when both ``PLIFEPRED2_HOME`` (an installed
+``plifepred2`` package) and ``PFEATURE_HOME`` (Pfeature's ``Standalone``
+directory) are set.
+"""
+
+import math
+import os
+from pathlib import Path
+import tempfile
+
+import pytest
+
+from mhctools import Kind, PlifePred2
+from mhctools.plifepred2 import (
+    PLIFEPRED2_MAX_PEPTIDE_LENGTH,
+    PLIFEPRED2_MIN_PEPTIDE_LENGTH,
+    half_life_hours,
+    parse_plifepred2_results,
+)
+from mhctools.pred import VALUE_BEST_DIRECTIONS, best_direction
+
+
+_OUTPUT = (
+    "__mhctools_id,peptide,log10_seconds\n"
+    "0,SIINFEKLGGALQAKKY,3.157266\n"
+    "1,GILGFVFTLAAAKKWWWQ,3.793472\n")
+
+
+def _write(text):
+    handle = tempfile.NamedTemporaryFile(
+        "w", suffix="_plifepred2.csv", delete=False)
+    handle.write(text)
+    handle.close()
+    return handle.name
+
+
+# --- units ------------------------------------------------------------------
+
+def test_half_life_hours_inverts_log10_seconds():
+    # One hour is 3600 s, so log10(3600) must come back as exactly 1 hour.
+    assert half_life_hours(math.log10(3600.0)) == pytest.approx(1.0)
+    assert half_life_hours(math.log10(86400.0)) == pytest.approx(24.0)
+
+
+def test_units_reproduce_the_documented_training_floor():
+    # The lineage paper (PLoS ONE 2018) discarded peptides with a half-life
+    # below 20 seconds, and the shipped forests' lowest leaf value inverts to
+    # that floor under log10-seconds. This is the evidence the transform rests
+    # on, so it is pinned here: if someone "fixes" the conversion to log2 or
+    # ln, the training range stops making sense.
+    lowest_leaf_value = 1.30535
+    assert half_life_hours(lowest_leaf_value) * 3600.0 == pytest.approx(
+        20.2, abs=0.1)
+    # The natural model's highest leaf value is exactly seven days.
+    assert half_life_hours(5.78161) == pytest.approx(24.0 * 7, rel=1e-4)
+
+
+def test_log2_and_ln_readings_contradict_the_documented_dataset():
+    # Guard the reasoning, not just the result. The paper's dataset spans
+    # 20 seconds to at least 24 hours, and the shipped forests' extreme leaf
+    # values are 1.30535 and 6.91424. Under log2 or ln seconds the whole
+    # training range collapses to a couple of seconds up to ~2-17 minutes:
+    # the floor falls under the documented 20 s and the ceiling nowhere near
+    # the documented 24 h. Only log10 spans the documented range.
+    lowest, highest = 1.30535, 6.91424
+    assert 2.0 ** lowest < 20.0                  # below the documented floor
+    assert 2.0 ** highest < 24 * 3600.0          # far below the documented cap
+    assert math.exp(lowest) < 20.0
+    assert math.exp(highest) < 24 * 3600.0
+    # log10 covers it: floor at 20 s, ceiling well past 24 h.
+    assert 10.0 ** lowest == pytest.approx(20.2, abs=0.1)
+    assert 10.0 ** highest > 24 * 3600.0
+
+
+# --- kind semantics ---------------------------------------------------------
+
+def test_blood_half_life_is_distinct_from_serum_and_pmhc_stability():
+    assert Kind.blood_half_life == "blood_half_life"
+    assert Kind.blood_half_life != Kind.serum_half_life
+    assert Kind.blood_half_life != Kind.pMHC_stability
+
+
+def test_blood_half_life_value_direction_is_max():
+    assert VALUE_BEST_DIRECTIONS[Kind.blood_half_life] == "max"
+    assert best_direction(Kind.blood_half_life, "value") == "max"
+
+
+def test_annotate_exposes_blood_half_life_separately_from_serum():
+    from mhctools.annotate import _OUTPUT_FIELDS, output_field_tokens
+    assert "blood_half_life" in output_field_tokens()
+    assert _OUTPUT_FIELDS["blood_half_life"] == (Kind.blood_half_life, "value")
+    assert _OUTPUT_FIELDS["serum_half_life"] != _OUTPUT_FIELDS["blood_half_life"]
+
+
+def test_accessors_do_not_mix_matrices():
+    from mhctools.pred import PeptideResult, Prediction
+    result = PeptideResult(preds=(
+        Prediction(kind=Kind.blood_half_life, score=3.0, value=3.0,
+                   peptide="SIINFEKLGGALQAKKY"),
+        Prediction(kind=Kind.serum_half_life, score=8.0, value=8.0,
+                   peptide="SIINFEKLGGALQAKKY"),
+    ))
+    assert result.blood_half_life.value == 3.0
+    assert result.serum_half_life.value == 8.0
+
+
+# --- parser -----------------------------------------------------------------
+
+def test_parse_results_converts_to_hours():
+    path = _write(_OUTPUT)
+    try:
+        frame = parse_plifepred2_results(
+            path, ["SIINFEKLGGALQAKKY", "GILGFVFTLAAAKKWWWQ"])
+    finally:
+        os.remove(path)
+    assert frame["log10_seconds"].tolist() == [3.157266, 3.793472]
+    assert frame["hours"].tolist() == pytest.approx([0.39899, 1.72651], rel=1e-4)
+
+
+def test_parse_results_restores_input_order():
+    shuffled = (
+        "__mhctools_id,peptide,log10_seconds\n"
+        "1,GILGFVFTLAAAKKWWWQ,3.793472\n"
+        "0,SIINFEKLGGALQAKKY,3.157266\n")
+    path = _write(shuffled)
+    try:
+        frame = parse_plifepred2_results(
+            path, ["SIINFEKLGGALQAKKY", "GILGFVFTLAAAKKWWWQ"])
+    finally:
+        os.remove(path)
+    assert frame["peptide"].tolist() == [
+        "SIINFEKLGGALQAKKY", "GILGFVFTLAAAKKWWWQ"]
+    assert frame["log10_seconds"].tolist() == [3.157266, 3.793472]
+
+
+def test_parse_results_rejects_shifted_rows():
+    # Pfeature links features to inputs by position only, so a shifted row set
+    # would silently attach each score to the wrong peptide.
+    shifted = (
+        "__mhctools_id,peptide,log10_seconds\n"
+        "0,GILGFVFTLAAAKKWWWQ,3.793472\n"
+        "1,SIINFEKLGGALQAKKY,3.157266\n")
+    path = _write(shifted)
+    try:
+        with pytest.raises(RuntimeError, match="different peptide"):
+            parse_plifepred2_results(
+                path, ["SIINFEKLGGALQAKKY", "GILGFVFTLAAAKKWWWQ"])
+    finally:
+        os.remove(path)
+
+
+def test_parse_results_rejects_dropped_peptide():
+    path = _write("__mhctools_id,peptide,log10_seconds\n0,SIINFEKLGGALQAKKY,3.1\n")
+    try:
+        with pytest.raises(RuntimeError, match="did not preserve"):
+            parse_plifepred2_results(
+                path, ["SIINFEKLGGALQAKKY", "GILGFVFTLAAAKKWWWQ"])
+    finally:
+        os.remove(path)
+
+
+def test_parse_results_rejects_non_finite_prediction():
+    path = _write("__mhctools_id,peptide,log10_seconds\n0,SIINFEKLGGALQAKKY,nan\n")
+    try:
+        with pytest.raises(RuntimeError, match="non-finite"):
+            parse_plifepred2_results(path, ["SIINFEKLGGALQAKKY"])
+    finally:
+        os.remove(path)
+
+
+def test_parse_results_rejects_missing_column():
+    path = _write("__mhctools_id,peptide\n0,SIINFEKLGGALQAKKY\n")
+    try:
+        with pytest.raises(ValueError, match="missing column 'log10_seconds'"):
+            parse_plifepred2_results(path, ["SIINFEKLGGALQAKKY"])
+    finally:
+        os.remove(path)
+
+
+# --- construction and validation --------------------------------------------
+
+def _fake_homes(tmp_path):
+    plifepred2 = tmp_path / "plifepred2"
+    (plifepred2 / "models").mkdir(parents=True)
+    (plifepred2 / "models" / "plifepred2_natural_model.sav").write_text("")
+    pfeature = tmp_path / "Standalone"
+    (pfeature / "Data").mkdir(parents=True)
+    (pfeature / "pfeature_comp.py").write_text("")
+    for name in ("Schneider-Wrede.csv", "Grantham.csv"):
+        (pfeature / "Data" / name).write_text("")
+    return str(plifepred2), str(pfeature)
+
+
+def test_missing_plifepred2_home_is_reported(tmp_path, monkeypatch):
+    monkeypatch.delenv("PLIFEPRED2_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    with pytest.raises(FileNotFoundError, match="PlifePred2 not found"):
+        PlifePred2()
+
+
+def test_missing_model_file_is_reported(tmp_path, monkeypatch):
+    monkeypatch.delenv("PLIFEPRED2_HOME", raising=False)
+    with pytest.raises(FileNotFoundError, match="natural_model.sav not found"):
+        PlifePred2(plifepred2_home=str(tmp_path))
+
+
+def test_missing_pfeature_home_is_reported(tmp_path, monkeypatch):
+    plifepred2_home, _ = _fake_homes(tmp_path)
+    monkeypatch.delenv("PFEATURE_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    with pytest.raises(FileNotFoundError, match="Pfeature not found"):
+        PlifePred2(plifepred2_home=plifepred2_home)
+
+
+def test_pfeature_home_without_distance_matrices_is_reported(tmp_path):
+    plifepred2_home, pfeature_home = _fake_homes(tmp_path)
+    os.remove(os.path.join(pfeature_home, "Data", "Grantham.csv"))
+    with pytest.raises(FileNotFoundError, match="Data/Grantham.csv not found"):
+        PlifePred2(
+            plifepred2_home=plifepred2_home, pfeature_home=pfeature_home)
+
+
+def _predictor(tmp_path):
+    plifepred2_home, pfeature_home = _fake_homes(tmp_path)
+    return PlifePred2(
+        plifepred2_home=plifepred2_home, pfeature_home=pfeature_home)
+
+
+def test_supported_kinds_and_mhc_context(tmp_path):
+    predictor = _predictor(tmp_path)
+    assert predictor.supported_kinds == (Kind.blood_half_life,)
+    support = predictor.kind_support()[Kind.blood_half_life]
+    assert support["mhc_dependence"] == "none"
+    assert support["mhc_class"] == "none"
+
+
+def test_empty_peptide_list_returns_nothing(tmp_path):
+    assert _predictor(tmp_path).predict([]) == []
+
+
+def test_short_peptide_is_rejected_rather_than_silently_dropped(tmp_path):
+    # Upstream's CLI writes these to eliminated_sequences.csv and carries on
+    # with a shorter result set; that must not reach a caller unannounced.
+    with pytest.raises(ValueError, match="12-100 residues"):
+        _predictor(tmp_path).predict(["SIINFEKL"])
+
+
+def test_long_peptide_is_rejected(tmp_path):
+    with pytest.raises(ValueError, match="12-100 residues"):
+        _predictor(tmp_path).predict(["A" * (PLIFEPRED2_MAX_PEPTIDE_LENGTH + 1)])
+
+
+def test_modified_residues_are_rejected(tmp_path):
+    with pytest.raises(ValueError, match="non-standard residues"):
+        _predictor(tmp_path).predict(["SIINFEKLGGALQAKKB"])
+
+
+def test_empty_peptide_is_rejected(tmp_path):
+    with pytest.raises(ValueError, match="Empty peptide"):
+        _predictor(tmp_path).predict([""])
+
+
+def test_missing_python_is_reported(tmp_path):
+    plifepred2_home, pfeature_home = _fake_homes(tmp_path)
+    with pytest.raises(FileNotFoundError, match="Python does not exist"):
+        PlifePred2(
+            plifepred2_home=plifepred2_home,
+            pfeature_home=pfeature_home,
+            plifepred2_python="/nonexistent/python")
+
+
+def test_predictor_version_names_the_natural_model(tmp_path):
+    assert _predictor(tmp_path).predictor_version == "1.0:natural"
+
+
+# --- end-to-end (opt-in) ----------------------------------------------------
+
+requires_plifepred2 = pytest.mark.skipif(
+    not (os.environ.get("PLIFEPRED2_HOME") and os.environ.get("PFEATURE_HOME")),
+    reason="set PLIFEPRED2_HOME and PFEATURE_HOME to run this")
+
+
+@requires_plifepred2
+def test_end_to_end_matches_the_reference_values():
+    # Computed by running Pfeature's QSO extractor and the shipped forest
+    # directly, outside this wrapper.
+    predictor = PlifePred2()
+    results = predictor.predict(["SIINFEKLGGALQAKKY", "GILGFVFTLAAAKKWWWQ"])
+    assert len(results) == 2
+    raw = predictor.last_qc["log10_seconds"].tolist()
+    assert raw == pytest.approx([3.1572664, 3.79347232], rel=1e-6)
+    for peptide, result in zip(
+            ["SIINFEKLGGALQAKKY", "GILGFVFTLAAAKKWWWQ"], results):
+        pred = result.preds[0]
+        assert pred.kind == Kind.blood_half_life
+        assert pred.peptide == peptide
+        assert pred.allele == ""
+        assert pred.value > 0
+        assert pred.value == pred.score
+
+
+@requires_plifepred2
+def test_end_to_end_scores_follow_their_peptides_when_reordered():
+    # Pfeature associates feature rows with inputs by position only, so this
+    # is the test that the ordering contract actually holds through it.
+    predictor = PlifePred2()
+    forward = predictor.predict(["SIINFEKLGGALQAKKY", "GILGFVFTLAAAKKWWWQ"])
+    reverse = predictor.predict(["GILGFVFTLAAAKKWWWQ", "SIINFEKLGGALQAKKY"])
+    assert forward[0].preds[0].value == pytest.approx(reverse[1].preds[0].value)
+    assert forward[1].preds[0].value == pytest.approx(reverse[0].preds[0].value)
+
+
+@requires_plifepred2
+def test_end_to_end_dataframe_has_the_standard_columns():
+    from mhctools.pred import COLUMNS
+    frame = PlifePred2().predict_dataframe(["SIINFEKLGGALQAKKY"])
+    assert list(frame.columns) == list(COLUMNS)
+    assert frame["kind"].tolist() == [Kind.blood_half_life]
+
+
+@requires_plifepred2
+def test_end_to_end_minimum_peptide_length_is_accepted():
+    peptide = "SIINFEKLGGAL"
+    assert len(peptide) == PLIFEPRED2_MIN_PEPTIDE_LENGTH
+    results = PlifePred2().predict([peptide])
+    assert results[0].preds[0].value > 0


### PR DESCRIPTION
Closes #283. Follows #287, which added `serum_half_life` and the PeptiVerse wrapper.

Adds `Kind.blood_half_life` and a `PlifePred2` wrapper for the natural-peptide model.

## Why a second half-life kind

Whole blood is not serum — serum is blood with the cells and clotting factors removed, and peptide stability differs measurably between the two. #279 requires the matrices stay distinct, and nothing in a `Prediction` records an assay matrix, so the kind string is where the distinction lives. PlifePred2's data is also mammalian rather than specifically human. Reusing `serum_half_life` here would have been exactly the mislabel that issue exists to prevent.

## Units: the output is not a probability

Upstream's docs describe the `Halflife` column as a "Predicted probability", and its CLI names the variable `prob`. Both are wrong. Both shipped models are `RandomForestRegressor`, so the `predict_proba` branch never runs and `model.predict` always does.

The target is **`log10(half-life in seconds)`**, established rather than assumed. The lineage paper (Mathur et al. 2018, PLoS ONE 13(6):e0196829) built its dataset from PEPlife filtered to mammalian blood and "removed all those peptides having half-life more than 24 hours and less than 20 seconds". Inverting the extreme leaf values of the shipped forests:

| model | min leaf | max leaf | as log10 s | as log2 s | as ln s |
|---|---|---|---|---|---|
| natural | 1.34242 | 5.78161 | 22.0 s → **604800.0 s = 7.000 d** | 2.5 s → 55 s | 3.8 s → 324 s |
| modified | 1.30535 | 6.91424 | **20.2 s** → 8208000 s = 95.0 d | 2.5 s → 121 s | 3.7 s → 1007 s |

Only log10 is coherent: it reproduces the documented 20-second floor and gives round durations at the ceiling. Under log2 or ln the entire training range sits below that floor. `test_log2_and_ln_readings_contradict_the_documented_dataset` pins the reasoning, not just the constant, so a later "fix" to the conversion fails loudly.

Two departures from the lineage paper confirm PlifePred2 is a distinct model rather than a repackaging: the transform is log10 where the paper used log2 (a constant factor of ~3.32 for anyone porting assumptions), and the paper's 24-hour ceiling is gone.

## The Linux-binary blocker is gone, and clean-room would have been wrong

The bundled `pfeature_comp` is a **PyInstaller freeze** (contains `_MEIPASS`, bundles `libpython3.9.so.1.0`) of `raghavagps/Pfeature`'s `Standalone/pfeature_comp.py`. That plain Python source computes the same descriptor on any platform, so the wrapper uses it and the Linux-only binary is never touched.

Worth a reviewer's attention: this deliberately is **not** a clean-room reimplementation, even though the natural model needs only 42 QSO features. Pfeature's `qos()` has a copy-paste bug —

```python
c3.append((w * zz[k][i]) / (1 + w * zz['sum'][i]))   # Schneider-Wrede
c4.append((w * zz[k][i]) / (1 + w * zz['sum'][i]))   # should be zz2 (Grantham)
```

— so `QSO1_G1` is a byte-for-byte duplicate of `QSO1_SC1` rather than the Grantham lag-1 coupling term (confirmed on real output: `QSO1_SC1=0.3389, QSO1_G1=0.3389`). The model was trained on features carrying that bug, so reproducing its predictions requires reproducing it. An implementation written from the published quasi-sequence-order definition would put a genuine Grantham value there and return different half-lives with no error.

## Isolation and input handling

Both upstreams are GPLv3, so neither is vendored and neither is imported into the mhctools interpreter — inference runs in a subprocess under `PLIFEPRED2_PYTHON`. The sidecar shells out to Pfeature with `cwd` set to its own directory, since `qos()` reads `Data/Schneider-Wrede.csv` and `Data/Grantham.csv` by relative path.

Natural peptides only, 12–100 residues. Upstream's CLI writes out-of-range and non-standard sequences to an `eliminated_sequences.csv` **in the current working directory** and carries on with a shorter result set; these are rejected up front instead, so a caller never receives a quietly truncated answer. The modified model is not wrapped: its modification flags (D-amino acid, terminal, cyclization, PTM) apply to a whole invocation rather than per peptide, and mhctools has nowhere to record a chemical form.

Pfeature associates its feature rows with inputs by **position only**, so the parser requires every peptide back under the id it was given with its sequence unchanged, and there is an opt-in end-to-end test that reorders the batch and checks the scores follow their peptides.

## Tests

Offline for units, kind semantics, parser and validation. End-to-end tests are opt-in on `PLIFEPRED2_HOME` + `PFEATURE_HOME` and were run against the real forest — `SIINFEKLGGALQAKKY` → 3.157266 log10 s (0.399 h), `GILGFVFTLAAAKKWWWQ` → 3.793472 (1.727 h), matching values computed outside the wrapper. Full suite: 781 passed.

## Caveat recorded in the docs

PlifePred2 cites no publication of its own, so its training set is unverified beyond what the artifacts reveal. In the lineage paper the composition-based natural model was the weaker of the pair (r = 0.643 against 0.743 for chemical descriptors), and sequences up to 90% similar were deliberately retained, so reported accuracy is optimistic for novel peptides. Overlap with PEPlife2 (#286) is worth checking before either is treated as independent validation of the other.

https://claude.ai/code/session_01NGKWupeNWvqdmWcWYsXaTc
