### PR TITLE
Make value units explicit per kind, and fill in pMHC_stability's value

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,20 +231,69 @@ Each `Prediction` has a `kind` string describing what it measures:
 
 The canonical prediction kind strings are defined in `mhctools.pred.Kind`.
 
-| Kind | Meaning |
-|---|---|
-| `pMHC_affinity` | Peptide-MHC binding affinity |
-| `pMHC_presentation` | Likelihood of surface presentation (EL/processing) |
-| `pMHC_stability` | Peptide-MHC complex stability |
-| `pMHC_TCR_binding` | TCR recognition of a peptide-MHC (pMHC:TCR binding) |
-| `immunogenicity` | T-cell immunogenicity |
-| `antigen_processing` | Combined processing score |
-| `proteasome_cleavage` | Proteasomal (MHC-I, cytosolic) C-terminal cleavage score |
-| `endolysosomal_cleavage` | Endolysosomal (MHC-II, cathepsin) C-terminal cleavage score |
-| `tap_transport` | TAP transport / binding score |
-| `erap_trimming` | ERAP1 N-terminal trimming score |
-| `serum_half_life` | Degradation half-life of the free peptide in serum, in hours |
-| `blood_half_life` | Degradation half-life of the free peptide in whole blood, in hours |
+| Kind | Meaning | `value` unit |
+|---|---|---|
+| `pMHC_affinity` | Peptide-MHC binding affinity | `nM` (IC50) |
+| `pMHC_presentation` | Likelihood of surface presentation (EL/processing) | — |
+| `pMHC_stability` | Peptide-MHC complex stability | `hours` (Thalf) |
+| `pMHC_TCR_binding` | TCR recognition of a peptide-MHC (pMHC:TCR binding) | — |
+| `immunogenicity` | T-cell immunogenicity | — |
+| `antigen_processing` | Combined processing score | — |
+| `proteasome_cleavage` | Proteasomal (MHC-I, cytosolic) C-terminal cleavage score | — |
+| `endolysosomal_cleavage` | Endolysosomal (MHC-II, cathepsin) C-terminal cleavage score | — |
+| `tap_transport` | TAP transport / binding score | `nM` |
+| `erap_trimming` | ERAP1 N-terminal trimming score | — |
+| `serum_half_life` | Degradation half-life of the free peptide in serum | `hours` |
+| `blood_half_life` | Degradation half-life of the free peptide in whole blood | `hours` |
+
+#### Units
+
+Kind and unit are independent. Every prediction has a `kind`, because every
+prediction measures *something*; only some kinds have a unit. A model that emits
+a bare 0–1 confidence is still a prediction of a kind — it just fills `score` and
+leaves `value` empty. Fill in both wherever the predictor supports it.
+
+- **`score`** — always present, always higher-is-better, unitless. Often a 0–1
+  confidence; for kinds with no meaningful normalization it repeats the `value`
+  so that ranking works without knowing the unit.
+- **`value`** — present only for the kinds marked above, carrying a physical
+  quantity on a **linear** scale in that unit: never a log, never a rescaling,
+  never whatever the upstream tool happened to print.
+- **`percentile_rank`** — present when the predictor scores against a background
+  distribution. Always lower-is-better.
+
+Affinity is the model to copy: `score` is the 0–1 `1-log50k` confidence and
+`value` is the IC50 in nM, so both are filled and each answers a different
+question.
+
+```python
+from mhctools import Kind
+from mhctools.pred import value_unit
+
+value_unit(Kind.pMHC_affinity)     # 'nM'
+value_unit(Kind.blood_half_life)   # 'hours'
+value_unit(Kind.immunogenicity)    # None
+```
+
+Converting is the wrapper's job, and it long predates the registry: affinity
+predictors commonly work in `1-log50k` space internally and every affinity
+wrapper here inverts it to nM, so a NetMHCpan IC50 and an MHCflurry IC50 are
+directly comparable. Half-life kinds work the same way — PlifePred2 is trained
+on `log10(seconds)` and PeptiVerse on `log1p(hours)`, and both wrappers invert
+exactly once and report hours.
+
+A predictor's native output isn't lost, it just doesn't belong in a
+units-bearing field. Wrappers keep it on their `last_qc` frame:
+
+```python
+predictor.predict(["SIINFEKLGGALQAKKY"])
+predictor.last_qc["log10_seconds"]     # PlifePred2's raw model output
+```
+
+Note that sharing a unit is not sharing a measurement: `pMHC_stability`,
+`serum_half_life` and `blood_half_life` are all half-lives in hours and all
+three are different quantities — complex dissociation, free-peptide degradation
+in serum, and free-peptide degradation in whole blood.
 
 Predictors also expose `kind_support()` so downstream code can tell what MHC
 context is meaningful for each emitted kind:

--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -11,6 +11,7 @@ from .pred import (
     Pred,
     Prediction,
     VALUE_BEST_DIRECTIONS,
+    VALUE_UNITS,
     best_direction,
     preds_from_rows,
 )
@@ -108,7 +109,7 @@ def __getattr__(name):
     raise AttributeError(
         "module %r has no attribute %r" % (__name__, name))
 
-__version__ = "3.37.0"
+__version__ = "3.38.0"
 
 __all__ = [
     "Prediction",
@@ -120,6 +121,7 @@ __all__ = [
     "MHC_DEPENDENCE_VALUES",
     "FIELD_BEST_DIRECTIONS",
     "VALUE_BEST_DIRECTIONS",
+    "VALUE_UNITS",
     "best_direction",
     "preds_from_rows",
     "MultiSample",

--- a/mhctools/annotate.py
+++ b/mhctools/annotate.py
@@ -69,8 +69,8 @@ _OUTPUT_FIELDS = {
     "value": (Kind.pMHC_affinity, "value"),
     "presentation": (Kind.pMHC_presentation, "score"),
     "processing": (Kind.antigen_processing, "score"),
-    # NetMHCstabpan reports half-life (Thalf) in `score`, not `value`
-    # (`parse_netmhcstabpan` sets no ic50), so read it from there.
+    # NetMHCstabpan's Thalf(h) lands in both `score` and `value`; read it from
+    # `score`, which is where this field has always read it.
     "stability": (Kind.pMHC_stability, "score"),
     "immunogenicity": (Kind.immunogenicity, "score"),
     "tap_transport": (Kind.tap_transport, "score"),

--- a/mhctools/parsing.py
+++ b/mhctools/parsing.py
@@ -139,7 +139,7 @@ def parse_stdout(
         score_index,
         rank_index=None,
         ic50_index=None,
-
+        value_index=None,
         ignored_value_indices={},
         transforms={}):
     """
@@ -205,6 +205,16 @@ def parse_stdout(
         else:
             ic50 = _try_float(fields[ic50_index])
 
+        # `value_index` fills the same field as `ic50_index` but for kinds
+        # whose value is not an affinity, so it skips the 1-log50k salvage
+        # below -- a half-life in hours must never be reconstructed as if it
+        # were an IC50.
+        if value_index is not None:
+            if ic50_index is not None:
+                raise ValueError(
+                    "pass either ic50_index or value_index, not both")
+            ic50 = _try_float(fields[value_index])
+
         key = str(fields[key_index])
         if sequence_key_mapping:
             original_key = sequence_key_mapping[key]
@@ -215,7 +225,8 @@ def parse_stdout(
 
         # if we have a bad IC50 score we might still get a salvageable
         # log of the score. Strangely, this is necessary sometimes!
-        if ic50_index is not None and (not valid_affinity(ic50)) and np.isfinite(score):
+        if (ic50_index is not None and value_index is None
+                and (not valid_affinity(ic50)) and np.isfinite(score)):
             # pylint: disable=invalid-unary-operand-type
             ic50 = 50000 ** (1 - score)
 
@@ -943,6 +954,10 @@ def parse_netmhcstabpan(
         allele_index=1,
         score_index=5,
         rank_index=6,
+        # Thalf(h) is the half-life in hours, the canonical `value` unit for
+        # Kind.pMHC_stability. It is reported in `score` too, for the callers
+        # and the `stability` output field that have always read it there.
+        value_index=5,
         transforms=transforms)
 
 def parse_netmhciipan43_stdout(

--- a/mhctools/pred.py
+++ b/mhctools/pred.py
@@ -81,17 +81,63 @@ FIELD_BEST_DIRECTIONS = {
     "percentile_rank": "min",
 }
 
-# Per-kind direction for ``value``. ``value`` carries the predictor's
-# raw output unit (IC50 nM for affinity, half-life for stability, ...);
-# whether higher or lower is "better" depends on what the unit means.
-# Add an entry when introducing a new ``value``-bearing kind.
-VALUE_BEST_DIRECTIONS = {
-    Kind.pMHC_affinity: "min",   # IC50 nM
-    Kind.pMHC_stability: "max",  # half-life
-    Kind.tap_transport: "min",   # predicted TAP-binding affinity, nM
-    Kind.serum_half_life: "max",  # hours in serum
-    Kind.blood_half_life: "max",  # hours in whole blood
+# The canonical unit of ``value`` for each kind that has one.
+#
+# ``value`` is always a physical quantity on a LINEAR scale in the unit named
+# here — never a log, never a rescaling, never "whatever upstream printed".
+# Wrappers convert. That rule predates these constants: affinity predictors
+# commonly work in 1-log50k space internally and every affinity wrapper here
+# inverts it to nM before filling ``value`` (see ``parse_stdout``'s
+# ``50000 ** (1 - score)`` salvage and ``caphla._affinity_nm``), so a consumer
+# can compare a NetMHCpan IC50 with an MHCflurry one without asking which
+# transform each applied. Half-life kinds work the same way: PlifePred2 is
+# trained on log10-seconds and PeptiVerse on log1p-hours, and both wrappers
+# invert exactly once and report hours.
+#
+# A predictor's native output is not lost, it just does not belong in a
+# units-bearing field: wrappers keep it in their ``last_qc`` frame
+# (``PlifePred2.last_qc["log10_seconds"]``, for instance).
+#
+# Kind and unit are independent: every prediction has a kind because every
+# prediction measures something, but only some kinds have a unit. A model that
+# emits a bare 0-1 confidence still has a kind -- it fills ``score`` and leaves
+# ``value`` empty. Kinds absent from this mapping are exactly those.
+VALUE_UNITS = {
+    Kind.pMHC_affinity: "nM",
+    Kind.pMHC_stability: "hours",
+    Kind.tap_transport: "nM",
+    Kind.serum_half_life: "hours",
+    Kind.blood_half_life: "hours",
 }
+
+# Per-kind direction for ``value``. Whether higher or lower is "better" depends
+# on what the unit in :data:`VALUE_UNITS` means. Add an entry alongside a
+# ``VALUE_UNITS`` entry when introducing a new ``value``-bearing kind.
+VALUE_BEST_DIRECTIONS = {
+    Kind.pMHC_affinity: "min",   # IC50: tighter binding is a smaller number
+    Kind.pMHC_stability: "max",  # pMHC complex dissociation half-life
+    Kind.tap_transport: "min",   # predicted TAP-binding affinity
+    Kind.serum_half_life: "max",  # survives longer in serum
+    Kind.blood_half_life: "max",  # survives longer in whole blood
+}
+
+
+def value_unit(kind) -> Optional[str]:
+    """Canonical unit of ``value`` for *kind*, or ``None`` if it has no value.
+
+    The unit is always linear — ``"nM"``, ``"hours"`` — never a log-transformed
+    scale. See :data:`VALUE_UNITS`.
+
+    Examples
+    --------
+    >>> value_unit(Kind.pMHC_affinity)
+    'nM'
+    >>> value_unit(Kind.blood_half_life)
+    'hours'
+    >>> value_unit(Kind.immunogenicity) is None
+    True
+    """
+    return VALUE_UNITS.get(kind)
 
 
 def best_direction(kind, field) -> str:

--- a/tests/test_netmhc_stabpan.py
+++ b/tests/test_netmhc_stabpan.py
@@ -99,3 +99,44 @@ def test_netmhc_stabpan_groups_mixed_length_peptides(monkeypatch):
         ["SIINFEKLL"],
         ["SIINFEKLQY"],
     ])
+
+
+def test_stability_value_is_half_life_in_hours():
+    # Thalf(h) must land in `value`, the units-bearing field, and not only in
+    # `score` -- Kind.pMHC_stability declares "hours" in VALUE_UNITS.
+    from mhctools.parsing import parse_netmhcstabpan
+    from mhctools.pred import Kind, value_unit
+
+    stdout = "\n".join([
+        "# NetMHCstabpan version 1.0",
+        "-" * 100,
+        " pos      HLA         peptide    Identity   Prediction  Thalf(h) %Rank_Stab",
+        "-" * 100,
+        "    0  HLA-A*02:01   AAAAAAAAAA   PEPLIST      0.075      0.27      19.00",
+        "-" * 100,
+    ])
+    predictions = parse_netmhcstabpan(stdout)
+    assert len(predictions) == 1
+    pred = predictions[0].to_pred(kind=Kind.pMHC_stability)
+    assert pred.kind == Kind.pMHC_stability
+    assert pred.value == 0.27
+    assert pred.score == 0.27
+    assert value_unit(pred.kind) == "hours"
+
+
+def test_stability_half_life_is_not_salvaged_as_an_affinity():
+    # The 1-log50k salvage in parse_stdout must not fire for a value_index
+    # column: a Thalf of 0 is a real (very unstable) reading, not a missing
+    # IC50 to reconstruct as 50000 ** (1 - score).
+    from mhctools.parsing import parse_netmhcstabpan
+
+    stdout = "\n".join([
+        "# NetMHCstabpan version 1.0",
+        "-" * 100,
+        " pos      HLA         peptide    Identity   Prediction  Thalf(h) %Rank_Stab",
+        "-" * 100,
+        "    0  HLA-A*02:01   AAAAAAAAAA   PEPLIST      0.000      0.00      99.00",
+        "-" * 100,
+    ])
+    predictions = parse_netmhcstabpan(stdout)
+    assert predictions[0].to_pred().value == 0.0

--- a/tests/test_pred.py
+++ b/tests/test_pred.py
@@ -723,3 +723,50 @@ def test_best_by_rank_falls_back_to_allele_less():
     assert best is not None
     assert best.allele == ""
     assert best.percentile_rank == 2.0
+
+
+# --- value units ------------------------------------------------------------
+
+def test_value_unit_returns_the_canonical_unit():
+    from mhctools.pred import value_unit
+    assert value_unit(Kind.pMHC_affinity) == "nM"
+    assert value_unit(Kind.tap_transport) == "nM"
+    assert value_unit(Kind.pMHC_stability) == "hours"
+    assert value_unit(Kind.serum_half_life) == "hours"
+    assert value_unit(Kind.blood_half_life) == "hours"
+
+
+def test_value_unit_is_none_for_unitless_kinds():
+    from mhctools.pred import value_unit
+    for kind in (Kind.immunogenicity, Kind.pMHC_presentation,
+                 Kind.antigen_processing, Kind.proteasome_cleavage,
+                 Kind.endolysosomal_cleavage, Kind.erap_trimming,
+                 Kind.pMHC_TCR_binding):
+        assert value_unit(kind) is None, kind
+
+
+def test_every_value_bearing_kind_declares_both_a_unit_and_a_direction():
+    # The two registries describe the same field, so a kind in one and not the
+    # other means `value` is either unitless or has no defined best direction.
+    from mhctools.pred import VALUE_BEST_DIRECTIONS, VALUE_UNITS
+    assert set(VALUE_UNITS) == set(VALUE_BEST_DIRECTIONS)
+
+
+def test_value_units_are_linear_not_log_scaled():
+    # The convention `value` rests on: a linear physical quantity, so that two
+    # predictors of the same kind are comparable without asking which transform
+    # each applied upstream.
+    from mhctools.pred import VALUE_UNITS
+    for kind, unit in VALUE_UNITS.items():
+        assert "log" not in unit.lower(), kind
+        assert unit in ("nM", "hours"), kind
+
+
+def test_half_life_kinds_share_a_unit_but_not_an_identity():
+    # Serum, whole blood and pMHC complex dissociation are all half-lives in
+    # hours, and all still distinct measurements.
+    from mhctools.pred import value_unit
+    half_life_kinds = (
+        Kind.pMHC_stability, Kind.serum_half_life, Kind.blood_half_life)
+    assert len(set(half_life_kinds)) == 3
+    assert {value_unit(k) for k in half_life_kinds} == {"hours"}


### PR DESCRIPTION
Relates to the endpoint-semantics foundation work in #288.

Makes the canonical unit of `value` machine-readable, instead of a comment sitting next to `VALUE_BEST_DIRECTIONS`.

```python
from mhctools import Kind
from mhctools.pred import value_unit

value_unit(Kind.pMHC_affinity)     # 'nM'
value_unit(Kind.blood_half_life)   # 'hours'
value_unit(Kind.immunogenicity)    # None
```

## Kind and unit are independent

Every prediction has a `kind`, because every prediction measures *something*. Only some kinds have a unit. A model that emits a bare 0–1 confidence is still a prediction of a kind — it fills `score` and leaves `value` empty, and `value_unit` returns `None` for exactly those kinds. The three fields answer different questions and should each be filled wherever the predictor supports it:

| field | always present? | direction | meaning |
|---|---|---|---|
| `score` | yes | higher-better | unitless; often a 0–1 confidence, otherwise a rank-equivalent |
| `value` | only for kinds in `VALUE_UNITS` | kind-specific | a linear physical quantity in the registered unit |
| `percentile_rank` | when scored against a background | lower-better | percentile |

Affinity is the pattern to copy: `score` is the 0–1 `1-log50k` confidence and `value` is the IC50 in nM, so both are filled and neither is redundant.

## Not a new convention — a named one

Affinity predictors commonly work in `1-log50k` space internally, and every affinity wrapper here already inverts it to nM before filling `value` (`parse_stdout`'s `50000 ** (1 - score)` salvage, `caphla._affinity_nm`). That is what lets a NetMHCpan IC50 and an MHCflurry IC50 be compared without asking which transform each applied.

The half-life kinds added in #287 and #308 follow it: PlifePred2 is trained on `log10(seconds)`, PeptiVerse on `log1p(hours)`, and both wrappers invert exactly once and report hours. So the rule `VALUE_UNITS` writes down is: **`value` is always linear, in the registered unit — never a log, never a rescaling, never whatever upstream printed.** A predictor's native output isn't lost, it stays on `last_qc` (`PlifePred2.last_qc["log10_seconds"]`) where nothing will mistake it for a duration.

## A bug the registry exposed

Writing the units down surfaced that `Kind.pMHC_stability` had **no `value` at all**. NetMHCstabpan's `Thalf(h)` went only to `score`, so the `"max"` direction registered for that kind in `VALUE_BEST_DIRECTIONS` was unreachable and `best_by_value(pMHC_stability)` always returned `None`.

`parse_stdout` gains a `value_index` alongside `ic50_index`. Same destination field, but it deliberately skips the `50000 ** (1 - score)` affinity salvage — a `Thalf` of 0 is a real reading of a very unstable complex, not a missing IC50 to reconstruct as if it were an affinity. Passing both raises.

`Thalf(h)` now lands in **both** `score` and `value`. The `stability` output field keeps reading `score`, where it has always read it, so no existing output changes.

## Tests

Registry consistency (`VALUE_UNITS` and `VALUE_BEST_DIRECTIONS` cover the same kinds), that no registered unit is log-scaled, that unitless kinds return `None`, that the three half-life kinds share a unit while staying distinct measurements, plus two NetMHCstabpan parser tests: `Thalf` reaches `value`, and a zero `Thalf` is not salvaged into an affinity. Full suite: 788 passed.

https://claude.ai/code/session_01NGKWupeNWvqdmWcWYsXaTc
