### PR TITLE
Validate half-life input boundaries, outputs and asset paths

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -275,6 +275,8 @@ jobs:
         with:
           path: ${{ env.MHCTOOLS_DATA_DIR }}
           key: mixtcrpred-${{ runner.os }}-${{ hashFiles('mhctools/artifacts.py', 'mhctools/mixtcrpred.py') }}
+          restore-keys: |
+            mixtcrpred-${{ runner.os }}-
 
       - name: Fetch licensed source and one optional Zenodo model
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,6 +52,8 @@ jobs:
             tests/test_netchop_parse.py \
             tests/test_process_helpers.py \
             tests/test_iedb_transport.py \
+            tests/test_peptiverse.py \
+            tests/test_plifepred2.py \
             tests/test_pred.py \
             tests/test_annotate_table.py \
             tests/test_prime.py \

--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -109,7 +109,7 @@ def __getattr__(name):
     raise AttributeError(
         "module %r has no attribute %r" % (__name__, name))
 
-__version__ = "3.39.1"
+__version__ = "3.39.2"
 
 __all__ = [
     "Prediction",

--- a/mhctools/mixtcrpred.py
+++ b/mhctools/mixtcrpred.py
@@ -186,8 +186,8 @@ def _zenodo_files():
             record = json.load(response)
     except (OSError, ValueError) as error:
         raise RuntimeError(
-            "Could not read MixTCRpred model metadata from %s" %
-            ZENODO_API_URL) from error
+            "Could not read MixTCRpred model metadata from %s: %s" %
+            (ZENODO_API_URL, error)) from error
     if str(record.get("id")) != ZENODO_RECORD:
         raise RuntimeError("Zenodo returned unexpected MixTCRpred record")
     return {entry["key"]: entry for entry in record.get("files", ())}
@@ -285,8 +285,14 @@ def fetch_models(
         data_dir=None,
         models=None,
         all_models=False,
-        high_confidence=False):
-    """Fetch selected MixTCRpred weights and return their catalog entries."""
+        high_confidence=False,
+        refresh_metadata=False):
+    """Fetch weights; verify recorded downloads locally unless refreshing.
+
+    An immutable Zenodo record and its saved MD5/SHA-256/size manifest
+    identify existing downloads. Unrecorded weights still require Zenodo
+    verification. ``refresh_metadata=True`` rechecks remote metadata too.
+    """
     home = _resolve_home(mixtcrpred_path, data_dir=data_dir)
     catalog = model_catalog(mixtcrpred_path=home)
     selected = _select_catalog_models(
@@ -297,10 +303,24 @@ def fetch_models(
     )
     if not selected:
         return ()
-    files = _zenodo_files()
     model_dir = home / "pretrained_models"
     manifest = _read_model_manifest(model_dir)
+    pending = []
     for model in selected:
+        path = Path(model.path)
+        recorded = manifest["models"].get(model.name)
+        if refresh_metadata or recorded is None or not path.is_file():
+            pending.append(model)
+            continue
+        md5, sha256 = _hashes(path)
+        if (recorded.get("filename") != path.name or
+                recorded.get("size") != path.stat().st_size or
+                recorded.get("md5") != md5 or recorded.get("sha256") != sha256):
+            raise RuntimeError(
+                "Existing MixTCRpred checkpoint does not match its recorded "
+                "manifest: %s. Move it aside before fetching again." % path)
+    files = _zenodo_files() if pending else {}
+    for model in pending:
         _fetch_one_model(model, files, manifest)
         _write_model_manifest(model_dir, manifest)
     refreshed = {model.name: model for model in model_catalog(mixtcrpred_path=home)}

--- a/mhctools/peptiverse.py
+++ b/mhctools/peptiverse.py
@@ -70,6 +70,7 @@ pickled code. Point ``PEPTIVERSE_HOME`` only at a snapshot you trust.
 """
 
 import os
+import math
 from pathlib import Path
 import shutil
 import subprocess
@@ -84,8 +85,8 @@ from .wrapper_base import AlleleFreePredictor
 #: Upstream revision this wrapper was written and verified against.
 UPSTREAM_REVISION = "8cf0b21dae356278ae96b414a088e4360357d16c"
 
-#: ESM2's positional limit; upstream's WTEmbedder truncates beyond it.
-PEPTIVERSE_MAX_PEPTIDE_LENGTH = 1022
+#: WTEmbedder allows 1022 tokens, including the two ESM special tokens.
+PEPTIVERSE_MAX_PEPTIDE_LENGTH = 1020
 
 _VALID_AMINO_ACIDS = frozenset("ACDEFGHIKLMNPQRSTVWY")
 
@@ -117,7 +118,7 @@ def _find_peptiverse_home(peptiverse_home=None):
             "PeptiVerse not found. Set PEPTIVERSE_HOME or pass "
             "peptiverse_home= to the constructor. Clone from "
             "https://huggingface.co/ChatterjeeLab/PeptiVerse")
-    candidate = str(Path(candidate).expanduser())
+    candidate = str(Path(candidate).expanduser().resolve())
     if not Path(candidate, "inference.py").is_file():
         raise FileNotFoundError(
             "inference.py not found in %r — is this a PeptiVerse snapshot?"
@@ -178,7 +179,7 @@ class PeptiVerse(AlleleFreePredictor):
         diagnostic, not a calibrated confidence interval.
     max_peptide_length : int
         Peptides longer than this are rejected instead of being silently
-        truncated by ESM2. Default 1022.
+        truncated by ESM2. Default 1020 (1022 tokens minus two special tokens).
     """
 
     mhc_class = "none"
@@ -324,9 +325,9 @@ def parse_peptiverse_results(filename, peptide_list):
 
     Every input peptide must come back exactly once, identified by the
     ``__mhctools_id`` the caller assigned, and with the peptide it was scored
-    under unchanged — upstream's embedders truncate or alter unsupported input
-    rather than failing, so a mismatch is an error rather than something to
-    reconcile silently. Duplicate input peptides keep separate rows.
+    under unchanged. This checks the echoed input identity; the sidecar checks
+    the actual tokenized residue count before inference. Duplicate input
+    peptides keep separate rows.
 
     Returns
     -------
@@ -358,4 +359,10 @@ def parse_peptiverse_results(filename, peptide_list):
             "PeptiVerse returned a different peptide than it was given "
             "(id, sent, got): %s" % mismatched[:5])
     output["hours"] = output["hours"].astype(float)
+    invalid = output["hours"].map(lambda value: not math.isfinite(value) or value < 0)
+    if invalid.any():
+        rows = output.loc[invalid, ["__mhctools_id", "peptide", "hours"]]
+        raise RuntimeError(
+            "PeptiVerse returned invalid half-lives (expected finite, "
+            "nonnegative hours): %s" % rows.to_dict("records"))
     return output

--- a/mhctools/peptiverse_sidecar.py
+++ b/mhctools/peptiverse_sidecar.py
@@ -34,6 +34,17 @@ def _parse_args():
     return parser.parse_args()
 
 
+def _verify_tokenized_length(embedder, peptide):
+    """Check the exact residue mask that the pinned WTEmbedder uses."""
+    tokens = embedder._tokenize([peptide])
+    valid = embedder._valid_mask(tokens["input_ids"], tokens["attention_mask"])
+    encoded_length = int(valid.sum().item())
+    if encoded_length != len(peptide):
+        raise RuntimeError(
+            "PeptiVerse tokenizer retained %d of %d residues; refusing to "
+            "score truncated or altered input" % (encoded_length, len(peptide)))
+
+
 def main():
     args = _parse_args()
     home = Path(args.home).resolve()
@@ -54,6 +65,7 @@ def main():
 
     results = []
     for row in rows:
+        _verify_tokenized_length(predictor.wt_embedder, row["peptide"])
         # `predict_property` takes (prop_key, col, input_str) positionally --
         # upstream's README examples pass `mode=`, which is not a parameter of
         # the shipped signature and raises TypeError.

--- a/mhctools/plifepred2.py
+++ b/mhctools/plifepred2.py
@@ -156,7 +156,7 @@ def _find_plifepred2_home(plifepred2_home=None):
             "PlifePred2 not found. Set PLIFEPRED2_HOME or pass "
             "plifepred2_home= to the constructor. `pip install plifepred2` "
             "into an environment and point at its site-packages/plifepred2.")
-    candidate = str(Path(candidate).expanduser())
+    candidate = str(Path(candidate).expanduser().resolve())
     if not Path(candidate, _NATURAL_MODEL).is_file():
         raise FileNotFoundError(
             "%s not found in %r — is this an installed plifepred2 package?"
@@ -176,7 +176,7 @@ def _find_pfeature_home(pfeature_home=None):
             "Pfeature not found. Set PFEATURE_HOME or pass pfeature_home= to "
             "the constructor. Clone https://github.com/raghavagps/Pfeature and "
             "point at its Standalone directory.")
-    candidate = str(Path(candidate).expanduser())
+    candidate = str(Path(candidate).expanduser().resolve())
     if not Path(candidate, "pfeature_comp.py").is_file():
         raise FileNotFoundError(
             "pfeature_comp.py not found in %r — point at Pfeature's Standalone "

--- a/mhctools/plifepred2_sidecar.py
+++ b/mhctools/plifepred2_sidecar.py
@@ -12,8 +12,8 @@ the mhctools interpreter. This script runs in whatever interpreter owns them
 
 1. Shells out to Pfeature's ``pfeature_comp.py`` for the quasi-sequence-order
    descriptor. That script reads ``Data/Schneider-Wrede.csv`` and
-   ``Data/Grantham.csv`` by relative path, so it must run with its own
-   directory as the working directory.
+   ``Data/Grantham.csv`` by relative path, so each invocation gets an isolated
+   working directory containing a copy of those resources.
 2. Loads PlifePred2's natural-peptide RandomForest and predicts.
 
 The model is loaded with joblib, which unpickles; the caller is responsible for

--- a/tests/test_mixtcrpred.py
+++ b/tests/test_mixtcrpred.py
@@ -200,6 +200,36 @@ def test_fetch_models_downloads_atomically_and_records_hashes(
     assert manifest["models"][MODEL]["md5"] == md5
     assert len(manifest["models"][MODEL]["sha256"]) == 64
 
+    def unavailable(url, timeout):
+        raise OSError("fixture offline")
+
+    monkeypatch.setattr(mixtcrpred, "urlopen", unavailable)
+    # A previously verified checkpoint can be used with no network access.
+    assert mixtcrpred.fetch_models(home, models=[MODEL])[0].status == "ready"
+    with pytest.raises(RuntimeError, match="fixture offline"):
+        mixtcrpred.fetch_models(home, models=[MODEL], refresh_metadata=True)
+
+    path = Path(selected[0].path)
+    # Same size, different contents: size alone must never verify a cache.
+    path.write_bytes(b"x" * len(content))
+    with pytest.raises(RuntimeError, match="does not match its recorded"):
+        mixtcrpred.fetch_models(home, models=[MODEL])
+
+    path.unlink()
+    with pytest.raises(RuntimeError, match="fixture offline"):
+        mixtcrpred.fetch_models(home, models=[MODEL])
+
+
+def test_unrecorded_cached_model_requires_remote_verification(monkeypatch, tmp_path):
+    home = _make_home(tmp_path)
+
+    def unavailable(url, timeout):
+        raise OSError("fixture offline")
+
+    monkeypatch.setattr(mixtcrpred, "urlopen", unavailable)
+    with pytest.raises(RuntimeError, match="fixture offline"):
+        mixtcrpred.fetch_models(home, models=[MODEL])
+
 
 def test_model_catalog_json_is_serializable(tmp_path):
     home = _make_home(tmp_path)

--- a/tests/test_peptiverse.py
+++ b/tests/test_peptiverse.py
@@ -21,7 +21,9 @@ interpreter that has torch + transformers.
 """
 
 import os
+from io import StringIO
 from pathlib import Path
+import sys
 import tempfile
 
 import pytest
@@ -185,6 +187,90 @@ def test_parse_results_rejects_missing_column():
         os.remove(path)
 
 
+@pytest.mark.parametrize("hours", ["nan", "inf", "-inf", "-1.0"])
+def test_parse_rejects_invalid_duration_with_row_context(hours):
+    data = StringIO("__mhctools_id,peptide,hours\n0,SIINFEKL,%s\n" % hours)
+    with pytest.raises(RuntimeError, match="invalid half-lives.*SIINFEKL"):
+        parse_peptiverse_results(data, ["SIINFEKL"])
+
+
+def test_zero_duration_is_preserved():
+    data = StringIO("__mhctools_id,peptide,hours\n0,SIINFEKL,0\n")
+    assert parse_peptiverse_results(data, ["SIINFEKL"])["hours"].tolist() == [0.0]
+
+
+def _stub_inference(tmp_path, hours=1.25, retained_limit=1020):
+    """Run the actual sidecar against a dependency-free upstream-shaped stub."""
+    home = tmp_path / "Pepti Verse"
+    home.mkdir()
+    _fake_home(home)
+    (home / "inference.py").write_text(f'''
+from pathlib import Path
+
+class Mask:
+    def __init__(self, n): self.n = n
+    def sum(self): return self
+    def item(self): return self.n
+
+class Embedder:
+    def _tokenize(self, peptides):
+        return {{"input_ids": peptides[0], "attention_mask": None}}
+    def _valid_mask(self, ids, mask):
+        return Mask(min(len(ids), {retained_limit}))
+
+class PeptiVersePredictor:
+    def __init__(self, manifest_path, classifier_weight_root, device):
+        assert Path(classifier_weight_root) == Path(__file__).resolve().parent
+        self.wt_embedder = Embedder()
+    def predict_property(self, prop, col, peptide, uncertainty):
+        return {{"score": {hours!r}, "emb_tag": "wt"}}
+''')
+    return home
+
+
+@pytest.mark.parametrize("via_environment", [False, True])
+def test_relative_home_survives_caller_and_sidecar_directory_changes(
+        tmp_path, monkeypatch, via_environment):
+    home = _stub_inference(tmp_path)
+    (tmp_path / "nested").mkdir()
+    relative = "nested/../Pepti Verse"
+    monkeypatch.chdir(tmp_path)
+    if via_environment:
+        monkeypatch.setenv("PEPTIVERSE_HOME", relative)
+        predictor = PeptiVerse(peptiverse_python=sys.executable)
+    else:
+        predictor = PeptiVerse(
+            peptiverse_home=relative, peptiverse_python=sys.executable)
+    monkeypatch.chdir(tmp_path / "nested")
+    assert predictor.peptiverse_home == str(home.resolve())
+    peptides = ["A" * 1019 + "K", "A" * 1019 + "R"]
+    results = predictor.predict(peptides)
+    assert [r.peptide for r in results] == peptides
+    assert [r.serum_half_life.value for r in results] == [1.25, 1.25]
+
+
+@pytest.mark.parametrize("hours", ["nan", "inf", "-inf", -1.0])
+def test_public_predict_rejects_invalid_sidecar_duration(tmp_path, hours):
+    home = _stub_inference(tmp_path, hours=hours)
+    predictor = PeptiVerse(peptiverse_home=home, peptiverse_python=sys.executable)
+    with pytest.raises(RuntimeError, match="invalid half-lives"):
+        predictor.predict(["SIINFEKL"])
+
+
+def test_sidecar_checks_actual_tokenizer_residue_count(tmp_path):
+    home = _stub_inference(tmp_path, retained_limit=7)
+    predictor = PeptiVerse(peptiverse_home=home, peptiverse_python=sys.executable)
+    with pytest.raises(RuntimeError, match="retained 7 of 8 residues"):
+        predictor.predict(["SIINFEKL"])
+
+
+@pytest.mark.parametrize("length", [1021, 1022])
+def test_rejects_lengths_that_fit_only_without_special_tokens(tmp_path, length):
+    predictor = PeptiVerse(peptiverse_home=_fake_home(tmp_path))
+    with pytest.raises(ValueError, match="up to 1020 residues"):
+        predictor.predict(["A" * (length - 1) + "K"])
+
+
 # --- construction and validation (no model) ---------------------------------
 
 def _fake_home(tmp_path):
@@ -239,12 +325,12 @@ def test_empty_peptide_is_rejected(tmp_path):
 
 def test_over_long_peptide_is_rejected_rather_than_truncated(tmp_path):
     predictor = PeptiVerse(peptiverse_home=_fake_home(tmp_path))
-    with pytest.raises(ValueError, match="up to 1022 residues"):
+    with pytest.raises(ValueError, match="up to 1020 residues"):
         predictor.predict(["A" * (PEPTIVERSE_MAX_PEPTIDE_LENGTH + 1)])
 
 
 def test_max_peptide_length_cannot_exceed_model_limit(tmp_path):
-    with pytest.raises(ValueError, match="at most 1022 residues"):
+    with pytest.raises(ValueError, match="at most 1020 residues"):
         PeptiVerse(
             peptiverse_home=_fake_home(tmp_path),
             max_peptide_length=PEPTIVERSE_MAX_PEPTIDE_LENGTH + 1)

--- a/tests/test_plifepred2.py
+++ b/tests/test_plifepred2.py
@@ -486,6 +486,36 @@ def test_value_is_withheld_by_default(tmp_path):
     assert _predictor(tmp_path).assume_log10_seconds is False
 
 
+@pytest.mark.parametrize("via_environment", [False, True])
+def test_relative_asset_homes_survive_directory_changes(
+        tmp_path, monkeypatch, via_environment):
+    from mhctools.plifepred2_sidecar import _run_pfeature
+
+    assets = tmp_path / "model assets"
+    assets.mkdir()
+    model_home, feature_home = _fake_homes(assets)
+    Path(feature_home, "pfeature_comp.py").write_text(_DESTRUCTIVE_STUB)
+    (tmp_path / "nested").mkdir()
+    monkeypatch.chdir(tmp_path)
+    relative_model = "nested/../model assets/plifepred2"
+    relative_features = "nested/../model assets/Standalone"
+    if via_environment:
+        monkeypatch.setenv("PLIFEPRED2_HOME", relative_model)
+        monkeypatch.setenv("PFEATURE_HOME", relative_features)
+        predictor = PlifePred2()
+    else:
+        predictor = PlifePred2(
+            plifepred2_home=relative_model, pfeature_home=relative_features)
+    monkeypatch.chdir(tmp_path / "nested")
+    assert predictor.plifepred2_home == str(Path(model_home).resolve())
+    assert predictor.pfeature_home == str(Path(feature_home).resolve())
+    fasta = tmp_path / "input.fa"
+    fasta.write_text(">0\nSIINFEKLGGAL\n")
+    output = tmp_path / "output.csv"
+    _run_pfeature(predictor.pfeature_home, fasta, output)
+    assert "QSO1_SC_A" in output.read_text()
+
+
 def test_opt_in_is_visible_in_the_repr(tmp_path):
     plifepred2_home, pfeature_home = _fake_homes(tmp_path)
     predictor = PlifePred2(


### PR DESCRIPTION
PeptiVerse accepted 1021–1022 residues although its 1022-token budget includes two special tokens, and accepted invalid physical half-lives. Reject inputs above 1020 residues, verify the actual residue mask before inference, and reject nonfinite or negative output hours. Resolve PeptiVerse, PlifePred2 and Pfeature asset homes before subprocesses change directories.

Regression tests exercise actual sidecar subprocesses with offline upstream fixtures, long peptides, tokenizer truncation, invalid values, and relative asset paths. Add these fixtures to the public CI matrix. Version: 3.39.2.

Validation: `./lint.sh` passes; focused tests 70 passed, 9 skipped; `TEST_SH_MAX=4 ./test.sh` passes with 827 passed, 65 skipped, 2 xfailed.

Closes #313. Closes #314. Closes #316. Follows #320; source: pinned PeptiVerse WTEmbedder at 8cf0b21dae356278ae96b414a088e4360357d16c, `max_length=1022` including ESM special tokens. Follow-up cleavage series: #322; separately tracked CI download dependency: #321.
