### PR TITLE
Add assay-aware benchmarks and lineage audits (3.42.0)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,6 +57,7 @@ jobs:
             tests/test_cleavage.py \
             tests/test_dpp4.py \
             tests/test_peptidases.py \
+            tests/test_benchmark.py \
             tests/test_eramer_cleavage.py \
             tests/test_pred.py \
             tests/test_annotate_table.py \

--- a/README.md
+++ b/README.md
@@ -1051,3 +1051,8 @@ trimming bond. Discover models with `mhctools cleavage --list-models`, or run
 `mhctools cleavage --sequence RPPGFSPFR --model app2-xp --model cpn-basic`.
 The [guide](docs/cleavage.md) includes a wider candidate inventory and
 prioritized follow-up issues.
+
+`mhctools benchmark` evaluates source-linked observations in separate assay,
+endpoint and native-unit strata. It reports training overlap, repeated
+measurements, unsupported inputs and missing target-domain evidence. See the
+[benchmark guide](docs/benchmarks.md) and `mhctools benchmark --lineage-inventory`.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,132 @@
+# Assay-aware benchmarks
+
+```sh
+mhctools benchmark --reference-cleavage --out reference-report.json
+mhctools benchmark --lineage-inventory --out lineage.json
+mhctools benchmark --input measurements-and-predictions.json --out evaluation.json
+mhctools benchmark --input site-measurements.json --model cpn-basic --model dpp9-xp-xa
+```
+
+The benchmark accepts JSON records represented by `AssayMeasurement`,
+`BenchmarkPrediction` and `ModelLineage` in `mhctools.benchmark`. Each
+measurement retains its own ID, original source measurement ID, source URL,
+study, assay, exact sequence and chemistry, endpoint, native units, species,
+matrix, optional cell type, censoring and experimental conditions. Site
+records also require an enzyme and a peptide bond. No missing bond label
+is converted into an experimental non-cleavage.
+
+The input object has `measurements`, optional `predictions`, optional
+`lineages`, and optional `requested_domains` lists. To run a cleavage model
+use `--model` instead of supplying predictions. A minimal supplied evaluation:
+
+```json
+{
+  "measurements": [{
+    "measurement_id": "experiment-1",
+    "source_measurement_id": "table-2-row-7",
+    "source": "https://example.org/replace-with-primary-source",
+    "dataset": "my-data", "study": "study-1", "assay": "incubation-1",
+    "sequence": "HAEGT", "chemistry": "linear_L_free",
+    "endpoint": "serum_half_life", "units": "hours",
+    "species": "Homo sapiens", "matrix": "serum", "value": 2.0,
+    "family": "GLP1", "conditions": {"temperature_C": "37"}
+  }],
+  "predictions": [{
+    "measurement_id": "experiment-1", "model": "my-model",
+    "endpoint": "serum_half_life", "units": "hours", "value": 3.0
+  }],
+  "requested_domains": [{
+    "name": "primary human DC cytosolic delivery",
+    "species": "Homo sapiens", "cell_type": "primary dendritic cell",
+    "endpoint": "cytosolic_delivery"
+  }]
+}
+```
+
+These numbers and URL are illustrative fixtures, not experimental data.
+Use explicit `unknown` descriptions for unspecified conditions and `null`
+for an unknown measurement value. Censored observations use `less_than`,
+`greater_than` or `unknown`; they remain visible but are excluded from ordinary
+point-error metrics. Chemistry descriptions are preserved verbatim. The
+cleavage runner can currently represent only `linear_L_free`,
+`linear_L_N_acetylated` and `linear_L_C_amidated`; other descriptions abstain.
+
+## Metrics and interpretation
+
+Reports stratify by model, endpoint, native units/output scale, study, assay,
+conditions, species, matrix, cell type and enzyme. Serum, plasma, whole blood,
+systemic half-life/clearance, fluorescence uptake, CPP classification,
+cytosolic delivery and antigen presentation remain distinct endpoints.
+There is no implicit unit conversion or transformed-score calibration.
+
+Compatible native regression outputs receive MAE, RMSE and signed bias.
+Binary decisions receive confusion counts; explicit probabilities receive a
+Brier score. Motif decisions are limited recognition rules, so their confusion
+counts measure that rule's behavior on supplied labels. Native qPISA/PWM
+scores cannot acquire probability metrics merely because the observed label
+is binary. Intervals are evaluated only when explicitly identified as
+individual-measurement prediction intervals in the native scale, with a
+stated nominal coverage. Model disagreement is not an uncertainty interval.
+
+Counts distinguish measurements, source measurements, unique sequences and
+chemical forms. Missing predictions, unsupported chemistry, runtime failures,
+unassessed sites and incompatible/censored records retain their reasons.
+The source-linked starter set reproduces four positive observations (two
+CPN-like plasma observations for bradykinin, aminopeptidase P on RPP and DPP9
+on the RU1 epitope). Eight model/observation combinations are off-enzyme and
+unassessed. This small, positive-only set cannot estimate specificity,
+calibration or independent predictive performance. CPN attribution is to
+CPN-like inhibitor-sensitive plasma activity, not an isolated purified enzyme.
+
+## Training overlap and applicability
+
+`ModelLineage` records dataset, study, assay, sequence, exact chemical-form,
+family and cell-type inventories. Provenance is `unknown`, `partial` or
+`complete`; complete provenance requires actual sequence, study and family
+inventories. Every evaluation record is checked against these inventories
+and against any supplied `split="train"` partition. Related chemistry does
+not erase sequence overlap. Family assignments are supplied explicitly; no
+arbitrary sequence-similarity threshold or confidence score is invented.
+
+The report labels an external evaluation unverified when training provenance,
+family assignments or independence cannot be established. `split="reference"`
+records are used only for `--evaluation reproduction`; the built-in reference
+command always selects reproduction. Metrics remain descriptive, and model
+agreement or reproduction is never represented as independent validation.
+
+Requested domains report available measurements, comparable predictions and
+missing evidence. A length restriction is a user-selected target population,
+not a learned applicability threshold. The supplied reference set reports no
+human serum half-life or primary-DC cytosolic-delivery observations.
+
+## Dataset/model lineage inventory
+
+The installed [inventory](../mhctools/data/model_lineage.json) records sources,
+known relationships and unresolved questions rather than assuming models
+have independent training data:
+
+- [Tan 2024](https://doi.org/10.1093/bib/bbae350) draws on PEPlife, PepTherDia,
+  THPdb and literature. Its species/organ/chemistry subsets require original
+  assay review before distinguishing incubation half-life from systemic PK.
+  Complete raw datasets are described as available on request.
+- [PEPlife2](https://www.mdpi.com/2673-5601/6/2/26) updates half-life curation
+  and retains repeated sequences measured under different conditions.
+- [pepADMET](https://pubmed.ncbi.nlm.nih.gov/41512092/) spans multiple ADMET
+  endpoints. Its exact half-life row overlap with Tan/PEPlife is unresolved;
+  shared authorship does not establish either identity or independence.
+- [POSEIDON](https://doi.org/10.1186/s13321-024-00810-7) revisits CPPsite2.0
+  primary studies and retains repeated peptides under different conditions.
+  Its regression endpoint is fluorescence uptake.
+- [PerseuCPP](https://doi.org/10.1093/bioadv/vbaf213) reuses MLCPP2.0 training
+  sets and adds CPPsite2.0 data. Some negative CPP labels are generated rather
+  than experimentally observed. This shared ancestry with POSEIDON requires
+  row-level auditing before claiming an independent comparison.
+- qPISA coefficient reproduction and ERAMER adapter agreement are documented
+  in the [cleavage guide](cleavage.md); their reproduction is separate from
+  new assay validation.
+
+No third-party raw exposure/uptake datasets or model weights are redistributed.
+The included small factual cleavage curation is offered under CC0 with source
+measurement identifiers and explicit caveats. Broad external validation on
+long vaccine peptides or primary human DCs remains an empirical data task;
+this report makes missing evidence visible and supplies the evaluation path.

--- a/mhctools/__init__.py
+++ b/mhctools/__init__.py
@@ -113,7 +113,7 @@ def __getattr__(name):
     raise AttributeError(
         "module %r has no attribute %r" % (__name__, name))
 
-__version__ = "3.41.0"
+__version__ = "3.42.0"
 
 __all__ = [
     "Prediction",

--- a/mhctools/benchmark.py
+++ b/mhctools/benchmark.py
@@ -1,0 +1,363 @@
+"""Assay-aware measurement evaluation and explicit provenance audits.
+
+No unit conversion, homolog clustering, unreported-negative construction or
+model training is performed. User-supplied family assignments are retained.
+"""
+
+from collections import Counter, defaultdict
+from dataclasses import asdict, dataclass
+from importlib.resources import files
+import json
+import math
+from typing import Optional, Tuple
+
+
+ENDPOINTS = frozenset((
+    "site_cleavage", "substrate_depletion", "serum_half_life", "plasma_half_life",
+    "whole_blood_half_life", "systemic_half_life", "systemic_clearance",
+    "distribution_volume", "fluorescence_uptake", "cpp_classification",
+    "cytosolic_delivery", "antigen_presentation"))
+
+
+def _finite(value):
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value)
+
+
+@dataclass(frozen=True)
+class AssayMeasurement:
+    """One source measurement; repetitions keep distinct measurement IDs.
+
+    Chemistry is an exact descriptive identifier, independent of sequence.
+    Unknown conditions must be explicit, rather than assumed physiological.
+    """
+
+    measurement_id: str
+    source_measurement_id: str
+    source: str
+    dataset: str
+    study: str
+    assay: str
+    sequence: str
+    chemistry: str
+    endpoint: str
+    units: str
+    species: str
+    matrix: str
+    value: Optional[float]
+    split: str = "test"
+    family: Optional[str] = None
+    cell_type: Optional[str] = None
+    enzyme: Optional[str] = None
+    bond: Optional[int] = None
+    censoring: str = "none"
+    conditions: Tuple[Tuple[str, str], ...] = ()
+
+    def __post_init__(self):
+        for key in ("measurement_id", "source_measurement_id", "source", "dataset", "study",
+                    "assay", "sequence", "chemistry", "units", "species", "matrix"):
+            if not isinstance(getattr(self, key), str) or not getattr(self, key).strip():
+                raise ValueError("Measurement requires explicit %s" % key)
+        if not self.source.startswith(("https://", "http://")):
+            raise ValueError("Measurement source must be a source URL")
+        if self.endpoint not in ENDPOINTS:
+            raise ValueError("Unknown measurement endpoint %r" % self.endpoint)
+        if self.split not in ("train", "test", "reference"):
+            raise ValueError("split must be train, test or reference")
+        if self.censoring not in ("none", "less_than", "greater_than", "unknown"):
+            raise ValueError("Unknown censoring status")
+        if self.value is not None and not _finite(self.value):
+            raise ValueError("Measurement value must be finite or None")
+        if self.units == "binary" and self.value not in (0, 1, None):
+            raise ValueError("Binary observations must be 0, 1 or None")
+        if self.endpoint == "site_cleavage":
+            if self.value not in (0, 1, None) or self.units != "binary":
+                raise ValueError("Site cleavage requires binary observations or unknown")
+            if (not isinstance(self.bond, int) or isinstance(self.bond, bool) or
+                    not 1 <= self.bond < len(self.sequence) or not self.enzyme):
+                raise ValueError("Site cleavage requires enzyme and an internal peptide bond")
+        conditions = self.conditions.items() if isinstance(self.conditions, dict) else self.conditions
+        conditions = tuple(sorted(tuple(pair) for pair in conditions))
+        if any(len(p) != 2 or not all(isinstance(v, str) for v in p) for p in conditions):
+            raise ValueError("Conditions must be string key/value pairs")
+        if len(dict(conditions)) != len(conditions):
+            raise ValueError("Duplicate condition keys")
+        object.__setattr__(self, "conditions", conditions)
+
+
+@dataclass(frozen=True)
+class BenchmarkPrediction:
+    """A prediction keyed to one exact measurement, with explicit output scale."""
+
+    measurement_id: str
+    model: str
+    endpoint: str
+    units: str
+    value: Optional[float] = None
+    status: str = "scored"
+    scale: str = "native"
+    reason: Optional[str] = None
+    interval: Optional[Tuple[float, float]] = None
+    interval_level: Optional[float] = None
+    interval_target: Optional[str] = None
+
+    def __post_init__(self):
+        if not self.measurement_id or not self.model or self.endpoint not in ENDPOINTS:
+            raise ValueError("Prediction requires measurement, model and known endpoint")
+        if self.status not in ("scored", "unsupported", "failed", "not_assessed"):
+            raise ValueError("Unknown prediction status")
+        if self.scale not in ("native", "probability", "decision"):
+            raise ValueError("Unknown prediction scale")
+        if self.status == "scored":
+            if not _finite(self.value):
+                raise ValueError("Scored predictions require finite values")
+            if self.scale == "probability" and not 0 <= self.value <= 1:
+                raise ValueError("Probability must be within 0..1")
+            if self.scale == "decision" and self.value not in (0, 1):
+                raise ValueError("Decision must be 0 or 1")
+        elif self.value is not None or not self.reason:
+            raise ValueError("Unscored predictions require a reason and no value")
+        if self.interval is not None:
+            interval = tuple(self.interval)
+            if (self.status != "scored" or len(interval) != 2 or
+                    not all(_finite(v) for v in interval) or interval[0] > interval[1] or
+                    not _finite(self.interval_level) or not 0 < self.interval_level < 1 or
+                    self.interval_target != "individual_measurement"):
+                raise ValueError("Intervals require ordered bounds, level and individual_measurement target")
+            object.__setattr__(self, "interval", interval)
+        elif self.interval_level is not None or self.interval_target is not None:
+            raise ValueError("Interval metadata requires bounds")
+
+
+@dataclass(frozen=True)
+class ModelLineage:
+    """Declared model training provenance; complete must be justified by source.
+
+    Empty collections with unknown/partial provenance never establish absence
+    of overlap. Families are externally curated, not guessed by this module.
+    """
+
+    model: str
+    source: str
+    provenance: str = "unknown"
+    datasets: Tuple[str, ...] = ()
+    studies: Tuple[str, ...] = ()
+    assays: Tuple[str, ...] = ()
+    sequences: Tuple[str, ...] = ()
+    chemical_forms: Tuple[Tuple[str, str], ...] = ()
+    families: Tuple[str, ...] = ()
+    cell_types: Tuple[str, ...] = ()
+    notes: str = ""
+
+    def __post_init__(self):
+        if self.provenance not in ("unknown", "partial", "complete"):
+            raise ValueError("Unknown training provenance state")
+        if not self.model or not self.source:
+            raise ValueError("Lineage requires model and source")
+        if self.provenance == "complete" and not (self.sequences and self.studies and self.families):
+            raise ValueError("Complete lineage requires sequence, study and family inventories")
+        for key in ("datasets", "studies", "assays", "sequences", "families", "cell_types"):
+            object.__setattr__(self, key, tuple(getattr(self, key)))
+        object.__setattr__(self, "chemical_forms", tuple(tuple(x) for x in self.chemical_forms))
+
+
+def _overlaps(row, lineage):
+    flags = []
+    for attr, values in (("dataset", lineage.datasets), ("study", lineage.studies),
+                         ("assay", lineage.assays), ("sequence", lineage.sequences),
+                         ("family", lineage.families), ("cell_type", lineage.cell_types)):
+        if getattr(row, attr) is not None and getattr(row, attr) in values:
+            flags.append(attr)
+    if (row.sequence, row.chemistry) in lineage.chemical_forms:
+        flags.append("chemical_form")
+    return flags
+
+
+def _metrics(pairs, scale):
+    if not pairs:
+        return None
+    truth = [m.value for m, p in pairs]
+    predicted = [p.value for m, p in pairs]
+    if pairs[0][0].units == "binary":
+        if any(v not in (0, 1) for v in truth):
+            return None
+        if scale == "decision":
+            return {"tp": sum(t == 1 and p == 1 for t, p in zip(truth, predicted)),
+                    "tn": sum(t == 0 and p == 0 for t, p in zip(truth, predicted)),
+                    "fp": sum(t == 0 and p == 1 for t, p in zip(truth, predicted)),
+                    "fn": sum(t == 1 and p == 0 for t, p in zip(truth, predicted))}
+        if scale == "probability":
+            return {"brier": sum((t - p) ** 2 for t, p in zip(truth, predicted)) / len(pairs)}
+        return None
+    errors = [p - t for t, p in zip(truth, predicted)]
+    return {"mae": sum(abs(e) for e in errors) / len(errors),
+            "rmse": math.sqrt(sum(e * e for e in errors) / len(errors)),
+            "bias": sum(errors) / len(errors)}
+
+
+def evaluate_benchmark(measurements, predictions, lineages=(), evaluation="external_validation", requested_domains=()):
+    """Evaluate comparable records, report overlap and retain every failure.
+
+    Metrics are descriptive within exact assay/domain/output-scale strata.
+    They never certify independence where training or family data are absent.
+    """
+    if evaluation not in ("external_validation", "reproduction"):
+        raise ValueError("Unknown evaluation purpose")
+    measurements = tuple(measurements)
+    by_id = {m.measurement_id: m for m in measurements}
+    if len(by_id) != len(measurements):
+        raise ValueError("Duplicate measurement IDs")
+    lineages = tuple(lineages)
+    lineage_map = {x.model: x for x in lineages}
+    if len(lineage_map) != len(lineages):
+        raise ValueError("Duplicate model lineage")
+    predictions = tuple(predictions)
+    prediction_map = {(p.measurement_id, p.model): p for p in predictions}
+    if len(prediction_map) != len(predictions):
+        raise ValueError("Duplicate measurement/model predictions")
+    if any(p.measurement_id not in by_id for p in predictions):
+        raise ValueError("Prediction references an unknown measurement")
+    models = sorted(set(p.model for p in predictions) | set(lineage_map))
+    if not models:
+        raise ValueError("At least one prediction model or lineage is required")
+    training = [m for m in measurements if m.split == "train"]
+    partition = ModelLineage("partition", "supplied benchmark train partition", "partial",
+        studies=tuple(m.study for m in training), assays=tuple(m.assay for m in training),
+        sequences=tuple(m.sequence for m in training), families=tuple(m.family for m in training if m.family),
+        chemical_forms=tuple((m.sequence, m.chemistry) for m in training),
+        cell_types=tuple(m.cell_type for m in training if m.cell_type))
+    rows = []
+    groups = defaultdict(list)
+    for model in models:
+        lineage = lineage_map.get(model, ModelLineage(model, "unknown"))
+        for m in measurements:
+            if m.split == "train":
+                continue
+            p = prediction_map.get((m.measurement_id, model))
+            flags = _overlaps(m, lineage)
+            partition_flags = _overlaps(m, partition) if m.split == "test" else []
+            independent = (lineage.provenance == "complete" and m.family is not None and
+                           not flags and not partition_flags and m.split == "test")
+            reason = None
+            if p is None:
+                reason = "missing_prediction"
+            elif p.status != "scored":
+                reason = p.status
+            elif m.value is None or m.censoring != "none":
+                reason = "unknown_or_censored_observation"
+            elif evaluation == "external_validation" and m.split != "test":
+                reason = "reference_record"
+            elif p.endpoint != m.endpoint or p.units != m.units:
+                reason = "incompatible_endpoint_or_units"
+            elif m.units == "binary" and p.scale not in ("decision", "probability"):
+                reason = "native_score_has_no_binary_calibration"
+            elif m.units != "binary" and p.scale != "native":
+                reason = "incompatible_output_scale"
+            row = {"measurement": asdict(m), "model": model,
+                   "prediction": asdict(p) if p else None, "exclusion": reason,
+                   "training_overlap": flags, "partition_overlap": partition_flags,
+                   "training_provenance": lineage.provenance,
+                   "family_audit": "available" if m.family is not None else "unknown",
+                   "independence_established": independent}
+            rows.append(row)
+            key = (model, m.endpoint, m.units, m.species, m.matrix, m.cell_type,
+                   m.assay, m.conditions, m.enzyme, p.scale if p else "unknown", m.study)
+            groups[key].append((m, p, row))
+    summaries = []
+    for key, values in groups.items():
+        comparable = [(m, p) for m, p, r in values if r["exclusion"] is None]
+        independent_count = sum(r["independence_established"] for m, p, r in values)
+        intervals = defaultdict(list)
+        for m, p in comparable:
+            if p.interval is not None:
+                intervals[p.interval_level].append(p.interval[0] <= m.value <= p.interval[1])
+        summaries.append({
+            "model": key[0], "endpoint": key[1], "units": key[2], "species": key[3],
+            "matrix": key[4], "cell_type": key[5], "assay": key[6],
+            "conditions": dict(key[7]), "enzyme": key[8], "scale": key[9], "study": key[10],
+            "measurement_count": len(values), "comparable_count": len(comparable),
+            "unique_sequences": len({m.sequence for m, p, r in values}),
+            "unique_source_measurements": len({(m.source, m.source_measurement_id) for m, p, r in values}),
+            "unique_chemical_forms": len({(m.sequence, m.chemistry) for m, p, r in values}),
+            "length_counts": dict(sorted(Counter(len(m.sequence) for m, p, r in values).items())),
+            "exclusions": dict(Counter(r["exclusion"] for m, p, r in values if r["exclusion"])),
+            "independent_measurement_count": independent_count,
+            "claim": ("reproduction" if evaluation == "reproduction" else
+                      "audited_external" if independent_count == len(values) else "unverified_external"),
+            "descriptive_metrics": _metrics(comparable, key[9]),
+            "prediction_interval_coverage": [{"nominal_level": level, "n": len(hits),
+                "coverage": sum(hits) / len(hits)} for level, hits in sorted(intervals.items())]})
+    domains = []
+    for domain in requested_domains:
+        allowed = {"name", "endpoint", "species", "matrix", "cell_type", "min_length", "max_length"}
+        if not domain.get("name") or set(domain) - allowed:
+            raise ValueError("Requested domains require a name and recognized constraints")
+        for bound in ("min_length", "max_length"):
+            if bound in domain and (not isinstance(domain[bound], int) or isinstance(domain[bound], bool) or domain[bound] < 1):
+                raise ValueError("Domain length bounds must be positive integers")
+        if domain.get("min_length", 1) > domain.get("max_length", float("inf")):
+            raise ValueError("Inverted domain length bounds")
+        def matches(m):
+            return (all(getattr(m, key) == value for key, value in domain.items()
+                        if key in ("endpoint", "species", "matrix", "cell_type")) and
+                    domain.get("min_length", 1) <= len(m.sequence) <= domain.get("max_length", float("inf")))
+        domain_rows = [m for m in measurements if m.split != "train" and matches(m)]
+        domain_ids = {m.measurement_id for m in domain_rows}
+        domains.append({"requested": dict(domain), "measurement_count": len(domain_rows),
+                        "unique_sequences": len({m.sequence for m in domain_rows}),
+                        "comparable_prediction_count": sum(r["exclusion"] is None and r["measurement"]["measurement_id"] in domain_ids for r in rows),
+                        "evidence": "records_available" if domain_rows else "no_evidence_in_supplied_data"})
+    return {"schema_version": 1, "evaluation": evaluation, "requested_domains": domains, "groups": summaries, "records": rows,
+            "lineages": [asdict(x) for x in lineages],
+            "limitations": "Repeated measurements are not independent peptides. Missing family/training data cannot establish external validation. No serum or delivery calibration is inferred from motif rules."}
+
+
+def model_lineage_inventory():
+    """Read the curated model/data relationships and unresolved provenance."""
+    return json.loads(files("mhctools").joinpath("data/model_lineage.json").read_text())
+
+
+def predict_cleavage_measurements(measurements, models):
+    """Run site models against explicit measurements; unassessed bonds abstain.
+
+    Only the exact canonical chemistry identifiers below can be represented
+    by CleavageInput; all other chemistry remains an unsupported record.
+    """
+    from .cleavage import CleavageInput
+    from .peptidases import get_cleavage_model
+    chemistry = {"linear_L_free": ("free", "free"),
+                 "linear_L_N_acetylated": ("acetylated", "free"),
+                 "linear_L_C_amidated": ("free", "amidated")}
+    predictions = []
+    for name in models:
+        try:
+            predictor = get_cleavage_model(name)
+        except (OSError, ImportError) as error:
+            predictor = None
+            failure = str(error)
+        for m in measurements:
+            kwargs = dict(measurement_id=m.measurement_id, model=name, endpoint=m.endpoint, units=m.units)
+            if predictor is None:
+                predictions.append(BenchmarkPrediction(**kwargs, status="failed", reason=failure))
+                continue
+            if m.endpoint != "site_cleavage" or m.enzyme != predictor.model.enzyme:
+                predictions.append(BenchmarkPrediction(**kwargs, status="not_assessed", reason="Different endpoint or enzyme"))
+                continue
+            if m.chemistry not in chemistry:
+                predictions.append(BenchmarkPrediction(**kwargs, status="unsupported", reason="Unrepresented chemistry"))
+                continue
+            try:
+                n_term, c_term = chemistry[m.chemistry]
+                result = predictor.predict(CleavageInput(m.sequence, n_term, c_term))
+                site = next((s for s in result.sites if s.bond == m.bond), None)
+                if site is None:
+                    predictions.append(BenchmarkPrediction(**kwargs, status="not_assessed",
+                        reason=result.unsupported_reason or "Bond outside model topology"))
+                elif site.status == "scored":
+                    predictions.append(BenchmarkPrediction(m.measurement_id, name,
+                        "substrate_depletion" if name == "dpp4-qpisa" else "site_cleavage",
+                        result.model.score_units, site.score))
+                else:
+                    predictions.append(BenchmarkPrediction(**kwargs, value=int(site.status == "matched"), scale="decision"))
+            except (ValueError, TypeError, RuntimeError, OSError, ImportError) as error:
+                predictions.append(BenchmarkPrediction(**kwargs, status="failed", reason=str(error)))
+    return tuple(predictions)

--- a/mhctools/cli/benchmark.py
+++ b/mhctools/cli/benchmark.py
@@ -1,0 +1,53 @@
+"""Evaluate supplied measurements and predictions without merging assay scales."""
+
+import argparse
+import json
+from pathlib import Path
+from importlib.resources import files
+
+from mhctools.benchmark import (
+    AssayMeasurement, BenchmarkPrediction, ModelLineage, evaluate_benchmark,
+    model_lineage_inventory, predict_cleavage_measurements,
+)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(prog="mhctools benchmark")
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--input", help="JSON containing measurements and predictions or --model inputs")
+    mode.add_argument("--lineage-inventory", action="store_true")
+    mode.add_argument("--reference-cleavage", action="store_true", help="Run the source-linked reproduction fixture")
+    parser.add_argument("--model", action="append", help="Run an exact cleavage model against site records")
+    parser.add_argument("--evaluation", choices=("external_validation", "reproduction"), default="external_validation")
+    parser.add_argument("--out")
+    args = parser.parse_args(argv)
+    try:
+        if args.lineage_inventory:
+            if args.model:
+                parser.error("--model cannot be combined with --lineage-inventory")
+            result = model_lineage_inventory()
+        else:
+            if args.reference_cleavage:
+                data = json.loads(files("mhctools").joinpath("data/cleavage_reference.json").read_text())
+                evaluation = "reproduction"
+            else:
+                data = json.loads(Path(args.input).read_text())
+                evaluation = args.evaluation
+            measurements = [AssayMeasurement(**m) for m in data["measurements"]]
+            if args.model and data.get("predictions"):
+                parser.error("Choose supplied predictions or --model, not both")
+            if args.model or args.reference_cleavage:
+                predictions = predict_cleavage_measurements(measurements, args.model or data["models"])
+            else:
+                predictions = [BenchmarkPrediction(**p) for p in data.get("predictions", [])]
+            lineages = [ModelLineage(**x) for x in data.get("lineages", [])]
+            result = evaluate_benchmark(measurements, predictions, lineages, evaluation, data.get("requested_domains", ()))
+            if args.reference_cleavage:
+                result["dataset_notice"] = data["notice"]
+        output = json.dumps(result, indent=2, allow_nan=False) + "\n"
+        if args.out:
+            Path(args.out).write_text(output)
+        else:
+            print(output, end="")
+    except (ValueError, TypeError, KeyError, OSError) as error:
+        parser.error(str(error))

--- a/mhctools/cli/script.py
+++ b/mhctools/cli/script.py
@@ -175,6 +175,9 @@ def main(args_list=None):
     if args_list and args_list[0] == "fetch":
         from .artifacts import fetch_main
         return fetch_main(args_list[1:])
+    if args_list and args_list[0] == "benchmark":
+        from .benchmark import main as benchmark_main
+        return benchmark_main(args_list[1:])
     if args_list and args_list[0] == "cleavage":
         from .cleavage import main as cleavage_main
         return cleavage_main(args_list[1:])

--- a/mhctools/data/cleavage_reference.json
+++ b/mhctools/data/cleavage_reference.json
@@ -1,0 +1,121 @@
+{
+  "schema_version": 1,
+  "notice": "Small manually curated factual reference set, offered under CC0-1.0. Positive observations only; CPN assignment is inhibitor-attributed CPN-like plasma activity. These are reproduction controls, not independent validation or negative-label data. No article prose, figures or third-party datasets are redistributed.",
+  "models": [
+    "cpn-basic",
+    "app2-xp",
+    "dpp9-xp-xa"
+  ],
+  "measurements": [
+    {
+      "measurement_id": "cpn-bk-low",
+      "source_measurement_id": "abstract:BK(1-8):nanomolar",
+      "source": "https://pubmed.ncbi.nlm.nih.gov/10749699/",
+      "dataset": "curated-cleavage-references-v1",
+      "study": "https://pubmed.ncbi.nlm.nih.gov/10749699/",
+      "assay": "human plasma with inhibitor attribution",
+      "sequence": "RPPGFSPFR",
+      "chemistry": "linear_L_free",
+      "endpoint": "site_cleavage",
+      "units": "binary",
+      "species": "Homo sapiens",
+      "matrix": "plasma",
+      "value": 1,
+      "split": "reference",
+      "family": "bradykinin",
+      "enzyme": "CPN1",
+      "bond": 8,
+      "conditions": {
+        "substrate_concentration": "nanomolar range",
+        "enzyme_attribution": "CPN-like activity",
+        "pH": "not specified in abstract",
+        "label": "product observed; fractional turnover not used"
+      }
+    },
+    {
+      "measurement_id": "cpn-bk-high",
+      "source_measurement_id": "abstract:BK:micromolar",
+      "source": "https://pubmed.ncbi.nlm.nih.gov/10749699/",
+      "dataset": "curated-cleavage-references-v1",
+      "study": "https://pubmed.ncbi.nlm.nih.gov/10749699/",
+      "assay": "human plasma with inhibitor attribution",
+      "sequence": "RPPGFSPFR",
+      "chemistry": "linear_L_free",
+      "endpoint": "site_cleavage",
+      "units": "binary",
+      "species": "Homo sapiens",
+      "matrix": "plasma",
+      "value": 1,
+      "split": "reference",
+      "family": "bradykinin",
+      "enzyme": "CPN1",
+      "bond": 8,
+      "conditions": {
+        "substrate_concentration": "micromolar range",
+        "enzyme_attribution": "CPN-like activity",
+        "pH": "not specified in abstract",
+        "label": "CPN-like degradation observed; fractional turnover not used"
+      }
+    },
+    {
+      "measurement_id": "app2-rpp",
+      "source_measurement_id": "Arg-Pro-Pro substrate",
+      "source": "https://pubmed.ncbi.nlm.nih.gov/15361070/",
+      "dataset": "curated-cleavage-references-v1",
+      "study": "https://pubmed.ncbi.nlm.nih.gov/15361070/",
+      "assay": "recombinant human membrane aminopeptidase P",
+      "sequence": "RPP",
+      "chemistry": "linear_L_free",
+      "endpoint": "site_cleavage",
+      "units": "binary",
+      "species": "Homo sapiens",
+      "matrix": "purified_enzyme",
+      "value": 1,
+      "split": "reference",
+      "family": "bradykinin",
+      "enzyme": "XPNPEP2",
+      "bond": 1,
+      "conditions": {
+        "substrate_concentration": "not transcribed",
+        "pH": "not transcribed"
+      }
+    },
+    {
+      "measurement_id": "dpp9-ru1",
+      "source_measurement_id": "RU1 epitope VPYGSFKHV",
+      "source": "https://pubmed.ncbi.nlm.nih.gov/19667070/",
+      "dataset": "curated-cleavage-references-v1",
+      "study": "https://pubmed.ncbi.nlm.nih.gov/19667070/",
+      "assay": "human DPP9 peptide cleavage",
+      "sequence": "VPYGSFKHV",
+      "chemistry": "linear_L_free",
+      "endpoint": "site_cleavage",
+      "units": "binary",
+      "species": "Homo sapiens",
+      "matrix": "purified_enzyme",
+      "value": 1,
+      "split": "reference",
+      "family": "RU1",
+      "enzyme": "DPP9",
+      "bond": 2,
+      "conditions": {
+        "substrate_concentration": "not transcribed",
+        "pH": "not transcribed"
+      }
+    }
+  ],
+  "requested_domains": [
+    {
+      "name": "human serum half-life",
+      "endpoint": "serum_half_life",
+      "species": "Homo sapiens",
+      "matrix": "serum"
+    },
+    {
+      "name": "primary human DC cytosolic delivery",
+      "endpoint": "cytosolic_delivery",
+      "species": "Homo sapiens",
+      "cell_type": "primary dendritic cell"
+    }
+  ]
+}

--- a/mhctools/data/model_lineage.json
+++ b/mhctools/data/model_lineage.json
@@ -1,0 +1,169 @@
+{
+  "schema_version": 1,
+  "curation_date": "2026-09-09",
+  "notice": "Relationship inventory, not an independently validated benchmark. Unknown row-level lineage remains unknown. No third-party raw datasets are redistributed.",
+  "models": [
+    {
+      "model": "Tan-2024",
+      "source": "https://doi.org/10.1093/bib/bbae350",
+      "provenance": "partial",
+      "datasets": [
+        "PEPlife",
+        "PepTherDia",
+        "THPdb",
+        "primary literature"
+      ],
+      "endpoints": [
+        "human blood natural/modified peptide half-life",
+        "mouse blood natural/modified peptide half-life",
+        "mouse intestine modified peptide half-life"
+      ],
+      "known_relationships": [
+        "PEPlife contributes records to Tan training curation"
+      ],
+      "unresolved": [
+        "Full row-level training/test membership and common source-measurement IDs",
+        "Whether each blood label is in vitro or systemic PK; inspect original assay",
+        "Datasets are stated to be available on request; redistribution rights not established"
+      ]
+    },
+    {
+      "model": "pepADMET",
+      "source": "https://doi.org/10.1021/acs.jcim.5c02518",
+      "provenance": "unknown",
+      "datasets": [],
+      "endpoints": [
+        "19 peptide ADMET endpoints"
+      ],
+      "known_relationships": [
+        "Same research line as Tan 2024; authorship alone does not establish dataset identity"
+      ],
+      "unresolved": [
+        "Exact half-life row overlap with Tan/PEPlife and endpoint-specific split membership",
+        "Local artifacts and redistribution license"
+      ]
+    },
+    {
+      "model": "PEPlife2-associated models",
+      "source": "https://www.mdpi.com/2673-5601/6/2/26",
+      "provenance": "partial",
+      "datasets": [
+        "PEPlife2",
+        "PEPlife"
+      ],
+      "endpoints": [
+        "assay-specific peptide and protein half-life"
+      ],
+      "known_relationships": [
+        "Updated repository of half-life records; repeated sequence entries can represent distinct assay conditions"
+      ],
+      "unresolved": [
+        "Exact model training membership and overlap with Tan/pepADMET",
+        "Which transformations and assay subsets apply to each model"
+      ]
+    },
+    {
+      "model": "POSEIDON",
+      "source": "https://doi.org/10.1186/s13321-024-00810-7",
+      "provenance": "partial",
+      "datasets": [
+        "CPPsite2.0",
+        "POSEIDON CPP_dataset.csv",
+        "POSEIDON CPP_ML.csv"
+      ],
+      "endpoints": [
+        "fluorescence_uptake"
+      ],
+      "known_relationships": [
+        "Recurates CPPsite2.0 primary studies and adds literature data",
+        "ML dataset retains repeated peptides under different conditions",
+        "Shares CPPsite2.0 ancestry with MLCPP2.0 and PerseuCPP"
+      ],
+      "unresolved": [
+        "Row-level overlap across study/family/cell types in a proposed evaluation set",
+        "Fluorescence does not establish cytosolic delivery or antigen presentation"
+      ]
+    },
+    {
+      "model": "MLCPP2.0",
+      "source": "https://pmc.ncbi.nlm.nih.gov/articles/PMC12462384/",
+      "provenance": "partial",
+      "datasets": [
+        "CPPsite2.0",
+        "MLCPP2.0 classification",
+        "MLCPP2.0 efficiency"
+      ],
+      "endpoints": [
+        "cpp_classification",
+        "uptake-efficiency classification"
+      ],
+      "known_relationships": [
+        "Training sets are reused and augmented by PerseuCPP"
+      ],
+      "unresolved": [
+        "Not all negative sequences are experimentally verified",
+        "Complete per-assay chemistry and primary measurement lineage"
+      ]
+    },
+    {
+      "model": "PerseuCPP",
+      "source": "https://doi.org/10.1093/bioadv/vbaf213",
+      "provenance": "partial",
+      "datasets": [
+        "CPPsite2.0",
+        "MLCPP2.0 classification",
+        "MLCPP2.0 efficiency"
+      ],
+      "endpoints": [
+        "cpp_classification",
+        "uptake-efficiency classification"
+      ],
+      "known_relationships": [
+        "Classification augments MLCPP2.0 with CPPsite2.0 sequences",
+        "Efficiency classifier uses MLCPP2.0 efficiency data",
+        "Some negatives are artificially generated, not observed failures"
+      ],
+      "unresolved": [
+        "Row-level overlap with POSEIDON and proposed external benchmarks",
+        "Primary DC, cytosolic delivery and in-vivo applicability are not established"
+      ]
+    },
+    {
+      "model": "dpp4-qpisa",
+      "source": "https://doi.org/10.1038/s44320-024-00071-4",
+      "provenance": "partial",
+      "datasets": [
+        "qPISA human DPP4 tryptic HeLa substrate experiment"
+      ],
+      "endpoints": [
+        "substrate_depletion"
+      ],
+      "known_relationships": [
+        "Published Dataset EV2 coefficients are reproduced locally",
+        "Keane 2011 substrates were used in published external comparison; they are not a newly untouched test set"
+      ],
+      "unresolved": [
+        "Full sequence/family overlap audit for a new benchmark",
+        "Human serum/plasma half-life calibration"
+      ]
+    },
+    {
+      "model": "eramer-step",
+      "source": "https://pubmed.ncbi.nlm.nih.gov/38925438/",
+      "provenance": "partial",
+      "datasets": [
+        "ERAMER length-specific PWMs"
+      ],
+      "endpoints": [
+        "ERAP1 intermediate specificity"
+      ],
+      "known_relationships": [
+        "Same external PWM as the ERAMER cascade adapter; agreement is model reproduction"
+      ],
+      "unresolved": [
+        "Independent assay-level holdout membership",
+        "Allotype and chemistry generalization"
+      ]
+    }
+  ]
+}

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,175 @@
+"""Assay separation, leakage, missingness and report regressions."""
+
+from dataclasses import replace
+import json
+
+import pytest
+
+from mhctools.benchmark import (
+    AssayMeasurement, BenchmarkPrediction, ModelLineage,
+    evaluate_benchmark, model_lineage_inventory, predict_cleavage_measurements,
+)
+from mhctools.cli.script import main
+
+
+def measurement(mid="one", **kwargs):
+    values = dict(measurement_id=mid, source_measurement_id=mid,
+        source="https://example.org/study", dataset="fixture", study="study",
+        assay="serum incubation", sequence="HAEGT", chemistry="linear_L_free",
+        endpoint="serum_half_life", units="hours", species="Homo sapiens",
+        matrix="serum", value=2.0, family="glp1")
+    values.update(kwargs)
+    return AssayMeasurement(**values)
+
+
+def prediction(mid="one", **kwargs):
+    values = dict(measurement_id=mid, model="model", endpoint="serum_half_life",
+                  units="hours", value=3.0)
+    values.update(kwargs)
+    return BenchmarkPrediction(**values)
+
+
+def test_native_metrics_and_repeats_are_not_independent_peptides():
+    rows = [measurement(), measurement("two", value=4)]
+    pred = [prediction(), prediction("two", value=2)]
+    report = evaluate_benchmark(rows, pred)
+    group = report["groups"][0]
+    assert group["measurement_count"] == 2
+    assert group["unique_sequences"] == 1
+    assert group["unique_chemical_forms"] == 1
+    assert group["descriptive_metrics"] == pytest.approx({"mae":1.5,"rmse":2.5**0.5,"bias":-0.5})
+    assert group["claim"] == "unverified_external"
+    assert group["independent_measurement_count"] == 0
+
+
+@pytest.mark.parametrize("changed", [
+    {"endpoint":"systemic_half_life"}, {"units":"minutes"},
+    {"matrix":"plasma"}, {"species":"Mus musculus"},
+    {"assay":"another incubation"}, {"study":"another study"},
+    {"conditions":{"pH":"6.0"}}, {"cell_type":"DC"},
+])
+def test_assays_and_domains_are_not_pooled(changed):
+    rows = [measurement(), measurement("two", **changed)]
+    result = evaluate_benchmark(rows, [prediction(), prediction("two")])
+    assert len(result["groups"]) == 2
+    assert all(g["measurement_count"] == 1 for g in result["groups"])
+
+
+def test_no_unit_or_endpoint_conversion():
+    for changes in ({"units":"minutes"}, {"endpoint":"fluorescence_uptake"}):
+        result = evaluate_benchmark([measurement()], [prediction(**changes)])
+        assert result["records"][0]["exclusion"] == "incompatible_endpoint_or_units"
+        assert result["groups"][0]["descriptive_metrics"] is None
+
+
+def test_censored_missing_failed_and_absent_predictions_remain_visible():
+    rows = [measurement(), measurement("two", censoring="greater_than"),
+            measurement("three"), measurement("four")]
+    preds = [prediction(status="unsupported", value=None, reason="chemistry"),
+             prediction("two"), prediction("three", status="failed", value=None, reason="runtime")]
+    report = evaluate_benchmark(rows, preds)
+    assert [r["exclusion"] for r in report["records"]] == [
+        "unsupported", "unknown_or_censored_observation", "failed", "missing_prediction"]
+    assert sum(g["measurement_count"] for g in report["groups"]) == 4
+    assert all(g["descriptive_metrics"] is None for g in report["groups"])
+
+
+def test_complete_provenance_is_required_and_overlap_is_reported():
+    lineage = ModelLineage("model", "https://example.org/training", "complete",
+        studies=("training-study",), sequences=("AAAA",), families=("training-family",),
+        chemical_forms=(("AAAA","linear_L_free"),), cell_types=("HeLa",))
+    clean = evaluate_benchmark([measurement()], [prediction()], [lineage])
+    assert clean["groups"][0]["claim"] == "audited_external"
+    row = measurement(sequence="AAAA", chemistry="linear_L_C_amidated", family="training-family", cell_type="HeLa")
+    dirty = evaluate_benchmark([row], [prediction()], [lineage])
+    assert set(dirty["records"][0]["training_overlap"]) == {"sequence","family","cell_type"}
+    assert "chemical_form" not in dirty["records"][0]["training_overlap"]
+    assert dirty["groups"][0]["claim"] == "unverified_external"
+    no_family = evaluate_benchmark([measurement(family=None)], [prediction()], [lineage])
+    assert no_family["groups"][0]["claim"] == "unverified_external"
+    with pytest.raises(ValueError, match="inventories"):
+        ModelLineage("model", "source", "complete")
+
+
+def test_split_overlap_and_reference_reproduction():
+    train = measurement("train", split="train")
+    test = measurement()
+    report = evaluate_benchmark([train,test], [prediction()])
+    assert {"sequence","study","assay","family","chemical_form"} <= set(report["records"][0]["partition_overlap"])
+    ref = measurement(split="reference")
+    external = evaluate_benchmark([ref], [prediction()])
+    assert external["records"][0]["exclusion"] == "reference_record"
+    reproduced = evaluate_benchmark([ref], [prediction()], evaluation="reproduction")
+    assert reproduced["groups"][0]["claim"] == "reproduction"
+    assert reproduced["groups"][0]["comparable_count"] == 1
+
+
+def test_native_site_score_never_becomes_a_probability():
+    row = measurement(endpoint="site_cleavage", units="binary", enzyme="DPP4", bond=2, value=1)
+    predictions = predict_cleavage_measurements([row], ["dpp4-qpisa"])
+    assert predictions[0].value == pytest.approx(2.1694)
+    report = evaluate_benchmark([row], predictions)
+    assert report["groups"][0]["descriptive_metrics"] is None
+    assert report["records"][0]["exclusion"] == "incompatible_endpoint_or_units"
+
+
+def test_binary_decisions_and_probabilities_keep_distinct_metrics():
+    rows = [measurement(endpoint="site_cleavage", units="binary", enzyme="CPN1", bond=4, value=1),
+            measurement("two", endpoint="site_cleavage", units="binary", enzyme="CPN1", bond=4, value=0)]
+    decisions = [prediction(endpoint="site_cleavage", units="binary", scale="decision", value=1),
+                 prediction("two", endpoint="site_cleavage", units="binary", scale="decision", value=1)]
+    assert evaluate_benchmark(rows,decisions)["groups"][0]["descriptive_metrics"] == {"tp":1,"fp":1,"tn":0,"fn":0}
+    probabilities = [replace(p,scale="probability",value=0.8) for p in decisions]
+    assert evaluate_benchmark(rows,probabilities)["groups"][0]["descriptive_metrics"]["brier"] == pytest.approx(0.34)
+
+
+def test_only_explicit_measurement_intervals_are_evaluated():
+    p = prediction(interval=(1,4), interval_level=0.9, interval_target="individual_measurement")
+    group = evaluate_benchmark([measurement()],[p])["groups"][0]
+    assert group["prediction_interval_coverage"] == [{"nominal_level":0.9,"n":1,"coverage":1.0}]
+    with pytest.raises(ValueError, match="target"):
+        prediction(interval=(1,4), interval_level=0.9, interval_target="model_disagreement")
+
+
+def test_unknown_chemistry_and_unassessed_bond_do_not_become_negatives():
+    row = measurement(sequence="RPPGFSPFR", chemistry="cyclic",endpoint="site_cleavage",units="binary",enzyme="CPN1",bond=8,value=1)
+    assert predict_cleavage_measurements([row],["cpn-basic"])[0].status == "unsupported"
+    row = replace(row,chemistry="linear_L_free",bond=4)
+    p = predict_cleavage_measurements([row],["cpn-basic"])[0]
+    assert p.status == "not_assessed" and p.value is None
+
+
+def test_identity_errors_are_rejected():
+    with pytest.raises(ValueError, match="Duplicate measurement"):
+        evaluate_benchmark([measurement(),measurement()],[prediction()])
+    with pytest.raises(ValueError, match="Duplicate measurement/model"):
+        evaluate_benchmark([measurement()],[prediction(),prediction()])
+    with pytest.raises(ValueError, match="unknown measurement"):
+        evaluate_benchmark([measurement()],[prediction("missing")])
+    for value in (float("nan"),float("inf"),True):
+        with pytest.raises(ValueError, match="finite"):
+            prediction(value=value)
+
+
+def test_reference_cli_and_lineage_inventory(capsys):
+    main(["benchmark","--reference-cleavage"])
+    data = json.loads(capsys.readouterr().out)
+    assert data["evaluation"] == "reproduction"
+    assert len(data["records"]) == 12
+    assert sum(g["comparable_count"] for g in data["groups"]) == 4
+    assert all(g["claim"] == "reproduction" for g in data["groups"])
+    main(["benchmark","--lineage-inventory"])
+    inventory = json.loads(capsys.readouterr().out)
+    assert inventory == model_lineage_inventory()
+    assert any(m["model"] == "pepADMET" and m["provenance"] == "unknown" for m in inventory["models"])
+    assert all(m["source"] and m["unresolved"] for m in inventory["models"])
+
+
+def test_requested_domains_report_absent_evidence_without_threshold_invention():
+    domains = [{"name":"human serum","matrix":"serum","species":"Homo sapiens"},
+               {"name":"requested long peptides","min_length":25},
+               {"name":"primary DC","cell_type":"primary dendritic cell"}]
+    report = evaluate_benchmark([measurement()],[prediction()],requested_domains=domains)
+    assert [r["measurement_count"] for r in report["requested_domains"]] == [1,0,0]
+    assert report["requested_domains"][1]["evidence"] == "no_evidence_in_supplied_data"
+    assert report["requested_domains"][1]["requested"]["min_length"] == 25


### PR DESCRIPTION
Add an assay-aware benchmark API and CLI that preserve repeated source measurements, separate biological endpoints and units, audit declared training overlap, and report missing applicability evidence. Native scores, motif decisions and probabilities receive separate summaries; unsupported or unmeasured cleavage sites never become negative observations.

Includes a source-linked model/dataset lineage inventory and four curated cleavage observations for reproducibility checks. Training provenance gaps and missing long-peptide/human-DC evidence remain explicit; the starter set is not external predictive validation.

Refs #291. Version: 3.42.0.

Validation: `./lint.sh`; `TEST_SH_MAX=4 ./test.sh` (912 passed, 65 skipped, 2 xfailed); isolated wheel/sdist build; installed-wheel benchmark and inventory CLI smoke checks.
