### PR TITLE
Bound IEDB waits and verify cached MixTCRpred models offline

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,6 +51,7 @@ jobs:
             tests/test_mhc_formats.py \
             tests/test_netchop_parse.py \
             tests/test_process_helpers.py \
+            tests/test_iedb_transport.py \
             tests/test_pred.py \
             tests/test_annotate_table.py \
             tests/test_prime.py \
@@ -72,6 +73,7 @@ jobs:
             tests/test_random.py
 
   integration-netmhc:
+    timeout-minutes: 30
     if: github.repository == 'openvax/mhctools'
     runs-on: ubuntu-22.04
     env:
@@ -146,7 +148,7 @@ jobs:
         run: |
           mkdir -p "$NETMHC_BUNDLE_TMPDIR"
           export PATH="$PATH:$NETMHC_BUNDLE_HOME/bin"
-          ./test.sh
+          ./test.sh -v --durations=15 -o faulthandler_timeout=120
 
   integration-tulip:
     # Exercises the TULIP wrapper end-to-end: mhctools runs in one interpreter

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -273,6 +273,8 @@ jobs:
         with:
           path: ${{ env.MHCTOOLS_DATA_DIR }}
           key: mixtcrpred-${{ runner.os }}-${{ hashFiles('mhctools/artifacts.py', 'mhctools/mixtcrpred.py') }}
+          restore-keys: |
+            mixtcrpred-${{ runner.os }}-
 
       - name: Fetch licensed source and one optional Zenodo model
         run: |

--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -109,7 +109,7 @@ def __getattr__(name):
     raise AttributeError(
         "module %r has no attribute %r" % (__name__, name))
 
-__version__ = "3.39.0"
+__version__ = "3.39.1"
 
 __all__ = [
     "Prediction",

--- a/mhctools/iedb.py
+++ b/mhctools/iedb.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 import io
+import math
 
 # pylint: disable=import-error
 from urllib.request import urlopen, Request
@@ -114,7 +115,10 @@ def _parse_iedb_response(response):
         "percentile rank": "rank"})
     return df
 
-def _query_iedb(request_values, url):
+DEFAULT_REQUEST_TIMEOUT = 60.0
+
+
+def _query_iedb(request_values, url, timeout=DEFAULT_REQUEST_TIMEOUT):
     """
     Call into IEDB's web API for MHC binding prediction using request dictionary
     with fields:
@@ -123,14 +127,23 @@ def _query_iedb(request_values, url):
         - "sequence_text"
         - "allele"
 
-    Parse the response into a DataFrame.
+    Parse the response into a DataFrame. ``timeout`` bounds individual
+    blocking socket operations (connection and reads), in seconds; it is
+    not a total deadline for an entire multi-sequence prediction.
     """
     data = urlencode(request_values)
     req = Request(url, data.encode("ascii"))
-    response = urlopen(req).read()
+    with urlopen(req, timeout=timeout) as handle:
+        response = handle.read()
     return _parse_iedb_response(response)
 
 class IedbBasePredictor(BasePredictor):
+    """IEDB web predictor with a configurable socket timeout in seconds.
+
+    ``request_timeout`` defaults to 60 seconds for each blocking connection
+    or read. Timeouts follow the existing ``raise_on_error`` policy.
+    """
+
     def __init__(
             self,
             alleles,
@@ -139,7 +152,13 @@ class IedbBasePredictor(BasePredictor):
             url,
             min_peptide_length=8,
             include_length_in_request=True,
-            raise_on_error=True):
+            raise_on_error=True,
+            request_timeout=DEFAULT_REQUEST_TIMEOUT):
+        if (not isinstance(request_timeout, (int, float))
+                or isinstance(request_timeout, bool)
+                or not math.isfinite(request_timeout) or request_timeout <= 0):
+            raise ValueError("request_timeout must be a finite positive number")
+        self.request_timeout = request_timeout
         BasePredictor.__init__(
             self,
             alleles=alleles,
@@ -234,7 +253,8 @@ class IedbBasePredictor(BasePredictor):
                     request)
 
                 try:
-                    response_df = _query_iedb(request, self.url)
+                    response_df = _query_iedb(
+                        request, self.url, timeout=self.request_timeout)
                     for _, row in response_df.iterrows():
                         binding_predictions.append(
                             BindingPrediction(
@@ -271,12 +291,14 @@ class IedbNetMHCcons(IedbBasePredictor):
             self,
             alleles,
             default_peptide_lengths=[8, 9, 10, 11],
-            raise_on_error=True):
+            raise_on_error=True,
+            request_timeout=DEFAULT_REQUEST_TIMEOUT):
         IedbBasePredictor.__init__(
             self,
             alleles=alleles,
             default_peptide_lengths=default_peptide_lengths,
             raise_on_error=raise_on_error,
+            request_timeout=request_timeout,
             prediction_method="netmhccons",
             url=IEDB_MHC_CLASS_I_URL)
 
@@ -285,12 +307,14 @@ class IedbNetMHCpan(IedbBasePredictor):
             self,
             alleles,
             default_peptide_lengths=[8, 9, 10, 11],
-            raise_on_error=True):
+            raise_on_error=True,
+            request_timeout=DEFAULT_REQUEST_TIMEOUT):
         IedbBasePredictor.__init__(
             self,
             alleles=alleles,
             default_peptide_lengths=default_peptide_lengths,
             raise_on_error=raise_on_error,
+            request_timeout=request_timeout,
             prediction_method="netmhcpan",
             url=IEDB_MHC_CLASS_I_URL)
 
@@ -299,12 +323,14 @@ class IedbSMM(IedbBasePredictor):
             self,
             alleles,
             default_peptide_lengths=[8, 9, 10, 11],
-            raise_on_error=True):
+            raise_on_error=True,
+            request_timeout=DEFAULT_REQUEST_TIMEOUT):
         IedbBasePredictor.__init__(
             self,
             alleles=alleles,
             default_peptide_lengths=default_peptide_lengths,
             raise_on_error=raise_on_error,
+            request_timeout=request_timeout,
             prediction_method="smm",
             url=IEDB_MHC_CLASS_I_URL)
 
@@ -313,12 +339,14 @@ class IedbSMM_PMBEC(IedbBasePredictor):
             self,
             alleles,
             default_peptide_lengths=[8, 9, 10, 11],
-            raise_on_error=True):
+            raise_on_error=True,
+            request_timeout=DEFAULT_REQUEST_TIMEOUT):
         IedbBasePredictor.__init__(
             self,
             alleles=alleles,
             default_peptide_lengths=default_peptide_lengths,
             raise_on_error=raise_on_error,
+            request_timeout=request_timeout,
             prediction_method="smmpmbec",
             url=IEDB_MHC_CLASS_I_URL)
 
@@ -332,7 +360,8 @@ class IedbNetMHCIIpan(IedbBasePredictor):
             alleles,
             default_peptide_lengths=[15, 16, 17, 18, 19, 20],
             raise_on_error=True,
-            url=IEDB_MHC_CLASS_II_URL):
+            url=IEDB_MHC_CLASS_II_URL,
+            request_timeout=DEFAULT_REQUEST_TIMEOUT):
         IedbBasePredictor.__init__(
             self,
             alleles=alleles,
@@ -340,6 +369,7 @@ class IedbNetMHCIIpan(IedbBasePredictor):
             default_peptide_lengths=default_peptide_lengths,
             prediction_method="NetMHCIIpan",
             raise_on_error=raise_on_error,
+            request_timeout=request_timeout,
             url=url,
             min_peptide_length=9,
             include_length_in_request=False)

--- a/mhctools/mixtcrpred.py
+++ b/mhctools/mixtcrpred.py
@@ -186,8 +186,8 @@ def _zenodo_files():
             record = json.load(response)
     except (OSError, ValueError) as error:
         raise RuntimeError(
-            "Could not read MixTCRpred model metadata from %s" %
-            ZENODO_API_URL) from error
+            "Could not read MixTCRpred model metadata from %s: %s" %
+            (ZENODO_API_URL, error)) from error
     if str(record.get("id")) != ZENODO_RECORD:
         raise RuntimeError("Zenodo returned unexpected MixTCRpred record")
     return {entry["key"]: entry for entry in record.get("files", ())}
@@ -285,8 +285,14 @@ def fetch_models(
         data_dir=None,
         models=None,
         all_models=False,
-        high_confidence=False):
-    """Fetch selected MixTCRpred weights and return their catalog entries."""
+        high_confidence=False,
+        refresh_metadata=False):
+    """Fetch weights; verify recorded downloads locally unless refreshing.
+
+    An immutable Zenodo record and its saved MD5/SHA-256/size manifest
+    identify existing downloads. Unrecorded weights still require Zenodo
+    verification. ``refresh_metadata=True`` rechecks remote metadata too.
+    """
     home = _resolve_home(mixtcrpred_path, data_dir=data_dir)
     catalog = model_catalog(mixtcrpred_path=home)
     selected = _select_catalog_models(
@@ -297,10 +303,24 @@ def fetch_models(
     )
     if not selected:
         return ()
-    files = _zenodo_files()
     model_dir = home / "pretrained_models"
     manifest = _read_model_manifest(model_dir)
+    pending = []
     for model in selected:
+        path = Path(model.path)
+        recorded = manifest["models"].get(model.name)
+        if refresh_metadata or recorded is None or not path.is_file():
+            pending.append(model)
+            continue
+        md5, sha256 = _hashes(path)
+        if (recorded.get("filename") != path.name or
+                recorded.get("size") != path.stat().st_size or
+                recorded.get("md5") != md5 or recorded.get("sha256") != sha256):
+            raise RuntimeError(
+                "Existing MixTCRpred checkpoint does not match its recorded "
+                "manifest: %s. Move it aside before fetching again." % path)
+    files = _zenodo_files() if pending else {}
+    for model in pending:
         _fetch_one_model(model, files, manifest)
         _write_model_manifest(model_dir, manifest)
     refreshed = {model.name: model for model in model_catalog(mixtcrpred_path=home)}

--- a/tests/test_iedb.py
+++ b/tests/test_iedb.py
@@ -25,7 +25,7 @@ protein_sequence_dict = {
 
 @pytest.mark.xfail(reason="IEDB server giving 403 errors from GitHub actions runners")
 def test_netmhcpan_iedb():
-    predictor = IedbNetMHCpan(alleles=[DEFAULT_ALLELE])
+    predictor = IedbNetMHCpan(alleles=[DEFAULT_ALLELE], request_timeout=5)
     binding_predictions = predictor.predict_subsequences(
         protein_sequence_dict,
         peptide_lengths=[9])
@@ -40,7 +40,7 @@ def test_netmhcpan_iedb():
 
 @pytest.mark.xfail(reason="IEDB server giving 403 errors from GitHub actions runners")
 def test_netmhcpan_iedb_unsupported_allele():
-    predictor = IedbNetMHCpan(alleles=[DEFAULT_ALLELE, UNSUPPORTED_ALLELE], raise_on_error=False)
+    predictor = IedbNetMHCpan(alleles=[DEFAULT_ALLELE, UNSUPPORTED_ALLELE], raise_on_error=False, request_timeout=5)
     binding_predictions = predictor.predict_subsequences(
         protein_sequence_dict,
         peptide_lengths=[9])
@@ -48,7 +48,7 @@ def test_netmhcpan_iedb_unsupported_allele():
         "Expected 4 binding predictions from %s" % (binding_predictions,)
 
     # check that the error is raised when raise_on_error is left at default (True)
-    predictor = IedbNetMHCpan(alleles=[DEFAULT_ALLELE, UNSUPPORTED_ALLELE])
+    predictor = IedbNetMHCpan(alleles=[DEFAULT_ALLELE, UNSUPPORTED_ALLELE], request_timeout=5)
     with assert_raises(ValueError):
         binding_predictions = predictor.predict_subsequences(
             protein_sequence_dict,

--- a/tests/test_iedb_transport.py
+++ b/tests/test_iedb_transport.py
@@ -1,0 +1,99 @@
+"""Offline HTTP timeout and error-policy regressions for IEDB predictors."""
+
+import io
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Event, Thread
+
+import pytest
+
+from mhctools import iedb
+
+
+RESPONSE = (
+    b"allele seq_num start end length peptide ic50 percentile_rank\n"
+    b"HLA-A*02:01 1 1 9 9 SIINFEKLA 123.0 1.5\n")
+
+
+@pytest.mark.parametrize("predictor_class", [
+    iedb.IedbNetMHCcons, iedb.IedbNetMHCpan, iedb.IedbSMM,
+    iedb.IedbSMM_PMBEC, iedb.IedbNetMHCIIpan,
+])
+def test_public_predictors_forward_timeout_and_close_response(
+        predictor_class, monkeypatch):
+    handles = []
+    timeouts = []
+
+    def open_response(request, timeout):
+        assert request.get_method() == "POST"
+        timeouts.append(timeout)
+        handle = io.BytesIO(RESPONSE)
+        handles.append(handle)
+        return handle
+
+    monkeypatch.setattr(iedb, "urlopen", open_response)
+    for configured in (None, 2.5):
+        options = {} if configured is None else {"request_timeout": configured}
+        predictor = predictor_class(alleles=["HLA-A*02:01"], **options)
+        predictions = predictor.predict_subsequences(
+            {"input": "SIINFEKLA"}, peptide_lengths=[9])
+        assert predictions[0].affinity == 123.0
+        assert handles[-1].closed
+    assert timeouts == [iedb.DEFAULT_REQUEST_TIMEOUT, 2.5]
+
+
+@pytest.mark.parametrize("timeout", [0, -1, float("inf"), float("nan"), None, True])
+def test_invalid_timeout_is_rejected(timeout):
+    with pytest.raises(ValueError, match="finite positive"):
+        iedb.IedbNetMHCpan(alleles=["HLA-A*02:01"], request_timeout=timeout)
+
+
+def test_read_timeout_closes_response_and_respects_error_policy(monkeypatch):
+    class StalledResponse(io.BytesIO):
+        def read(self, *args):
+            raise TimeoutError("IEDB response stalled")
+
+    handles = []
+
+    def open_response(request, timeout):
+        handle = StalledResponse()
+        handles.append(handle)
+        return handle
+
+    monkeypatch.setattr(iedb, "urlopen", open_response)
+    predictor = iedb.IedbNetMHCpan(alleles=["HLA-A*02:01"])
+    with pytest.raises(TimeoutError, match="stalled"):
+        predictor.predict_subsequences({"input": "SIINFEKLA"}, [9])
+    assert handles[-1].closed
+    predictor.raise_on_error = False
+    assert len(predictor.predict_subsequences({"input": "SIINFEKLA"}, [9])) == 0
+    assert handles[-1].closed
+
+
+def test_http_body_stall_obeys_socket_timeout():
+    """Exercise urllib's actual transport against a local stalled response."""
+    release = Event()
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            self.send_response(200)
+            self.send_header("Content-Length", "100")
+            self.end_headers()
+            self.wfile.flush()
+            # Bound the fixture even if the client timeout regresses.
+            release.wait(1)
+
+        def log_message(self, *args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = Thread(target=lambda: server.serve_forever(poll_interval=0.01))
+    thread.start()
+    try:
+        url = "http://127.0.0.1:%d/" % server.server_port
+        with pytest.raises(TimeoutError):
+            iedb._query_iedb({"method": "fixture"}, url, timeout=0.05)
+    finally:
+        release.set()
+        server.shutdown()
+        server.server_close()
+        thread.join()

--- a/tests/test_mixtcrpred.py
+++ b/tests/test_mixtcrpred.py
@@ -200,6 +200,36 @@ def test_fetch_models_downloads_atomically_and_records_hashes(
     assert manifest["models"][MODEL]["md5"] == md5
     assert len(manifest["models"][MODEL]["sha256"]) == 64
 
+    def unavailable(url, timeout):
+        raise OSError("fixture offline")
+
+    monkeypatch.setattr(mixtcrpred, "urlopen", unavailable)
+    # A previously verified checkpoint can be used with no network access.
+    assert mixtcrpred.fetch_models(home, models=[MODEL])[0].status == "ready"
+    with pytest.raises(RuntimeError, match="fixture offline"):
+        mixtcrpred.fetch_models(home, models=[MODEL], refresh_metadata=True)
+
+    path = Path(selected[0].path)
+    # Same size, different contents: size alone must never verify a cache.
+    path.write_bytes(b"x" * len(content))
+    with pytest.raises(RuntimeError, match="does not match its recorded"):
+        mixtcrpred.fetch_models(home, models=[MODEL])
+
+    path.unlink()
+    with pytest.raises(RuntimeError, match="fixture offline"):
+        mixtcrpred.fetch_models(home, models=[MODEL])
+
+
+def test_unrecorded_cached_model_requires_remote_verification(monkeypatch, tmp_path):
+    home = _make_home(tmp_path)
+
+    def unavailable(url, timeout):
+        raise OSError("fixture offline")
+
+    monkeypatch.setattr(mixtcrpred, "urlopen", unavailable)
+    with pytest.raises(RuntimeError, match="fixture offline"):
+        mixtcrpred.fetch_models(home, models=[MODEL])
+
 
 def test_model_catalog_json_is_serializable(tmp_path):
     home = _make_home(tmp_path)


### PR DESCRIPTION
IEDB requests could wait indefinitely and make the full integration job appear stalled. Add a finite configurable socket timeout to every public IEDB predictor, close responses on success/failure, and preserve the existing error policy. CI reports individual tests, slow durations and timeout tracebacks, with a 30-minute integration job ceiling.

The release also exposed a repeated Zenodo outage: restored MixTCRpred checkpoints still required live metadata. Reuse them only after checking the saved immutable record, filename, size, MD5 and SHA-256; unrecorded/missing models still require remote verification. `refresh_metadata=True` explicitly rechecks Zenodo, and failures include the underlying transport diagnostic. Restore earlier caches across wrapper changes; verification remains mandatory.

Validation: `./lint.sh` passes; `TEST_SH_MAX=4 ./test.sh` passes (812 passed, 65 skipped, 2 xfailed). Regression tests cover real local HTTP body stalls, predictor timeout forwarding, response cleanup/error policy, verified offline caches, altered same-size checkpoints, missing files/manifests, and explicit refresh. Version 3.39.1.

Closes #277. Closes #321.
