### PR TITLE
Isolate Pfeature's workspace, stop claiming PlifePred2's units, unleak stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,9 @@ leaves `value` empty. Fill in both wherever the predictor supports it.
   so that ranking works without knowing the unit.
 - **`value`** — present only for the kinds marked above, carrying a physical
   quantity on a **linear** scale in that unit: never a log, never a rescaling,
-  never whatever the upstream tool happened to print.
+  never whatever the upstream tool happened to print. A kind having a unit does
+  not oblige every predictor to fill it — one whose transform to that unit is
+  unresolved should leave `value` empty rather than guess (see `PlifePred2`).
 - **`percentile_rank`** — present when the predictor scores against a background
   distribution. Always lower-is-better.
 
@@ -712,7 +714,7 @@ results[0].erap_trimming.score
 | Predictor | Kinds produced | Requires |
 |---|---|---|
 | `PeptiVerse` | Serum half-life (`serum_half_life`) | a PeptiVerse snapshot (`PEPTIVERSE_HOME`) + a torch/transformers Python |
-| `PlifePred2` | Whole-blood half-life (`blood_half_life`) | `plifepred2` (`PLIFEPRED2_HOME`) + a Pfeature checkout (`PFEATURE_HOME`) |
+| `PlifePred2` | Blood half-life (`blood_half_life`) ⚠️ unresolved semantics | `plifepred2` (`PLIFEPRED2_HOME`) + a Pfeature checkout (`PFEATURE_HOME`) |
 
 How long a **free peptide** survives in blood serum before proteases degrade it,
 in hours. This is a peptide-drug property rather than an immunological one: it
@@ -752,29 +754,52 @@ unmodified sequence.
 > `torch.load(weights_only=False)`, which executes pickled code — point
 > `PEPTIVERSE_HOME` only at a snapshot you trust.
 
-`PlifePred2` predicts the same quantity in **whole blood** rather than serum, so
-it emits a different kind: serum is blood with the cells and clotting factors
-removed, and peptide stability differs measurably between the two. Its training
-data is mammalian rather than specifically human.
+`PlifePred2` targets blood rather than serum, so it emits a different kind —
+serum is blood with the cells and clotting factors removed, and peptide
+stability differs measurably between the two.
+
+> ⚠️ **This endpoint's semantics are not established.** PlifePred2 ships no
+> publication, no training data and no target definition, so its units,
+> transform, species and assay matrix are all inferred from the artifacts. By
+> default the wrapper reports only the model's native output and claims no
+> duration at all.
 
 ```python
 from mhctools import PlifePred2
 
 predictor = PlifePred2()                       # PLIFEPRED2_HOME + PFEATURE_HOME
 results = predictor.predict(["SIINFEKLGGALQAKKY"])
-results[0].blood_half_life.value               # hours, higher = longer-lived
-predictor.last_qc["log10_seconds"]             # the raw model output
+results[0].blood_half_life.score               # native output, higher = longer-lived
+results[0].blood_half_life.value               # None by default
+predictor.last_qc["log10_seconds"]             # the same value, named
+
+# Opt in to a duration, accepting the inference below:
+opted_in = PlifePred2(assume_log10_seconds=True)
+opted_in.predict(["SIINFEKLGGALQAKKY"])[0].blood_half_life.value   # hours
 ```
 
-Upstream's docs call this column `Halflife` and describe it as a "Predicted
-probability". It is neither a probability nor a raw duration: both shipped
-models are `RandomForestRegressor` (so upstream's `predict_proba` branch is dead
-code) and the target is `log10(half-life in seconds)`. That transform is
-established, not assumed — the lineage paper discarded peptides below 20 seconds,
-and inverting the shipped forests' extreme leaf values under log10-seconds
-reproduces that floor (20.2 s) and gives round durations at the top (exactly
-7.000 days); under log2 or ln the whole training range falls below the
-documented floor.
+**What is known.** Both shipped models are `RandomForestRegressor`, verified by
+loading them. So the output is not a class probability — upstream's docs
+("Halflife … Predicted probability") and its CLI's `predict_proba` branch are
+both wrong, and the branch is dead code. Being monotone in half-life, the
+output ranks correctly whatever the transform turns out to be.
+
+**What is inferred.** `log10(half-life in seconds)` is the strongest reading:
+inverting the forests' extreme leaf values under it gives round durations —
+exactly 7.000 days for the natural model, 95.0 days for the modified one — to
+about seven significant figures, where log2 and ln both invert the whole
+training range to a few seconds up to a couple of minutes. The minimum also
+lands on 20.2 s, matching the 20-second floor in the lineage paper. That last
+point is corroboration rather than proof: the same forests hold targets past
+that paper's 24-hour ceiling, so PlifePred2 was trained on a different dataset
+and the old filter cannot establish the new target. Note also that the lineage
+paper states log2, not log10.
+
+**What is not established.** The species and assay matrix. `blood_half_life` is
+assigned from the lineage paper's PEPlife-filtered-to-mammalian-blood dataset —
+the best available guide, but inherited from data this model demonstrably does
+not use. Do not report it as a measured whole-blood property, and do not treat
+it as interchangeable with PeptiVerse's human-serum endpoint.
 
 Natural peptides only, 12–100 residues. Upstream's CLI silently drops
 out-of-range and modified sequences into an `eliminated_sequences.csv` and

--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -109,7 +109,7 @@ def __getattr__(name):
     raise AttributeError(
         "module %r has no attribute %r" % (__name__, name))
 
-__version__ = "3.38.0"
+__version__ = "3.39.0"
 
 __all__ = [
     "Prediction",

--- a/mhctools/binding_prediction.py
+++ b/mhctools/binding_prediction.py
@@ -168,13 +168,27 @@ class BindingPrediction(Serializable):
         kind : Kind
             What this prediction measures. Defaults to pMHC_affinity since
             most BindingPrediction objects represent binding affinity.
+
+        Notes
+        -----
+        ``Prediction.value`` normally comes from ``affinity`` (IC50 nM). The
+        exception is ``pMHC_stability``: NetMHCstabpan has no affinity column
+        and reports ``Thalf(h)`` as its score, so the hours that
+        ``VALUE_UNITS`` promises for that kind are read from ``score``. The
+        legacy ``affinity`` attribute is deliberately left alone -- it is
+        documented as a binding affinity, and writing a duration into it would
+        silently change units for ``predict_peptides`` and ``to_dataframe``
+        callers.
         """
+        value = self.affinity
+        if kind == Kind.pMHC_stability and value is None:
+            value = self.score
         return Prediction(
             kind=kind,
             score=self.score if self.score is not None else 0.0,
             peptide=self.peptide,
             allele=self.allele or "",
-            value=self.affinity,
+            value=value,
             percentile_rank=self.percentile_rank,
             source_sequence_name=self.source_sequence_name,
             offset=self.offset,

--- a/mhctools/parsing.py
+++ b/mhctools/parsing.py
@@ -139,7 +139,6 @@ def parse_stdout(
         score_index,
         rank_index=None,
         ic50_index=None,
-        value_index=None,
         ignored_value_indices={},
         transforms={}):
     """
@@ -205,16 +204,6 @@ def parse_stdout(
         else:
             ic50 = _try_float(fields[ic50_index])
 
-        # `value_index` fills the same field as `ic50_index` but for kinds
-        # whose value is not an affinity, so it skips the 1-log50k salvage
-        # below -- a half-life in hours must never be reconstructed as if it
-        # were an IC50.
-        if value_index is not None:
-            if ic50_index is not None:
-                raise ValueError(
-                    "pass either ic50_index or value_index, not both")
-            ic50 = _try_float(fields[value_index])
-
         key = str(fields[key_index])
         if sequence_key_mapping:
             original_key = sequence_key_mapping[key]
@@ -225,8 +214,7 @@ def parse_stdout(
 
         # if we have a bad IC50 score we might still get a salvageable
         # log of the score. Strangely, this is necessary sometimes!
-        if (ic50_index is not None and value_index is None
-                and (not valid_affinity(ic50)) and np.isfinite(score)):
+        if ic50_index is not None and (not valid_affinity(ic50)) and np.isfinite(score):
             # pylint: disable=invalid-unary-operand-type
             ic50 = 50000 ** (1 - score)
 
@@ -954,10 +942,10 @@ def parse_netmhcstabpan(
         allele_index=1,
         score_index=5,
         rank_index=6,
-        # Thalf(h) is the half-life in hours, the canonical `value` unit for
-        # Kind.pMHC_stability. It is reported in `score` too, for the callers
-        # and the `stability` output field that have always read it there.
-        value_index=5,
+        # Thalf(h) is both the score and, once converted to a Prediction, the
+        # `value` in hours -- see BindingPrediction.to_pred. It deliberately
+        # does NOT go through ic50_index: `affinity` is documented as an IC50,
+        # and a duration must not be written there.
         transforms=transforms)
 
 def parse_netmhciipan43_stdout(

--- a/mhctools/plifepred2.py
+++ b/mhctools/plifepred2.py
@@ -12,33 +12,58 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Wrapper for PlifePred2's natural-peptide blood half-life model.
+"""Wrapper for PlifePred2's natural-peptide half-life model.
 
-How long a free peptide survives incubated in **mammalian whole blood**, in
-hours. That matrix matters and is why this emits ``Kind.blood_half_life`` rather
-than the ``Kind.serum_half_life`` that :mod:`mhctools.peptiverse` emits: serum
-is blood with the cells and clotting factors removed, and peptide stability
-differs measurably between the two. Neither is ``pMHC_stability``, which is
-peptide-MHC complex dissociation, and neither is a cleavage-site map.
+.. warning::
 
-Units
------
-Upstream's README calls the output column ``Halflife`` and describes it as a
-"Predicted probability". It is neither a probability nor a raw duration. Both
-shipped models are ``RandomForestRegressor``, so the ``predict_proba`` branch in
-upstream's CLI is dead code, and the target is ``log10(half-life in seconds)``.
+   **This endpoint's semantics are not established.** PlifePred2 ships no
+   publication, no training data and no target definition, so its units,
+   transform, species and assay matrix are all inferred from the artifacts.
+   By default this wrapper therefore reports only the model's native output as
+   ``score`` and leaves ``value`` empty. Pass ``assume_log10_seconds=True`` to
+   opt in to a half-life in hours, accepting the inference below.
 
-That transform is established rather than assumed. The lineage paper (Mathur et
-al. 2018, PLoS ONE 13(6):e0196829) built its dataset from PEPlife filtered to
-mammalian blood, discarding anything below 20 seconds. Inverting the extreme
-leaf values of the shipped forests under log10-seconds reproduces that floor
-(20.2 s) and yields round durations at the top (exactly 7.000 days for the
-natural model, 95.0 days for the modified one); under log2 or ln the entire
-training range falls below the documented 20-second floor, which is impossible.
+What is actually known
+----------------------
+Both shipped models are ``RandomForestRegressor``. That much is verified by
+loading them, and it is enough to establish one thing: the output is **not** a
+class probability, so upstream's README ("Halflife ... Predicted probability")
+and its CLI's ``predict_proba`` branch are both wrong — the branch is dead code
+and ``model.predict`` always runs. The output is a regression target on some
+monotone-in-half-life scale, which makes it usable for ranking whatever the
+transform turns out to be.
 
-Note that PlifePred2 departs from that paper in two ways, so its numbers are not
-the paper's: the transform is log10 where the paper used log2 (a constant factor
-of ~3.32), and the paper's 24-hour ceiling is gone.
+What is inferred, and how strongly
+----------------------------------
+The evidence for ``log10(half-life in seconds)`` is circumstantial but not
+weak. Inverting the extreme leaf values of the shipped forests under that
+reading gives round durations — the natural model's maximum is 604800.0 s,
+exactly 7.000 days, and the modified model's is 8208000 s, exactly 95.0 days —
+agreeing to about seven significant figures. Under log2 or ln the same extrema
+invert to a few seconds up to a couple of minutes, which no half-life dataset
+would span. The minimum also inverts to 20.2 s, matching the 20-second floor
+documented by the lineage paper (Mathur et al. 2018, PLoS ONE 13(6):e0196829).
+
+That last point is the weakest of the three, and it is worth being precise
+about why. The same forests hold targets out to 7 and 95 days, which violates
+the 24-hour ceiling that paper also documents. So PlifePred2 was trained on a
+*different* dataset, and a filter from the old one cannot independently
+establish the new one's target. The round-number extrema stand on their own;
+the floor agreement is corroboration, not proof.
+
+Note also that the lineage paper states log2, not log10 — anyone carrying
+assumptions across from it will be wrong by a factor of log2(10) ~ 3.32.
+
+What is not established at all
+------------------------------
+The **species and assay matrix**. ``Kind.blood_half_life`` is assigned because
+the lineage paper drew its data from PEPlife filtered to mammalian whole blood,
+and that is the best available guide. But it is inherited from a dataset this
+model demonstrably does not use. Whether PlifePred2's own data is whole blood,
+plasma, serum or a mixture, from which species, and ex vivo or in vivo, is
+unknown. Do not report this as a measured whole-blood property, and do not
+treat it as interchangeable with :mod:`mhctools.peptiverse`'s human-serum
+endpoint. Resolving this needs the authors or a model-specific publication.
 
 Natural peptides only
 ---------------------
@@ -112,8 +137,9 @@ _SECONDS_PER_HOUR = 3600.0
 def half_life_hours(log10_seconds):
     """Convert a raw PlifePred2 prediction to hours.
 
-    The model's target is ``log10(half-life in seconds)``; see the module
-    docstring for how that was established.
+    This applies the **inferred** ``log10(seconds)`` transform; see the module
+    docstring for the evidence and its limits. Upstream documents no target,
+    so a caller reaching for this is accepting that inference.
     """
     return (10.0 ** log10_seconds) / _SECONDS_PER_HOUR
 
@@ -194,6 +220,13 @@ class PlifePred2(AlleleFreePredictor):
         the argument, then ``$PLIFEPRED2_PYTHON``, then the current interpreter.
         Upstream pins ``scikit-learn==1.4.2``; a different version loads the
         forest but warns, so give this its own environment to be exact.
+    assume_log10_seconds : bool
+        Opt in to reporting a half-life in hours by treating the model's output
+        as ``log10(seconds)``. Off by default: that transform is inferred from
+        the shipped forests, not documented by upstream (see the module
+        docstring). While off, ``value`` is left empty and only the native
+        output is reported, in ``score``. Turning it on is an assertion that
+        you accept the inference.
     """
 
     mhc_class = "none"
@@ -202,15 +235,19 @@ class PlifePred2(AlleleFreePredictor):
             self,
             plifepred2_home=None,
             pfeature_home=None,
-            plifepred2_python=None):
+            plifepred2_python=None,
+            assume_log10_seconds=False):
         self.plifepred2_home = _find_plifepred2_home(plifepred2_home)
         self.pfeature_home = _find_pfeature_home(pfeature_home)
         self.plifepred2_python = _resolve_python(plifepred2_python)
+        self.assume_log10_seconds = assume_log10_seconds
         self.last_qc = pd.DataFrame()
 
     def __str__(self):
-        return "PlifePred2(plifepred2_home=%r, pfeature_home=%r)" % (
-            self.plifepred2_home, self.pfeature_home)
+        return ("PlifePred2(plifepred2_home=%r, pfeature_home=%r, "
+                "assume_log10_seconds=%r)") % (
+            self.plifepred2_home, self.pfeature_home,
+            self.assume_log10_seconds)
 
     def _default_pred_kind(self):
         return Kind.blood_half_life
@@ -249,9 +286,14 @@ class PlifePred2(AlleleFreePredictor):
         -------
         list of PeptideResult
             One entry per input peptide, in input order, each holding a single
-            ``Kind.blood_half_life`` prediction with an empty ``allele``. Both
-            ``score`` and ``value`` carry the half-life in **hours**; the raw
-            ``log10(seconds)`` model output is kept in :attr:`last_qc`.
+            ``Kind.blood_half_life`` prediction with an empty ``allele``.
+
+            ``score`` is always the model's **native output** — higher means
+            longer-lived, which is all that is needed to rank. ``value`` is the
+            half-life in hours, and is filled **only** when the predictor was
+            constructed with ``assume_log10_seconds=True``; otherwise it is
+            ``None``, because the transform from the native output to a
+            duration is inferred rather than documented.
         """
         peptide_list = self._normalize_peptides(peptides)
         self._check_peptides(peptide_list)
@@ -263,12 +305,13 @@ class PlifePred2(AlleleFreePredictor):
         return [
             PeptideResult(preds=(Prediction(
                 kind=Kind.blood_half_life,
-                score=hours,
-                value=hours,
+                score=native,
+                value=(half_life_hours(native)
+                       if self.assume_log10_seconds else None),
                 peptide=peptide,
                 predictor_name=self._predictor_name(),
                 predictor_version=self.predictor_version),))
-            for peptide, hours in zip(peptide_list, output["hours"])
+            for peptide, native in zip(peptide_list, output["log10_seconds"])
         ]
 
     def _run_sidecar(self, peptide_list):
@@ -311,7 +354,7 @@ class PlifePred2(AlleleFreePredictor):
                         (process.stderr or process.stdout).strip()))
             output = parse_plifepred2_results(output_path, peptide_list)
 
-        self.last_qc = output.drop(columns=["hours"])
+        self.last_qc = output
         return output
 
 
@@ -326,8 +369,10 @@ def parse_plifepred2_results(filename, peptide_list):
     Returns
     -------
     pandas.DataFrame
-        Sorted by ``__mhctools_id``, with the raw ``log10_seconds`` output and
-        the derived ``hours``.
+        Sorted by ``__mhctools_id``, carrying the model's native output as
+        ``log10_seconds`` and, as ``hours_if_log10_seconds``, what that would
+        mean in hours under the inferred transform. The column is named for
+        its assumption on purpose: nothing upstream documents the target.
     """
     output = pd.read_csv(filename, keep_default_na=False)
     for column in ("__mhctools_id", "peptide", "log10_seconds"):
@@ -358,5 +403,6 @@ def parse_plifepred2_results(filename, peptide_list):
         raise RuntimeError(
             "PlifePred2 returned a non-finite prediction; the feature matrix "
             "is probably misaligned with the model")
-    output["hours"] = output["log10_seconds"].map(half_life_hours)
+    output["hours_if_log10_seconds"] = output["log10_seconds"].map(
+        half_life_hours)
     return output

--- a/mhctools/plifepred2_sidecar.py
+++ b/mhctools/plifepred2_sidecar.py
@@ -23,6 +23,7 @@ pointing at checkouts it trusts.
 from argparse import ArgumentParser
 import csv
 from pathlib import Path
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -38,31 +39,56 @@ def _parse_args():
 
 
 def _run_pfeature(pfeature_home, fasta_path, features_path):
-    """Run Pfeature's QSO job, returning nothing but writing *features_path*."""
-    script = Path(pfeature_home) / "pfeature_comp.py"
-    command = [
-        sys.executable,
-        # runpy rather than the script path so that the Pfeature directory is
-        # not prepended to sys.path in this process's child.
-        "-c",
-        ("import runpy,sys; sys.argv=sys.argv[1:]; "
-         "runpy.run_path(sys.argv[0],run_name='__main__')"),
-        str(script),
-        "-i", str(fasta_path),
-        "-o", str(features_path),
-        "-j", "QSO",
-    ]
-    process = subprocess.run(
-        command,
-        cwd=str(pfeature_home),
-        capture_output=True,
-        text=True,
-    )
-    if process.returncode != 0:
+    """Run Pfeature's QSO job, returning nothing but writing *features_path*.
+
+    Upstream's script is written to run from its own directory: it reads
+    ``Data/*.csv`` by relative path, scatters intermediates into the working
+    directory, and finishes with an unscoped ``glob.glob("sam_allcomp*")``
+    followed by ``os.remove`` on every match. Running it with the installation
+    as the working directory therefore requires that installation to be
+    writable, deletes any pre-existing ``sam_allcomp*`` files a user happens to
+    have there, and makes concurrent invocations race over shared intermediate
+    filenames.
+
+    So each extraction gets a private workspace with a copy of ``Data``
+    (~600 KB) and runs there. The installation is only ever read, the wildcard
+    cleanup can only reach this invocation's own scratch files, and concurrent
+    calls against one shared installation cannot collide.
+    """
+    pfeature_home = Path(pfeature_home)
+    script = (pfeature_home / "pfeature_comp.py").resolve()
+    data_source = pfeature_home / "Data"
+    if not data_source.is_dir():
         raise RuntimeError(
-            "Pfeature QSO extraction failed (exit %d):\n%s" % (
-                process.returncode,
-                (process.stderr or process.stdout).strip()))
+            "Pfeature installation %r has no Data directory" % str(pfeature_home))
+
+    with tempfile.TemporaryDirectory(prefix="mhctools_pfeature_run_") as run_dir:
+        # copy, not symlink: a symlinked tree would let upstream's cleanup and
+        # intermediate writes reach back into the installation.
+        shutil.copytree(data_source, Path(run_dir) / "Data")
+        command = [
+            sys.executable,
+            # runpy rather than the script path so that the Pfeature directory
+            # is not prepended to sys.path in this process's child.
+            "-c",
+            ("import runpy,sys; sys.argv=sys.argv[1:]; "
+             "runpy.run_path(sys.argv[0],run_name='__main__')"),
+            str(script),
+            "-i", str(Path(fasta_path).resolve()),
+            "-o", str(Path(features_path).resolve()),
+            "-j", "QSO",
+        ]
+        process = subprocess.run(
+            command,
+            cwd=run_dir,
+            capture_output=True,
+            text=True,
+        )
+        if process.returncode != 0:
+            raise RuntimeError(
+                "Pfeature QSO extraction failed (exit %d):\n%s" % (
+                    process.returncode,
+                    (process.stderr or process.stdout).strip()))
 
 
 def main():

--- a/mhctools/pred.py
+++ b/mhctools/pred.py
@@ -61,10 +61,12 @@ class Kind:
     # rather than being folded in here, since nothing else in a ``Prediction``
     # records the matrix.
     serum_half_life = "serum_half_life"
-    # Ex-vivo degradation half-life of the free peptide in whole blood, in
-    # hours. Separate from ``serum_half_life``: serum is blood with the cells
-    # and clotting factors removed, and peptide stability differs measurably
-    # between the two (Jenssen & Aspmo 2008).
+    # Degradation half-life of the free peptide in whole blood, in hours.
+    # Separate from ``serum_half_life``: serum is blood with the cells and
+    # clotting factors removed, and peptide stability differs measurably
+    # between the two (Jenssen & Aspmo 2008). Note that a predictor may emit
+    # this kind with no ``value`` at all when its transform to a duration is
+    # not established -- see :mod:`mhctools.plifepred2`.
     blood_half_life = "blood_half_life"
 
 

--- a/tests/test_netmhc_stabpan.py
+++ b/tests/test_netmhc_stabpan.py
@@ -101,21 +101,34 @@ def test_netmhc_stabpan_groups_mixed_length_peptides(monkeypatch):
     ])
 
 
-def test_stability_value_is_half_life_in_hours():
-    # Thalf(h) must land in `value`, the units-bearing field, and not only in
-    # `score` -- Kind.pMHC_stability declares "hours" in VALUE_UNITS.
-    from mhctools.parsing import parse_netmhcstabpan
-    from mhctools.pred import Kind, value_unit
+_STABPAN_FIXTURE = "\n".join([
+    "# NetMHCstabpan version 1.0",
+    "-" * 100,
+    " pos      HLA         peptide    Identity   Prediction  Thalf(h) %Rank_Stab",
+    "-" * 100,
+    "    0  HLA-A*02:01   AAAAAAAAAA   PEPLIST      0.075      0.27      19.00",
+    "-" * 100,
+])
 
-    stdout = "\n".join([
+
+def _zero_half_life_fixture():
+    return "\n".join([
         "# NetMHCstabpan version 1.0",
         "-" * 100,
         " pos      HLA         peptide    Identity   Prediction  Thalf(h) %Rank_Stab",
         "-" * 100,
-        "    0  HLA-A*02:01   AAAAAAAAAA   PEPLIST      0.075      0.27      19.00",
+        "    0  HLA-A*02:01   AAAAAAAAAA   PEPLIST      0.000      0.00      99.00",
         "-" * 100,
     ])
-    predictions = parse_netmhcstabpan(stdout)
+
+
+def test_stability_value_is_half_life_in_hours():
+    # Thalf(h) must reach `value`, the units-bearing field, because
+    # Kind.pMHC_stability declares "hours" in VALUE_UNITS.
+    from mhctools.parsing import parse_netmhcstabpan
+    from mhctools.pred import Kind, value_unit
+
+    predictions = parse_netmhcstabpan(_STABPAN_FIXTURE)
     assert len(predictions) == 1
     pred = predictions[0].to_pred(kind=Kind.pMHC_stability)
     assert pred.kind == Kind.pMHC_stability
@@ -124,19 +137,49 @@ def test_stability_value_is_half_life_in_hours():
     assert value_unit(pred.kind) == "hours"
 
 
-def test_stability_half_life_is_not_salvaged_as_an_affinity():
-    # The 1-log50k salvage in parse_stdout must not fire for a value_index
-    # column: a Thalf of 0 is a real (very unstable) reading, not a missing
-    # IC50 to reconstruct as 50000 ** (1 - score).
+def test_half_life_never_reaches_the_legacy_affinity_field():
+    # Regression: `affinity` is documented as an IC50. A duration written
+    # there silently changes units for every legacy consumer.
+    from mhctools.binding_prediction_collection import BindingPredictionCollection
     from mhctools.parsing import parse_netmhcstabpan
 
-    stdout = "\n".join([
-        "# NetMHCstabpan version 1.0",
-        "-" * 100,
-        " pos      HLA         peptide    Identity   Prediction  Thalf(h) %Rank_Stab",
-        "-" * 100,
-        "    0  HLA-A*02:01   AAAAAAAAAA   PEPLIST      0.000      0.00      99.00",
-        "-" * 100,
-    ])
-    predictions = parse_netmhcstabpan(stdout)
-    assert predictions[0].to_pred().value == 0.0
+    predictions = parse_netmhcstabpan(_STABPAN_FIXTURE)
+    assert predictions[0].affinity is None
+
+    frame = BindingPredictionCollection(predictions).to_dataframe()
+    assert frame["affinity"].isna().all()
+    # The half-life is still there, in the column that has always carried it.
+    assert frame["score"].tolist() == [0.27]
+
+
+def test_legacy_serialization_roundtrip_keeps_affinity_empty():
+    from mhctools.binding_prediction import BindingPrediction
+    from mhctools.parsing import parse_netmhcstabpan
+
+    original = parse_netmhcstabpan(_STABPAN_FIXTURE)[0]
+    restored = BindingPrediction.from_dict(original.to_dict())
+    assert restored.affinity is None
+    assert restored.score == 0.27
+
+
+def test_best_by_value_finds_the_stability_half_life():
+    from mhctools.parsing import parse_netmhcstabpan
+    from mhctools.pred import Kind, PeptideResult
+
+    pred = parse_netmhcstabpan(_STABPAN_FIXTURE)[0].to_pred(
+        kind=Kind.pMHC_stability)
+    result = PeptideResult(preds=(pred,))
+    best = result.best_by_value(Kind.pMHC_stability)
+    assert best is not None, "the registered max-value direction was unreachable"
+    assert best.value == 0.27
+
+
+def test_zero_half_life_is_kept_and_not_reconstructed_as_an_affinity():
+    # A Thalf of 0 is a real reading of a very unstable complex, not a missing
+    # IC50 to rebuild as 50000 ** (1 - score).
+    from mhctools.parsing import parse_netmhcstabpan
+    from mhctools.pred import Kind
+
+    prediction = parse_netmhcstabpan(_zero_half_life_fixture())[0]
+    assert prediction.affinity is None
+    assert prediction.to_pred(kind=Kind.pMHC_stability).value == 0.0

--- a/tests/test_plifepred2.py
+++ b/tests/test_plifepred2.py
@@ -59,26 +59,24 @@ def test_half_life_hours_inverts_log10_seconds():
     assert half_life_hours(math.log10(86400.0)) == pytest.approx(24.0)
 
 
-def test_units_reproduce_the_documented_training_floor():
-    # The lineage paper (PLoS ONE 2018) discarded peptides with a half-life
-    # below 20 seconds, and the shipped forests' lowest leaf value inverts to
-    # that floor under log10-seconds. This is the evidence the transform rests
-    # on, so it is pinned here: if someone "fixes" the conversion to log2 or
-    # ln, the training range stops making sense.
+def test_inferred_transform_is_self_consistent_with_the_forest_extrema():
+    # NOT a validation of the transform -- upstream documents no target, and
+    # agreement with our own conversion is not external evidence. This pins
+    # the arithmetic behind the inference recorded in the module docstring, so
+    # that changing `half_life_hours` without revisiting that reasoning fails.
     lowest_leaf_value = 1.30535
     assert half_life_hours(lowest_leaf_value) * 3600.0 == pytest.approx(
         20.2, abs=0.1)
-    # The natural model's highest leaf value is exactly seven days.
+    # The natural model's highest leaf value comes out at exactly seven days.
     assert half_life_hours(5.78161) == pytest.approx(24.0 * 7, rel=1e-4)
 
 
-def test_log2_and_ln_readings_contradict_the_documented_dataset():
-    # Guard the reasoning, not just the result. The paper's dataset spans
-    # 20 seconds to at least 24 hours, and the shipped forests' extreme leaf
-    # values are 1.30535 and 6.91424. Under log2 or ln seconds the whole
-    # training range collapses to a couple of seconds up to ~2-17 minutes:
-    # the floor falls under the documented 20 s and the ceiling nowhere near
-    # the documented 24 h. Only log10 spans the documented range.
+def test_log2_and_ln_readings_give_implausible_durations():
+    # Guard the reasoning, not just the result. Under log2 or ln seconds the
+    # forests' extreme leaf values (1.30535, 6.91424) invert to a range of a
+    # couple of seconds up to about two minutes, which no peptide half-life
+    # dataset would span. This is what makes log10 the strongest reading; it
+    # is not proof, since the training targets themselves are undocumented.
     lowest, highest = 1.30535, 6.91424
     assert 2.0 ** lowest < 20.0                  # below the documented floor
     assert 2.0 ** highest < 24 * 3600.0          # far below the documented cap
@@ -123,7 +121,7 @@ def test_accessors_do_not_mix_matrices():
 
 # --- parser -----------------------------------------------------------------
 
-def test_parse_results_converts_to_hours():
+def test_parse_results_names_the_derived_column_for_its_assumption():
     path = _write(_OUTPUT)
     try:
         frame = parse_plifepred2_results(
@@ -131,7 +129,11 @@ def test_parse_results_converts_to_hours():
     finally:
         os.remove(path)
     assert frame["log10_seconds"].tolist() == [3.157266, 3.793472]
-    assert frame["hours"].tolist() == pytest.approx([0.39899, 1.72651], rel=1e-4)
+    # Not "hours": the conversion rests on an inferred transform, and the
+    # column name has to carry that so a QC frame cannot be read as measured.
+    assert "hours" not in frame.columns
+    assert frame["hours_if_log10_seconds"].tolist() == pytest.approx(
+        [0.39899, 1.72651], rel=1e-4)
 
 
 def test_parse_results_restores_input_order():
@@ -306,14 +308,16 @@ def test_end_to_end_matches_the_reference_values():
     assert len(results) == 2
     raw = predictor.last_qc["log10_seconds"].tolist()
     assert raw == pytest.approx([3.1572664, 3.79347232], rel=1e-6)
-    for peptide, result in zip(
-            ["SIINFEKLGGALQAKKY", "GILGFVFTLAAAKKWWWQ"], results):
+    for peptide, result, native in zip(
+            ["SIINFEKLGGALQAKKY", "GILGFVFTLAAAKKWWWQ"], results, raw):
         pred = result.preds[0]
         assert pred.kind == Kind.blood_half_life
         assert pred.peptide == peptide
         assert pred.allele == ""
-        assert pred.value > 0
-        assert pred.value == pred.score
+        # score is the native model output, and by default no duration is
+        # claimed at all.
+        assert pred.score == pytest.approx(native)
+        assert pred.value is None
 
 
 @requires_plifepred2
@@ -323,8 +327,22 @@ def test_end_to_end_scores_follow_their_peptides_when_reordered():
     predictor = PlifePred2()
     forward = predictor.predict(["SIINFEKLGGALQAKKY", "GILGFVFTLAAAKKWWWQ"])
     reverse = predictor.predict(["GILGFVFTLAAAKKWWWQ", "SIINFEKLGGALQAKKY"])
-    assert forward[0].preds[0].value == pytest.approx(reverse[1].preds[0].value)
-    assert forward[1].preds[0].value == pytest.approx(reverse[0].preds[0].value)
+    assert forward[0].preds[0].score == pytest.approx(reverse[1].preds[0].score)
+    assert forward[1].preds[0].score == pytest.approx(reverse[0].preds[0].score)
+
+
+@requires_plifepred2
+def test_end_to_end_hours_require_explicit_opt_in():
+    # The duration is gated because the transform is inferred, not documented.
+    default = PlifePred2().predict(["SIINFEKLGGALQAKKY"])[0].preds[0]
+    assert default.value is None
+
+    opted_in = PlifePred2(assume_log10_seconds=True)
+    pred = opted_in.predict(["SIINFEKLGGALQAKKY"])[0].preds[0]
+    assert pred.value == pytest.approx(half_life_hours(default.score))
+    assert pred.value == pytest.approx(0.39899, rel=1e-4)
+    # score stays the native output either way, so ranking is unaffected.
+    assert pred.score == pytest.approx(default.score)
 
 
 @requires_plifepred2
@@ -340,4 +358,138 @@ def test_end_to_end_minimum_peptide_length_is_accepted():
     peptide = "SIINFEKLGGAL"
     assert len(peptide) == PLIFEPRED2_MIN_PEPTIDE_LENGTH
     results = PlifePred2().predict([peptide])
-    assert results[0].preds[0].value > 0
+    assert results[0].preds[0].score is not None
+
+
+# --- Pfeature workspace isolation (offline, uses a stub extractor) ----------
+
+# Upstream's real pfeature_comp.py reads Data/ by relative path, scatters
+# intermediates into the working directory, and ends with an unscoped
+# glob.glob("sam_allcomp*") + os.remove. This stub reproduces exactly those
+# three behaviours so the isolation can be tested without a real install.
+_DESTRUCTIVE_STUB = '''\
+import argparse, glob, os, sys
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-i"); parser.add_argument("-o"); parser.add_argument("-j")
+args = parser.parse_args()
+
+# 1. Data must be reachable by RELATIVE path, as upstream reads it.
+open(os.path.join("Data", "Schneider-Wrede.csv")).close()
+
+# 2. Upstream scatters intermediates into the working directory.
+for name in ("sam_allcomp.qso_st", "sam_input.csv"):
+    with open(name, "w") as handle:
+        handle.write("scratch\\n")
+
+# 3. Upstream's unscoped wildcard cleanup.
+for path in glob.glob("sam_allcomp*"):
+    os.remove(path)
+
+with open(args.o, "w") as handle:
+    handle.write("QSO1_SC_A\\n1.0\\n")
+'''
+
+
+def _stub_installation(tmp_path):
+    """A Pfeature-shaped installation whose extractor is the stub above."""
+    home = tmp_path / "Standalone"
+    (home / "Data").mkdir(parents=True)
+    for name in ("Schneider-Wrede.csv", "Grantham.csv"):
+        (home / "Data" / name).write_text("Name,A\nA,0\n")
+    (home / "pfeature_comp.py").write_text(_DESTRUCTIVE_STUB)
+    return home
+
+
+def test_pfeature_cleanup_cannot_delete_files_in_the_installation(tmp_path):
+    # Regression for the wildcard cleanup deleting unrelated user files.
+    from mhctools.plifepred2_sidecar import _run_pfeature
+
+    home = _stub_installation(tmp_path)
+    sentinel = home / "sam_allcomp.review_sentinel"
+    sentinel.write_text("do not delete me")
+
+    fasta = tmp_path / "in.fasta"
+    fasta.write_text(">0\nSIINFEKLGGAL\n")
+    out = tmp_path / "qso.csv"
+    _run_pfeature(str(home), fasta, out)
+
+    assert out.exists(), "extraction still has to produce its output"
+    assert sentinel.exists(), "upstream cleanup reached into the installation"
+    assert sentinel.read_text() == "do not delete me"
+
+
+def test_pfeature_leaves_no_intermediates_in_the_installation(tmp_path):
+    from mhctools.plifepred2_sidecar import _run_pfeature
+
+    home = _stub_installation(tmp_path)
+    before = {path.name for path in home.iterdir()}
+
+    fasta = tmp_path / "in.fasta"
+    fasta.write_text(">0\nSIINFEKLGGAL\n")
+    _run_pfeature(str(home), fasta, tmp_path / "qso.csv")
+
+    assert {path.name for path in home.iterdir()} == before
+
+
+def test_pfeature_works_with_a_read_only_installation(tmp_path):
+    import stat
+    from mhctools.plifepred2_sidecar import _run_pfeature
+
+    home = _stub_installation(tmp_path)
+    fasta = tmp_path / "in.fasta"
+    fasta.write_text(">0\nSIINFEKLGGAL\n")
+    out = tmp_path / "qso.csv"
+
+    read_only = stat.S_IRUSR | stat.S_IXUSR
+    paths = [home / "Data", home]
+    original = [path.stat().st_mode for path in paths]
+    for path in paths:
+        path.chmod(read_only)
+    try:
+        _run_pfeature(str(home), fasta, out)
+    finally:
+        for path, mode in zip(paths, original):
+            path.chmod(mode)
+    assert out.exists()
+
+
+def test_concurrent_extractions_do_not_collide_on_one_installation(tmp_path):
+    from concurrent.futures import ThreadPoolExecutor
+    from mhctools.plifepred2_sidecar import _run_pfeature
+
+    home = _stub_installation(tmp_path)
+
+    def run(index):
+        fasta = tmp_path / ("in_%d.fasta" % index)
+        fasta.write_text(">0\nSIINFEKLGGAL\n")
+        out = tmp_path / ("qso_%d.csv" % index)
+        _run_pfeature(str(home), fasta, out)
+        return out.exists()
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        assert all(pool.map(run, range(4)))
+
+
+def test_missing_data_directory_is_reported(tmp_path):
+    from mhctools.plifepred2_sidecar import _run_pfeature
+
+    home = tmp_path / "Standalone"
+    home.mkdir()
+    (home / "pfeature_comp.py").write_text(_DESTRUCTIVE_STUB)
+    with pytest.raises(RuntimeError, match="no Data directory"):
+        _run_pfeature(str(home), tmp_path / "in.fasta", tmp_path / "out.csv")
+
+
+def test_value_is_withheld_by_default(tmp_path):
+    # The units gate is a constructor-level contract, checkable without a model.
+    assert _predictor(tmp_path).assume_log10_seconds is False
+
+
+def test_opt_in_is_visible_in_the_repr(tmp_path):
+    plifepred2_home, pfeature_home = _fake_homes(tmp_path)
+    predictor = PlifePred2(
+        plifepred2_home=plifepred2_home,
+        pfeature_home=pfeature_home,
+        assume_log10_seconds=True)
+    assert "assume_log10_seconds=True" in str(predictor)


### PR DESCRIPTION
Fixes #310, #311 and #312 — all regressions in work I shipped in 3.37.0–3.38.0. Thanks for the reviews; all three reproduced.

## #310 — Pfeature cleanup could delete files in the installation (P1, destructive)

Confirmed at the upstream source: `pfeature_comp.py` ends with

```python
filelist = glob.glob("sam_allcomp*")
for file_2 in filelist:
    os.remove(file_2)
```

unscoped and relative to the working directory, and it scatters intermediates (`sam_allcomp.*`, `sam_input.csv`) there along the way. The sidecar ran it with `cwd=pfeature_home`, so it **required a writable installation, deleted any pre-existing `sam_allcomp*` file a user happened to have there, and let concurrent calls race over shared intermediate filenames.**

Each extraction now runs in its own `TemporaryDirectory` with a copy of `Data/` (~600 KB). The installation is only ever read; the wildcard cleanup can only reach the invocation's own scratch. Copy rather than symlink, deliberately — a symlinked tree would let the cleanup reach back into the installation.

Predictions are unchanged byte for byte (`3.157266404183623`, `3.7934723194625297` before and after).

The regression tests need no real Pfeature: a stub extractor reproduces the three behaviours that matter — relative `Data/` reads, intermediates in cwd, and the wildcard cleanup. Verified they fail against the previous code:

```
FAILED test_pfeature_cleanup_cannot_delete_files_in_the_installation
FAILED test_pfeature_leaves_no_intermediates_in_the_installation
FAILED test_pfeature_works_with_a_read_only_installation
```

plus a concurrency test running four extractions against one shared installation.

## #311 — PlifePred2 published an inference as established fact (P1)

You're right, and the internal contradiction you point at was real: the docstring said the transform was "established rather than assumed" while also admitting the training set is unknown, and it asserted an ex-vivo mammalian-whole-blood assay inherited from a paper whose dataset this model demonstrably does not use.

**`value` is now withheld by default.** `score` carries the model's native output — monotone in half-life, so ranking is unaffected — and a duration in hours requires opting in:

```python
PlifePred2().predict([pep])[0].blood_half_life.value                          # None
PlifePred2(assume_log10_seconds=True).predict([pep])[0].blood_half_life.value  # hours
```

The docs now separate three tiers explicitly:

- **Verified** — both models are `RandomForestRegressor`, so the output is not a class probability and upstream's `predict_proba` branch is dead code.
- **Inferred** — `log10(seconds)`, resting on the round-number leaf extrema (7.000 days, 95.0 days, ~7 significant figures) where log2 and ln invert the whole training range to seconds-to-minutes. The 20-second floor agreement is now described as **corroboration, not proof**, exactly on your reasoning: once the dataset differs, the old filter cannot establish the new target.
- **Not established** — species and assay matrix, inherited from a dataset this model does not use.

The derived QC column is renamed `hours_if_log10_seconds` so a QC frame can't be read as measured, and the tests that read as validating the transform now state they pin the arithmetic behind an inference rather than confirm it.

I did not withhold the typed endpoint entirely, taking your first option (gate) rather than the second. Say the word if you'd rather it not ship at all until the authors confirm.

## #312 — half-life leaked into the legacy affinity field (P2)

Reproduced, and my "no existing output changed" claim in #309 was wrong. `value_index` filled `Prediction.value` *by way of* `BindingPrediction.affinity`, so Thalf(h) reached a field documented as an IC50 and surfaced through `predict_peptides` and `to_dataframe`.

The parser plumbing is reverted — `affinity` is `None` for NetMHCstabpan again, as before #309 — and the hours are resolved in `to_pred` instead, which is the single conversion point and the one place the kind is known. Tests now cover the legacy object, dataframe and serialization paths alongside the typed one, plus `best_by_value(Kind.pMHC_stability)` and the zero-half-life case.

## Not addressed here

#313–#317 are queued behind these three, per your prioritization. Your per-bond note — that an enzyme field alone won't preserve site coordinates and context — is taken; I haven't started that design and won't until the shape is agreed.

Full suite: 798 passed, and the PlifePred2 end-to-end tests were re-run against the real forest.

https://claude.ai/code/session_01NGKWupeNWvqdmWcWYsXaTc
