### PR TITLE
Add serum, cytosolic and ER peptidase evidence with a JSON cleavage CLI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,6 +56,8 @@ jobs:
             tests/test_plifepred2.py \
             tests/test_cleavage.py \
             tests/test_dpp4.py \
+            tests/test_peptidases.py \
+            tests/test_eramer_cleavage.py \
             tests/test_pred.py \
             tests/test_annotate_table.py \
             tests/test_prime.py \

--- a/README.md
+++ b/README.md
@@ -1043,3 +1043,11 @@ pp_list = collection.to_peptide_preds() # list of PeptideResult
 assay provenance and parent-sequence bond coordinates. See the
 [cleavage guide](docs/cleavage.md) for usage and model limits. qPISA scores
 are substrate-depletion estimates, not serum half-lives or probabilities.
+
+The local cleavage panel also provides motif rules for CPN, aminopeptidase P,
+FAP, aminopeptidases A/N, DPP8/9, PREP and ERAP2. An optional `eramer-step`
+model exposes ERAP1's existing length-specific PWM score at the initial
+trimming bond. Discover models with `mhctools cleavage --list-models`, or run
+`mhctools cleavage --sequence RPPGFSPFR --model app2-xp --model cpn-basic`.
+The [guide](docs/cleavage.md) includes a wider candidate inventory and
+prioritized follow-up issues.

--- a/docs/cleavage.md
+++ b/docs/cleavage.md
@@ -69,3 +69,116 @@ The shared result contract also supports `motif_rule` evidence, reported as
 known recognition pattern; a non-match does not establish resistance.
 `unsupported_reason` means the input could not be assessed and carries no
 score. These states must remain separate in downstream displays and ranking.
+
+## Model panel and JSON command
+
+```sh
+mhctools cleavage --list-models
+mhctools cleavage --sequence RPPGFSPFR --model app2-xp --model cpn-basic
+mhctools cleavage --sequence VPYGSFKHV --compartment cytosol --out cleavage.json
+mhctools cleavage --sequence HAEGTFTSD --model dpp4-qpisa --n-term acetylated
+```
+
+```python
+from mhctools import predict_cleavage
+results = predict_cleavage("TSGPNQ", models=["fap-endo-gp", "prep-pro"])
+```
+
+The default panel evaluates all 11 built-in models and returns separate
+results. `--model` and `--sequence` can be repeated. The JSON output retains
+unmatched and unsupported results, source coordinates, chemistry and model
+provenance. `--source-start` is a zero-based offset shared by the supplied
+inputs; use separate calls when fragments have different offsets.
+
+Compartment filtering uses exact, conservative enzyme-location annotations.
+`serum`, `plasma`, `extracellular`, `cytosol`, and `er` are distinct. The
+`extracellular` filter is useful for broader candidate screening; `serum`
+is not an exhaustive inventory of everything potentially present in a serum
+sample. Presence, concentration, activation, inhibitors and exposure are not
+inferred. No combination is converted into overall stability.
+
+| Model | Assessed recognition pattern | Main scope and primary evidence |
+| --- | --- | --- |
+| `dpp4-qpisa` | N-terminal P2-P1\|P1′ score | Human DPP4; quantitative model described above |
+| `cpn-basic` | C-terminal \|Lys/Arg | Human plasma CPN; [Oshima et al. 1975](https://doi.org/10.1016/0003-9861(75)90104-6) |
+| `app2-xp` | N-terminal X\|Pro | Human XPNPEP2; [Molinaro et al.](https://pubmed.ncbi.nlm.nih.gov/15361070/) |
+| `fap-dipeptidyl` | N-terminal X-Pro\|non-Pro | Human FAP; [Edosada et al.](https://pubmed.ncbi.nlm.nih.gov/16410248/) |
+| `fap-endo-gp` | Gly-Pro\|non-Pro | FAP endopeptidase; [substrate profiling](https://pubmed.ncbi.nlm.nih.gov/16480718/), [prime-side constraint](https://pubmed.ncbi.nlm.nih.gov/22750443/) |
+| `enpep-acidic` | N-terminal Asp/Glu\|X | Aminopeptidase A; [human specificity study](https://pubmed.ncbi.nlm.nih.gov/23888046/); calcium and sequence affect activity |
+| `anpep-ala` | N-terminal Ala\|X preference | Aminopeptidase N; [human structure/biochemistry](https://pubmed.ncbi.nlm.nih.gov/22932899/); many other substrates omitted |
+| `dpp8-xp-xa` | N-terminal X-(Pro/Ala)\|non-Pro | Cytosolic DPP8; [characterization](https://pubmed.ncbi.nlm.nih.gov/11012666/), [degradomics](https://pmc.ncbi.nlm.nih.gov/articles/PMC3656252/) |
+| `dpp9-xp-xa` | N-terminal X-(Pro/Ala)\|non-Pro | Cytosolic DPP9; [antigen processing](https://pubmed.ncbi.nlm.nih.gov/19667070/), same degradomics study |
+| `prep-pro` | Internal X-Pro\|X | PREP/POP, conservative 4–30-residue domain; [human profiling](https://pubmed.ncbi.nlm.nih.gov/22750443/); flanking preferences omitted |
+| `erap2-basic` | N-terminal Arg/Lys\|X preference | ERAP2 in ER; [biochemistry](https://pubmed.ncbi.nlm.nih.gov/12799365/), [peptide structures](https://pubmed.ncbi.nlm.nih.gov/26381406/); not a full-context predictor |
+| `eramer-step` (optional) | Initial N-terminal bond; length-specific PWM score | ERAP1 in ER; [ERAMER](https://pubmed.ncbi.nlm.nih.gov/38925438/), 9–16 residues |
+
+The motif models return decisions without numerical scores. For example,
+APP removes the first residue of `RPPGFSPFR` at `R|PPGFSPFR`; DPP-like
+activity would remove two residues and is a separate assessment. FAP's
+endopeptidase rule can also assess an N-acetylated input, supported by its
+blocked-substrate activity. The other initial rules conservatively accept
+free termini only; an unsupported modified input does not establish that
+its bonds resist enzymatic cleavage.
+
+### ERAP1 and existing processing models
+
+```sh
+mhctools fetch eramer
+# Install openpyxl in the environment if it is not already available.
+mhctools cleavage --sequence LAAAFGAAA --model eramer-step
+```
+
+Alternatively, construct `ERAMERCleavage(pwm_path="/path/to/PWM.xlsx")` or set
+`ERAMER_HOME`. This optional model is listed without loading assets and is
+excluded from the default panel. Explicit selection fails clearly if the
+external asset or its runtime is missing.
+
+`eramer-step` computes the existing ERAMER intermediate PWM specificity for
+one exposed 9–16-residue precursor, assigning it to bond 1. It does not report
+the average of later trimming intermediates. Its version contains the SHA-256
+of the actual workbook snapshot used for inference. The GPL-licensed workbook
+is loaded at runtime and is not included in the mhctools distribution.
+
+The existing `ERAMER` cascade API, `NetChop`, `Pepsickle` and other proteasome
+predictors remain available through their existing interfaces. Their output
+scales must not be mixed with qPISA scores or motif decisions.
+
+## Wider candidate inventory and next PRs
+
+This is a starting panel, not a complete inventory of human proteolysis.
+The next work is prioritized by useful substrate coverage and evidence:
+
+1. **Benchmark the shipped models** on held-out, assay-specific substrates:
+   [#291](https://github.com/openvax/mhctools/issues/291). Include observed
+   non-cleavages, terminal modifications, homologous-sequence leakage checks,
+   and coverage/abstention. Purified-enzyme turnover and disappearance of intact
+   peptide in serum are separate endpoints.
+2. **ACE, MME/neprilysin and activated CPB2/TAFI**:
+   [#326](https://github.com/openvax/mhctools/issues/326). ACE includes both
+   terminal dipeptide processing and exceptional substrate behavior. MME needs
+   length and local sequence context. CPB2 requires activation state. Human
+   plasma bradykinin data demonstrate [concentration-dependent enzyme contributions](https://pubmed.ncbi.nlm.nih.gov/10749699/);
+   serum carboxypeptidase activity also [differs from plasma](https://pubmed.ncbi.nlm.nih.gov/2760564/).
+3. **TPP2, NPEPPS, THOP1, NLN and XPNPEP1**, plus endosomal **LNPEP/IRAP**:
+   [#327](https://github.com/openvax/mhctools/issues/327). N-terminal removal
+   of three residues describes TPP2 topology, not a selective substrate model.
+   [TPP2 precursor processing](https://pubmed.ncbi.nlm.nih.gov/16849449/)
+   and [THOP1/NLN substrate studies](https://pubmed.ncbi.nlm.nih.gov/11284698/)
+   are starting evidence. IRAP belongs in an endosomal context, not a default
+   ER panel.
+4. **Activated blood and inflammation-associated proteases**: F2/thrombin,
+   PLG/plasmin, KLKB1, ELANE, CTSG, PRTN3 and relevant extracellular cathepsins
+   and matrix metalloproteases. Curate activation, inhibitors, tissue exposure,
+   and assay conditions before choosing a predictor. A generic Arg/Lys or
+   hydrophobic-residue scan would not distinguish these enzymes.
+5. **Other exopeptidases/compartments**: DPP7, DPP2-family annotations,
+   cathepsins C/H, ACE2, carboxypeptidases M/E and lysosomal/endosomal processing
+   merit separate domain reviews. Do not infer ER or serum activity merely
+   from membership in a peptidase family.
+
+Downstream sequence overlays and fragment/construct projections are tracked
+in [topiary #288](https://github.com/openvax/topiary/issues/288) and
+[vaxrank #422](https://github.com/openvax/vaxrank/issues/422). They should retain
+exact fragment chemistry and parent coordinates rather than treating internal
+exo motifs as immediate cleavage sites. The broader validated serum-cleavage
+work remains tracked in [#278](https://github.com/openvax/mhctools/issues/278).

--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -49,6 +49,8 @@ from .peptiverse import PeptiVerse
 from .plifepred2 import PlifePred2
 from .cleavage import CleavageInput, CleavageModel, CleavageSite, CleavageResult
 from .dpp4 import DPP4qPISA
+from .peptidases import cleavage_models, get_cleavage_model, predict_cleavage
+from .eramer_cleavage import ERAMERCleavage
 from .tlimmuno2 import TLimmuno2
 from .processing_predictor import (
     ProcessingPredictor,
@@ -111,7 +113,7 @@ def __getattr__(name):
     raise AttributeError(
         "module %r has no attribute %r" % (__name__, name))
 
-__version__ = "3.40.0"
+__version__ = "3.41.0"
 
 __all__ = [
     "Prediction",
@@ -162,6 +164,10 @@ __all__ = [
     "CleavageSite",
     "CleavageResult",
     "DPP4qPISA",
+    "cleavage_models",
+    "get_cleavage_model",
+    "predict_cleavage",
+    "ERAMERCleavage",
     "TLimmuno2",
     "MHCflurry",
     "MHCflurry_Affinity",

--- a/mhctools/cli/cleavage.py
+++ b/mhctools/cli/cleavage.py
@@ -1,0 +1,47 @@
+"""JSON reporting for per-bond cleavage evidence."""
+
+import argparse
+from dataclasses import asdict
+import json
+from pathlib import Path
+
+from mhctools.cleavage import CleavageInput
+from mhctools.peptidases import cleavage_models, predict_cleavage
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        prog="mhctools cleavage",
+        description="Report peptidase motif evidence and native model scores per bond.")
+    parser.add_argument("--list-models", action="store_true")
+    parser.add_argument("--sequence", action="append", help="Canonical linear L-peptide; repeat for multiple inputs")
+    parser.add_argument("--model", action="append", help="Exact model name; repeat to select multiple models")
+    parser.add_argument("--compartment", help="Filter enzyme locations: serum, plasma, extracellular, cytosol, er")
+    parser.add_argument("--n-term", choices=("free", "acetylated", "unknown"), default="free")
+    parser.add_argument("--c-term", choices=("free", "amidated", "unknown"), default="free")
+    parser.add_argument("--source-id")
+    parser.add_argument("--source-start", type=int, default=0)
+    parser.add_argument("--out", help="Write JSON to this path instead of stdout")
+    args = parser.parse_args(argv)
+    if args.list_models:
+        if args.sequence or args.model or args.compartment:
+            parser.error("--list-models cannot be combined with prediction options")
+        result = {"models": [asdict(m) for m in cleavage_models(include_optional=True)]}
+    else:
+        if not args.sequence:
+            parser.error("Provide --sequence or --list-models")
+        try:
+            result = {"results": [
+                prediction.to_dict()
+                for seq in args.sequence
+                for prediction in predict_cleavage(CleavageInput(
+                    seq, args.n_term, args.c_term, args.source_id, args.source_start),
+                    models=args.model, compartment=args.compartment)]}
+        except (ValueError, TypeError, OSError, ImportError) as error:
+            parser.error(str(error))
+    result["schema_version"] = 1
+    output = json.dumps(result, indent=2, allow_nan=False) + "\n"
+    if args.out:
+        Path(args.out).write_text(output, encoding="utf-8")
+    else:
+        print(output, end="")

--- a/mhctools/cli/script.py
+++ b/mhctools/cli/script.py
@@ -175,6 +175,9 @@ def main(args_list=None):
     if args_list and args_list[0] == "fetch":
         from .artifacts import fetch_main
         return fetch_main(args_list[1:])
+    if args_list and args_list[0] == "cleavage":
+        from .cleavage import main as cleavage_main
+        return cleavage_main(args_list[1:])
     if args_list and args_list[0] == "predict-table":
         from .annotate_table import main as annotate_table_main
         return annotate_table_main(args_list[1:])

--- a/mhctools/eramer_cleavage.py
+++ b/mhctools/eramer_cleavage.py
@@ -1,0 +1,50 @@
+"""Expose one ERAMER PWM trimming assessment with its exact artifact identity."""
+
+from dataclasses import replace
+import hashlib
+from io import BytesIO
+from pathlib import Path
+
+from .cleavage import CleavageInput, CleavageModel, CleavageResult, CleavageSite
+from .eramer import _find_pwm_path, _specificity, load_pwm
+
+
+class ERAMERCleavage:
+    """Score the initial ERAP1 trimming step of a 9-16mer with ERAMER's PWM.
+
+    This is the existing ERAMER intermediate-specificity score, not the
+    cascade average. The external GPL-licensed PWM is loaded, never vendored.
+    """
+
+    model = CleavageModel(
+        name="eramer-step", version="2024-external-PWM", enzyme="ERAP1",
+        uniprot="Q9NZ08", species="Homo sapiens", compartments=("er",),
+        evidence="quantitative_model",
+        references=("https://pubmed.ncbi.nlm.nih.gov/38925438/",
+                    "https://github.com/aalokaily/ERAMER"),
+        assay="ERAMER length-specific position weight matrices for ERAP1 specificity",
+        limitations=("Requires separately fetched ERAMER PWM and openpyxl. "
+                     "Single intermediate score; not a probability, kinetic rate or cascade average. "
+                     "No allotype, enzyme exposure or MHC protection model."),
+        score_name="intermediate_pwm_specificity", score_units="native ERAMER specificity")
+
+    def __init__(self, eramer_home=None, pwm_path=None):
+        path = Path(_find_pwm_path(eramer_home, pwm_path)).expanduser().resolve()
+        data = path.read_bytes()
+        self._weights = load_pwm(BytesIO(data))
+        self.model = replace(self.model, version="pwm-sha256:" + hashlib.sha256(data).hexdigest())
+
+    def predict(self, peptide):
+        """Assess only the initial N-terminal bond; fragments require new input."""
+        if isinstance(peptide, str):
+            peptide = CleavageInput(peptide)
+        if not isinstance(peptide, CleavageInput):
+            raise TypeError("Expected CleavageInput or canonical peptide string")
+        if peptide.n_term != "free" or peptide.c_term != "free":
+            return CleavageResult(peptide, self.model, unsupported_reason="ERAMER requires unmodified free termini")
+        length = len(peptide.sequence)
+        if not 9 <= length <= 16:
+            return CleavageResult(peptide, self.model, unsupported_reason="ERAMER has PWMs only for 9-16 residues")
+        score = _specificity(peptide.sequence, self._weights[length])
+        return CleavageResult(peptide, self.model, (CleavageSite(
+            1, "scored", "Mean length-specific PWM weight for this exposed precursor", score),))

--- a/mhctools/peptidases.py
+++ b/mhctools/peptidases.py
@@ -1,0 +1,189 @@
+"""Curated human peptidase recognition rules and model selection.
+
+Rules flag partial substrate-recognition patterns, not enzyme activity,
+probabilities or whole-peptide stability. Every rule retains its scope.
+"""
+
+from dataclasses import dataclass
+import re
+from typing import Optional, Tuple
+
+from .cleavage import CleavageInput, CleavageModel, CleavageResult, CleavageSite
+from .dpp4 import DPP4qPISA
+
+
+@dataclass(frozen=True)
+class PeptidaseMotif:
+    """A partial specificity rule with explicit terminal or internal topology."""
+
+    model: CleavageModel
+    topology: str
+    removed: int
+    left: str
+    right: str
+    description: str
+    min_length: int = 2
+    max_length: Optional[int] = None
+    n_chemistry: Tuple[str, ...] = ("free",)
+
+    def __post_init__(self):
+        if self.topology not in ("n_terminal", "c_terminal", "internal"):
+            raise ValueError("Unknown cleavage topology")
+        if (self.topology != "internal" and
+                (self.removed < 1 or self.min_length <= self.removed)):
+            raise ValueError("Terminal rule must leave a peptide bond to assess")
+        re.compile(self.left)
+        re.compile(self.right)
+
+    def predict(self, peptide):
+        """Assess eligible bonds; a non-match is not evidence of resistance."""
+        if isinstance(peptide, str):
+            peptide = CleavageInput(peptide)
+        if not isinstance(peptide, CleavageInput):
+            raise TypeError("Expected CleavageInput or canonical peptide string")
+        seq = peptide.sequence
+        reason = None
+        if peptide.n_term not in self.n_chemistry or peptide.c_term != "free":
+            reason = "Terminal chemistry is outside this rule's documented input domain"
+        elif len(seq) < self.min_length:
+            reason = "Rule requires at least %d residues" % self.min_length
+        elif self.max_length is not None and len(seq) > self.max_length:
+            reason = "Rule is limited to peptides of at most %d residues" % self.max_length
+        if reason:
+            return CleavageResult(peptide, self.model, unsupported_reason=reason)
+        if self.topology == "n_terminal":
+            bonds = (self.removed,)
+        elif self.topology == "c_terminal":
+            bonds = (len(seq) - self.removed,)
+        else:
+            bonds = range(1, len(seq))
+        sites = []
+        for bond in bonds:
+            match = (re.search(self.left + "$", seq[:bond]) is not None and
+                     re.match(self.right, seq[bond:]) is not None)
+            sites.append(CleavageSite(
+                bond, "matched" if match else "not_matched", self.description))
+        return CleavageResult(peptide, self.model, tuple(sites))
+
+
+def _rule(name, enzyme, accession, compartments, papers, topology, removed,
+          left, right, description, assay, limitations, **kwargs):
+    metadata = CleavageModel(
+        name=name, version="1", enzyme=enzyme, uniprot=accession,
+        species="Homo sapiens", compartments=compartments, evidence="motif_rule",
+        references=tuple(papers) + (
+            "https://www.uniprot.org/uniprotkb/%s/entry" % accession,),
+        assay=assay,
+        limitations=limitations + " Partial specificity rule; no kinetic or matrix calibration.")
+    return PeptidaseMotif(metadata, topology, removed, left, right, description, **kwargs)
+
+
+_RULES = (
+    _rule("cpn-basic", "CPN1", "P15169", ("plasma", "serum", "extracellular"),
+          ("https://doi.org/10.1016/0003-9861(75)90104-6",),
+          "c_terminal", 1, ".", "[KR]", "Free C-terminal Lys/Arg removal",
+          "Human plasma CPN peptide-substrate assays",
+          "Penultimate residues affect rates; Lys and Arg are not kinetically equivalent."),
+    _rule("app2-xp", "XPNPEP2", "O43895", ("plasma", "extracellular"),
+          ("https://pubmed.ncbi.nlm.nih.gov/15361070/",),
+          "n_terminal", 1, ".", "P", "Exposed N-terminal X|Pro",
+          "Recombinant human membrane aminopeptidase P and kinin substrates",
+          "Removes the FIRST residue; this is not DPP-like dipeptide removal."),
+    _rule("fap-dipeptidyl", "FAP", "Q12884", ("extracellular", "plasma"),
+          ("https://pubmed.ncbi.nlm.nih.gov/16410248/",),
+          "n_terminal", 2, ".P", "[^P]", "Exposed N-terminal X-Pro|non-Pro",
+          "Purified human FAP dipeptide substrate profiling",
+          "Dipeptidyl activity only; P2 preferences and whole-peptide context omitted.",
+          min_length=3),
+    _rule("fap-endo-gp", "FAP", "Q12884", ("extracellular", "plasma"),
+          ("https://pubmed.ncbi.nlm.nih.gov/16480718/",
+           "https://pubmed.ncbi.nlm.nih.gov/16410248/",
+           "https://pubmed.ncbi.nlm.nih.gov/22750443/"),
+          "internal", 0, "GP", "[^P]", "Gly-Pro|non-Pro endopeptidase recognition",
+          "Human FAP substrate profiling around alpha-2-antiplasmin cleavage site",
+          "P3 preferences and accessibility omitted; independent of dipeptidyl activity.",
+          min_length=3, n_chemistry=("free", "acetylated")),
+    _rule("enpep-acidic", "ENPEP", "Q07075", ("extracellular",),
+          ("https://pubmed.ncbi.nlm.nih.gov/23888046/",),
+          "n_terminal", 1, "[DE]", ".", "Exposed N-terminal Asp/Glu|X",
+          "Human aminopeptidase A structural/substrate specificity experiments",
+          "Calcium-dependent preference; enzyme exposure and calcium are not modeled."),
+    _rule("anpep-ala", "ANPEP", "P15144", ("extracellular",),
+          ("https://pubmed.ncbi.nlm.nih.gov/22932899/",),
+          "n_terminal", 1, "A", ".", "Preferred N-terminal Ala|X",
+          "Human aminopeptidase N structural/biochemical specificity",
+          "Only an Ala preference flag. Broad alternative substrates and X-Pro dipeptide removal omitted."),
+    _rule("dpp8-xp-xa", "DPP8", "Q6V1X1", ("cytosol",),
+          ("https://pubmed.ncbi.nlm.nih.gov/11012666/",
+           "https://pmc.ncbi.nlm.nih.gov/articles/PMC3656252/"),
+          "n_terminal", 2, ".[PA]", "[^P]", "Exposed X-(Pro/Ala)|non-Pro",
+          "Human DPP8 biochemical characterization and substrate degradomics",
+          "Qualitative rule only; DPP4 and C. elegans DPF-3 coefficients are inapplicable.",
+          min_length=3),
+    _rule("dpp9-xp-xa", "DPP9", "Q86TI2", ("cytosol",),
+          ("https://pubmed.ncbi.nlm.nih.gov/19667070/",
+           "https://pmc.ncbi.nlm.nih.gov/articles/PMC3656252/"),
+          "n_terminal", 2, ".[PA]", "[^P]", "Exposed X-(Pro/Ala)|non-Pro",
+          "Human DPP9 peptide/antigen processing assays and substrate degradomics",
+          "Shared recognition pattern with DPP8 does not imply identical substrate rates.",
+          min_length=3),
+    _rule("prep-pro", "PREP", "P48147", ("cytosol", "extracellular", "serum"),
+          ("https://pubmed.ncbi.nlm.nih.gov/22750443/",),
+          "internal", 0, ".P", ".", "Internal post-proline X-Pro|X recognition",
+          "Recombinant human POP/FAP peptide substrate profiling",
+          "Conservative 4-30-residue model domain; not an absolute enzyme size cutoff. "
+          "Weaker non-Pro cleavage and flanking charge preferences omitted; abundance unmodeled.",
+          min_length=4, max_length=30),
+    _rule("erap2-basic", "ERAP2", "Q6P179", ("er",),
+          ("https://pubmed.ncbi.nlm.nih.gov/12799365/",
+           "https://pubmed.ncbi.nlm.nih.gov/26381406/"),
+          "n_terminal", 1, "[RK]", ".", "Preferred exposed N-terminal Arg/Lys|X",
+          "Human ERAP2 biochemical specificity and peptide-complex structures",
+          "A basic-residue preference flag only; length, allotype and internal sequence affect trimming."),
+)
+
+
+def cleavage_models(include_optional=False):
+    """List built-in model metadata without loading optional runtimes."""
+    models = (DPP4qPISA.model,) + tuple(rule.model for rule in _RULES)
+    if include_optional:
+        from .eramer_cleavage import ERAMERCleavage
+        models += (ERAMERCleavage.model,)
+    return models
+
+
+def get_cleavage_model(name):
+    """Select an exact model name; never silently substitute another enzyme."""
+    if name == "dpp4-qpisa":
+        return DPP4qPISA()
+    if name == "eramer-step":
+        from .eramer_cleavage import ERAMERCleavage
+        return ERAMERCleavage()
+    for rule in _RULES:
+        if rule.model.name == name:
+            return rule
+    raise ValueError("Unknown cleavage model %r; choices: %s" % (
+        name, ", ".join(model.name for model in cleavage_models(include_optional=True))))
+
+
+def predict_cleavage(peptide, models=None, compartment=None):
+    """Return distinct model results without aggregation or enzyme ranking.
+
+    ``compartment`` filters annotated enzyme locations, not assay validation.
+    Explicit selections incompatible with that filter are rejected.
+    """
+    if compartment is not None and compartment not in {
+            c for model in cleavage_models() for c in model.compartments}:
+        raise ValueError("Unknown compartment %r" % compartment)
+    if models is None:
+        models = [m.name for m in cleavage_models()
+                  if compartment is None or compartment in m.compartments]
+    elif isinstance(models, str):
+        models = [models]
+    results = []
+    for name in dict.fromkeys(models):
+        predictor = get_cleavage_model(name)
+        if compartment is not None and compartment not in predictor.model.compartments:
+            raise ValueError("Model %s is not annotated for compartment %s" % (name, compartment))
+        results.append(predictor.predict(peptide))
+    return tuple(results)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61", "wheel"]
+requires = ["setuptools>=77.0.3", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/tests/test_eramer_cleavage.py
+++ b/tests/test_eramer_cleavage.py
@@ -1,0 +1,44 @@
+"""Single-step PWM mapping and provenance, independent of external weights."""
+
+import hashlib
+
+import pytest
+
+from mhctools import CleavageInput, ERAMERCleavage
+
+
+@pytest.fixture
+def pwm(tmp_path):
+    openpyxl = pytest.importorskip("openpyxl")
+    workbook = openpyxl.Workbook()
+    workbook.remove(workbook.active)
+    for length in range(9, 17):
+        sheet = workbook.create_sheet("Length %d" % length)
+        sheet.append(["index", "aa"] + list(range(length)))
+        for index, aa in enumerate("ACDEFGHIKLMNPQRSTVWY"):
+            sheet.append([index, aa] + [length / 100] * length)
+    path = tmp_path / "PWM.xlsx"
+    workbook.save(path)
+    return path
+
+
+def test_one_step_score_and_loaded_artifact_identity(pwm):
+    digest = hashlib.sha256(pwm.read_bytes()).hexdigest()
+    predictor = ERAMERCleavage(pwm_path=pwm)
+    # The in-memory snapshot retains its identity even if the file changes.
+    pwm.write_bytes(b"changed after loading")
+    result = predictor.predict(CleavageInput("LAAAFGAAA", source_start=40))
+    assert result.model.version == "pwm-sha256:" + digest
+    assert len(result.sites) == 1
+    assert result.sites[0].bond == 1
+    assert result.sites[0].score == pytest.approx(0.09)
+    assert result.to_dict()["sites"][0]["source_bond"] == 41
+    assert predictor.predict("A" * 16).sites[0].score == pytest.approx(0.16)
+
+
+def test_erap_domain_and_terminal_chemistry(pwm):
+    predictor = ERAMERCleavage(pwm_path=pwm)
+    for peptide in ("A" * 8, "A" * 17, CleavageInput("A" * 9, n_term="acetylated")):
+        result = predictor.predict(peptide)
+        assert result.unsupported_reason
+        assert not result.sites

--- a/tests/test_peptidases.py
+++ b/tests/test_peptidases.py
@@ -1,0 +1,133 @@
+"""Scientific topology, abstention, and public reporting regressions."""
+
+import json
+
+import pytest
+
+from mhctools import (
+    CleavageInput, cleavage_models, get_cleavage_model, predict_cleavage,
+)
+from mhctools.cli.script import main
+
+
+@pytest.mark.parametrize("model,sequence,bond", [
+    ("cpn-basic", "RPPGFSPFR", 8),  # C-terminal Arg of bradykinin
+    ("app2-xp", "RPPGFSPFR", 1),  # first residue, NOT the Pro at position 2
+    ("fap-dipeptidyl", "APGAA", 2),
+    ("fap-endo-gp", "TSGPNQ", 4),  # alpha-2-antiplasmin recognition context
+    ("enpep-acidic", "DRVYIHPF", 1),  # angiotensin II N-terminal Asp
+    ("anpep-ala", "AAGF", 1),
+    ("dpp8-xp-xa", "APGAA", 2),
+    ("dpp9-xp-xa", "VPYGSFKHV", 2),  # RU1 epitope N-terminal dipeptide
+    ("prep-pro", "RPPGFSPFR", 7),
+    ("erap2-basic", "RSLYNTVATL", 1),
+])
+def test_recognition_bonds(model, sequence, bond):
+    result = get_cleavage_model(model).predict(CleavageInput(sequence, source_start=20))
+    assert result.unsupported_reason is None
+    site = next(s for s in result.sites if s.bond == bond)
+    assert site.status == "matched"
+    assert site.score is None
+    assert result.model.evidence == "motif_rule"
+    assert result.model.score_units is None
+    assert any(s["source_bond"] == 20 + bond for s in result.to_dict()["sites"])
+
+
+@pytest.mark.parametrize("model,sequence", [
+    ("cpn-basic", "RPPGFSPFA"),
+    ("app2-xp", "AAPG"),
+    ("fap-dipeptidyl", "APPG"),
+    ("fap-endo-gp", "TSGPPQ"),
+    ("enpep-acidic", "AAGF"),
+    ("anpep-ala", "RAGF"),
+    ("dpp8-xp-xa", "VPPGSFKHV"),
+    ("dpp9-xp-xa", "VPPGSFKHV"),
+    ("prep-pro", "AAAA"),
+    ("erap2-basic", "ASLYNTVATL"),
+])
+def test_nonmatches_retain_rule_semantics(model, sequence):
+    result = get_cleavage_model(model).predict(sequence)
+    assert result.sites
+    assert {s.status for s in result.sites} == {"not_matched"}
+    assert all(s.score is None for s in result.sites)
+    assert result.unsupported_reason is None
+
+
+def test_blocked_termini_distinguish_endo_and_exo():
+    peptide = CleavageInput("GPNQ", n_term="acetylated")
+    assert get_cleavage_model("fap-dipeptidyl").predict(peptide).unsupported_reason
+    result = get_cleavage_model("fap-endo-gp").predict(peptide)
+    assert next(s for s in result.sites if s.bond == 2).status == "matched"
+    assert get_cleavage_model("cpn-basic").predict(
+        CleavageInput("AARK", c_term="amidated")).unsupported_reason
+
+
+def test_all_models_abstain_for_unknown_chemistry_and_too_short_input():
+    for model in cleavage_models():
+        predictor = get_cleavage_model(model.name)
+        for peptide in (CleavageInput("AAPRG", n_term="unknown"), CleavageInput("A")):
+            result = predictor.predict(peptide)
+            assert result.unsupported_reason, model.name
+            assert not result.sites
+
+
+def test_internal_dpp_motif_requires_conditional_fragment():
+    peptide = CleavageInput("GGVPYGSFKHV", source_id="precursor", source_start=5)
+    initial = get_cleavage_model("dpp9-xp-xa").predict(peptide)
+    assert [(s.bond, s.status) for s in initial.sites] == [(2, "not_matched")]
+    fragment = peptide.fragment(2, 11, n_term="free", c_term="free")
+    followup = get_cleavage_model("dpp9-xp-xa").predict(fragment)
+    assert followup.to_dict()["sites"][0]["source_bond"] == 9
+    assert followup.sites[0].status == "matched"
+
+
+def test_prep_length_scope():
+    assert get_cleavage_model("prep-pro").predict("A" * 29 + "PA").unsupported_reason
+    assert get_cleavage_model("prep-pro").predict("PAA").unsupported_reason
+
+
+def test_compartment_filter_and_explicit_selection():
+    results = predict_cleavage("VPYGSFKHV", compartment="cytosol")
+    assert {r.model.enzyme for r in results} == {"DPP8", "DPP9", "PREP"}
+    assert len(predict_cleavage("HAE", models=["dpp4-qpisa", "dpp4-qpisa"])) == 1
+    with pytest.raises(ValueError, match="not annotated"):
+        predict_cleavage("HAE", models="dpp4-qpisa", compartment="er")
+    with pytest.raises(ValueError, match="Unknown compartment"):
+        predict_cleavage("HAE", compartment="blood")
+    with pytest.raises(ValueError, match="Unknown cleavage model"):
+        predict_cleavage("HAE", models="dpp3")
+
+
+def test_cli_json_preserves_scores_chemistry_and_provenance(capsys, tmp_path):
+    main(["cleavage", "--sequence", "HAE", "--model", "dpp4-qpisa",
+          "--source-start", "10", "--source-id", "construct"])
+    data = json.loads(capsys.readouterr().out)
+    result = data["results"][0]
+    assert data["schema_version"] == 1
+    assert result["sites"][0]["score"] == pytest.approx(2.1694)
+    assert result["sites"][0]["source_bond"] == 12
+    assert result["model"]["references"]
+    path = tmp_path / "evidence.json"
+    main(["cleavage", "--sequence", "HAE", "--model", "dpp4-qpisa",
+          "--n-term", "acetylated", "--out", str(path)])
+    result = json.loads(path.read_text())["results"][0]
+    assert result["peptide"]["n_term"] == "acetylated"
+    assert result["unsupported_reason"]
+    assert result["sites"] == []
+
+
+def test_cli_lists_optional_models_without_loading_assets(capsys, monkeypatch):
+    monkeypatch.setenv("ERAMER_HOME", "/does-not-exist")
+    main(["cleavage", "--list-models"])
+    data = json.loads(capsys.readouterr().out)
+    assert len(data["models"]) == 12
+    assert any(m["name"] == "eramer-step" for m in data["models"])
+
+
+@pytest.mark.parametrize("args", [[], ["--sequence", "HAX"],
+    ["--sequence", "HAE", "--model", "unknown"],
+    ["--list-models", "--sequence", "HAE"]])
+def test_cli_invalid_requests_fail(args):
+    with pytest.raises(SystemExit) as error:
+        main(["cleavage"] + args)
+    assert error.value.code == 2


### PR DESCRIPTION
Expand cleavage evidence across extracellular, cytosolic and ER processing, with a public JSON report. The built-in panel adds rules for CPN, XPNPEP2, FAP dipeptidyl/endo activity, ENPEP, ANPEP, DPP8, DPP9, PREP and ERAP2. For bradykinin, APP assesses R|PPGFSPFR while CPN assesses RPPGFSPF|R; internal DPP motifs require an explicitly exposed fragment.

An optional `eramer-step` adapter exposes the existing ERAP1 length-specific PWM score at the initial trimming bond. Its model identity includes the SHA-256 of the exact external workbook snapshot. It preserves native scores and does not substitute the ERAMER cascade average.

`mhctools cleavage --list-models` discovers all 12 entries; selection, conservative compartment filters, terminal chemistry and source coordinates are available in Python and the CLI. Motif matches/nonmatches have no numerical score; unsupported inputs abstain explicitly. Models include primary references and limitations. The guide inventories further serum, cytosolic, ER and endosomal candidates and prioritizes concrete follow-ups #291, #326, #327, topiary#288 and vaxrank#422.

Version 3.41.0. Validation: `./lint.sh` passes; focused tests 33 passed; `./test.sh` 892 passed, 65 skipped, 2 xfailed. Isolated wheel/sdist build passed; CLI inference from the extracted wheel outside the source tree preserves distinct APP/CPN bond coordinates. The fetched real ERAMER PWM also reproduces its published cascade reference and matches existing one-step ERAMER scores for three distinct peptides (artifact SHA-256 `1113f799564d0e6d8616bfd74f9a1d5f025ebcb869ba0f77de61cbb750b47356`). Tests cover known substrate contexts, negative motif controls, unknown/blocked termini, FAP endo/exo separation, source offsets, length limits, compartment selection, CLI error/reporting behavior, and ERAMER artifact identity.

Closes #322. Advances #278; assay-specific validation remains tracked separately in #291. No motif match or qPISA/PWM score is represented as a serum half-life or calibrated cleavage probability.
